### PR TITLE
docs: add pre-1.0 release criteria and roadmap docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ This repository is scaffolded to follow the Helm layered architecture:
 Only the Rust core workspace contracts are initialized in this stage.
 No UI or service implementation is included yet.
 
+Helm is currently pre-1.0. See docs/DEFINITION_OF_DONE.md for release criteria.

--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -1,0 +1,113 @@
+# Helm 1.0 Definition of Done
+
+This document defines the criteria required before Helm can be released as 1.0.0.
+
+It is intentionally strict.
+
+This document may only be modified via PR targeting main.
+
+---
+
+## 1. Architectural Stability
+
+- Adapter trait considered stable.
+- Orchestration model finalized.
+- No breaking schema changes expected.
+- Service boundary contract documented and versioned.
+
+---
+
+## 2. Functional Completeness
+
+Helm must support:
+
+Core managers:
+- Homebrew (formula + cask)
+- npm (global)
+- pipx
+- Cargo
+
+Capabilities:
+- list installed
+- list outdated
+- search (local + progressive remote)
+- install
+- uninstall
+- upgrade
+- pin / unpin
+- upgrade all (pin-aware)
+
+---
+
+## 3. Orchestration Guarantees
+
+- Cross-manager parallelism
+- Per-manager serialization
+- True process-level cancellation
+- Authority ordering respected
+- Pin enforcement during bulk upgrades
+
+---
+
+## 4. Safety Requirements
+
+- No shell injection vectors
+- Structured process invocation
+- Timeouts enforced
+- Clear error attribution
+- Guardrails for OS updates
+
+---
+
+## 5. Persistence Guarantees
+
+- SQLite schema versioned
+- Migration tested
+- Pin state durable
+- Cache corruption does not crash app
+
+---
+
+## 6. UI Requirements
+
+- Menu bar utility
+- Installed view
+- Search view
+- Task panel
+- Settings panel
+- Non-blocking UI
+- Pin indicator visible
+
+---
+
+## 7. Quality Bar
+
+- Unit tests for:
+  - adapters
+  - parsing
+  - orchestration
+- Integration tests for:
+  - refresh
+  - cancellation
+  - multi-manager behavior
+- No known race conditions
+- No unhandled panics in Rust core
+
+---
+
+## 8. Documentation
+
+- README complete
+- Supported managers listed
+- Known limitations documented
+- Architecture overview included
+
+---
+
+## Explicit Non-Goals for 1.0
+
+- Dependency graph resolution
+- Plugin marketplace
+- CLI companion tool
+- Telemetry
+- Cloud sync

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,139 @@
+# Helm Roadmap
+
+This roadmap defines capability milestones. Dates are intentionally omitted.
+Milestones are feature-driven, not time-driven.
+
+---
+
+## 0.1.x — Core Foundation (alpha)
+
+Goal:
+- Rust workspace initialized
+- Manager adapter trait defined
+- Capability declaration model
+- SQLite schema v1
+- Basic logging system
+
+Exit Criteria:
+- Compiles
+- Unit tests pass
+- No real adapters yet
+
+---
+
+## 0.2.x — First Adapter (alpha)
+
+Goal:
+- Homebrew adapter implemented
+- list_installed
+- list_outdated
+- basic search (local)
+- Task execution scaffold
+
+Exit Criteria:
+- Brew detection works
+- Installed packages listed correctly
+- Tests include parsing fixtures
+
+---
+
+## 0.3.x — Orchestration Engine (beta)
+
+Goal:
+- Background task queue
+- Per-manager locking
+- Cross-manager parallelism
+- True process cancellation
+- Structured error reporting
+
+Exit Criteria:
+- Multiple managers can run concurrently
+- Same manager tasks are serialized
+- Cancellation verified via tests
+
+---
+
+## 0.4.x — SwiftUI Shell (beta)
+
+Goal:
+- Menu bar app scaffold
+- Task list UI
+- Installed packages view
+- Refresh action wired
+
+Exit Criteria:
+- App launches
+- Refresh populates UI
+- Tasks update live
+
+---
+
+## 0.5.x — Progressive Search (beta)
+
+Goal:
+- Local-first fuzzy search
+- Debounced remote search
+- Cancellation semantics
+- Cache enrichment model
+
+Exit Criteria:
+- Typing cancels remote searches
+- Cache updates incrementally
+- No UI freezing
+
+---
+
+## 0.6.x — Pinning & Policy (beta)
+
+Goal:
+- Native pin support (brew first)
+- Virtual pin fallback
+- Pin-aware upgrade-all
+- Settings controls for pin behavior
+
+Exit Criteria:
+- Pinned packages excluded from bulk upgrades
+- Pin state persists across restarts
+
+---
+
+## 0.7.x — Guardrails & Safety (beta)
+
+Goal:
+- Privilege boundary enforcement
+- OS update confirmations
+- Timeout tuning
+- Retry policies
+- Robust error surfacing
+
+Exit Criteria:
+- No shell injection paths
+- Clear per-manager failure reporting
+
+---
+
+## 0.8.x — Hardening (rc)
+
+Goal:
+- Comprehensive test coverage
+- Deterministic parsing tests
+- Logging refinement
+- Crash recovery validation
+
+Exit Criteria:
+- All core paths covered by tests
+- No known race conditions
+
+---
+
+## 1.0.0 — Stable Release
+
+Goal:
+- Stable architecture
+- Stable adapter trait
+- Stable orchestration semantics
+- Usable UI
+- Documentation complete
+- Known limitations documented
+
+See: docs/DEFINITION_OF_DONE.md

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,98 @@
+# Helm Versioning Strategy
+
+Helm follows Semantic Versioning 2.0.0:
+
+MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
+
+Example:
+0.3.0-alpha.1
+0.5.0-beta.2
+0.8.0-rc.1
+1.0.0
+
+---
+
+## Pre-1.0 Rules (0.x.y)
+
+Before 1.0, Helm is considered unstable and may introduce breaking changes.
+
+Version meaning:
+
+- MINOR (0.X.0)
+  Represents a capability milestone or architectural layer.
+  Minor bumps may include breaking changes.
+
+- PATCH (0.X.Y)
+  Bug fixes, small improvements, or incremental changes within a milestone.
+
+- PRERELEASE TAGS
+  - alpha: early milestone work; incomplete; unstable
+  - beta: feature-complete for milestone; may contain defects
+  - rc: release candidate; expected to be production-ready unless defects are found
+
+Examples:
+0.2.0-alpha.1 → first working adapter
+0.3.0-beta.1 → orchestration engine complete
+0.8.0-rc.1 → near-1.0 stability
+
+---
+
+## 1.0.0 Meaning
+
+1.0.0 represents:
+
+- Stable core architecture
+- Stable manager adapter interface
+- Stable task orchestration model
+- Functional UI
+- Production-safe execution semantics
+- Documented limitations
+
+Breaking architectural changes after 1.0 require a MAJOR version bump.
+
+---
+
+## Version Bump Rules
+
+- Breaking change (post-1.0): MAJOR
+- New feature: MINOR
+- Bug fix or internal improvement: PATCH
+
+Pre-1.0:
+- Capability milestone → bump MINOR
+- Iteration within milestone → bump PATCH
+
+---
+
+## Tagging Rules
+
+- Only tag from `main`.
+- Do not tag from `dev`.
+- Format: vX.Y.Z[-tag]
+
+Examples:
+v0.3.0-beta.1
+v0.4.0
+v1.0.0
+
+---
+
+## Release Flow
+
+1. Complete milestone work on `dev`.
+2. Update version in:
+   - Cargo.toml
+   - Swift bundle version
+3. Merge `dev` → `main`.
+4. Create annotated tag.
+5. Push tag to GitHub.
+6. Generate release notes.
+
+---
+
+## Stability Promise (Post-1.0)
+
+After 1.0:
+- Public core APIs are stable.
+- Adapter trait changes require MAJOR bump.
+- Orchestration semantics remain backward compatible.


### PR DESCRIPTION
### Summary

This PR formalizes Helm’s governance, milestone structure, and release criteria. It introduces structured documentation to prevent architectural drift and clarify the path to 1.0.

This does **not** introduce any functional code changes.

---

### Added

* `docs/VERSIONING.md`
  Defines Helm’s Semantic Versioning policy, pre-1.0 rules, tagging strategy, and release flow.

* `docs/ROADMAP.md`
  Establishes capability-driven milestone waves (0.1 → 1.0), aligned with architectural layers.

* `docs/DEFINITION_OF_DONE.md`
  Defines strict 1.0 release criteria across:

  * Architecture stability
  * Functional completeness
  * Orchestration guarantees
  * Safety requirements
  * Persistence guarantees
  * UI expectations
  * Quality bar
  * Documentation completeness

---

### Updated

* `AGENTS.md`
  Added structured git workflow guidance and reinforced implementation discipline.

* `PROJECT_BRIEF.md`
  Confirmed alignment with roadmap and governance model.

---

### Why This Matters

Helm is infrastructure software. Before implementing core functionality, we are locking in:

* Clear milestone sequencing
* Versioning discipline
* Stable release contract
* Explicit 1.0 bar
* Scope boundaries (non-goals for 1.0)

This ensures development remains intentional and milestone-driven rather than feature-driven.

---

### Next Steps

* Begin `0.1.x` milestone work:

  * Scaffold Rust workspace
  * Define manager adapter trait
  * Define core data models
  * Implement SQLite schema v1

---

No breaking changes.
No runtime impact.
Documentation-only PR.
