### PR TITLE
chore: start v0.11.0-beta.2 stabilization pass

### DIFF
--- a/apps/macos-ui/scripts/run_v0110b2_stabilization_checks.sh
+++ b/apps/macos-ui/scripts/run_v0110b2_stabilization_checks.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+run() {
+  echo
+  echo "==> $*"
+  "$@"
+}
+
+echo "v0.11.0-beta.2 stabilization checks"
+
+echo
+run cargo test -p helm-core -p helm-ffi --manifest-path "$ROOT_DIR/core/rust/Cargo.toml"
+
+echo
+echo "==> xcodebuild HelmTests"
+XCODE_LOG="/tmp/helm_v0110b2_xcodebuild.log"
+if ! xcodebuild -project "$ROOT_DIR/apps/macos-ui/Helm.xcodeproj" \
+  -scheme HelmTests \
+  -destination 'platform=macOS' \
+  -derivedDataPath /tmp/helmtests-deriveddata \
+  CODE_SIGNING_ALLOWED=NO \
+  CODE_SIGNING_REQUIRED=NO \
+  test 2>&1 | tee "$XCODE_LOG"; then
+  if rg -q "Sandbox restriction|testmanagerd\\.control" "$XCODE_LOG"; then
+    echo "warning: xcodebuild test blocked by sandbox testmanagerd IPC restrictions; continuing with non-Xcode checks."
+  else
+    echo "error: xcodebuild test failed; see $XCODE_LOG" >&2
+    exit 1
+  fi
+fi
+
+run "$ROOT_DIR/apps/macos-ui/scripts/check_locale_lengths.sh"
+
+echo
+run /bin/bash -lc '
+set -euo pipefail
+for l in en es de fr pt-BR ja; do
+  diff -ru "$0/locales/$l" "$0/apps/macos-ui/Helm/Resources/locales/$l" >/dev/null
+  echo "locale mirror parity OK: $l"
+done
+' "$ROOT_DIR"
+
+run /bin/bash -lc '
+set -euo pipefail
+PATTERN="Text\\(\"[A-Za-z]|Button\\(\"[A-Za-z]|Toggle\\(\"[A-Za-z]|TextField\\(\"[A-Za-z]|\\.alert\\(\"[A-Za-z]|\\.help\\(\"[A-Za-z]"
+if rg -n "$PATTERN" "$0/apps/macos-ui/Helm"; then
+  echo "Found hardcoded UI strings; use L10n keys instead." >&2
+  exit 1
+fi
+echo "hardcoded UI string lint passed"
+' "$ROOT_DIR"
+
+echo
+echo "All v0.11.0-beta.2 stabilization checks passed."

--- a/apps/macos-ui/scripts/smoke_priority2_managers.sh
+++ b/apps/macos-ui/scripts/smoke_priority2_managers.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+OUT_FILE="${ROOT_DIR}/docs/validation/v0.11.0-beta.2-smoke-matrix.md"
+
+mkdir -p "${ROOT_DIR}/docs/validation"
+
+run_with_timeout() {
+  local timeout_s="$1"
+  shift
+  perl -e 'alarm shift; exec @ARGV' "$timeout_s" "$@"
+}
+
+probe() {
+  local manager="$1"
+  local detect_cmd="$2"
+  local list_cmd="$3"
+  local outdated_cmd="$4"
+
+  local detected="no"
+  local version="n/a"
+  local list_status="not-run"
+  local outdated_status="not-run"
+
+  if /bin/bash -lc "$detect_cmd" >/tmp/helm_${manager}_detect.out 2>/tmp/helm_${manager}_detect.err; then
+    detected="yes"
+    version="$(awk 'NF && $0 ~ /[Vv]ersion/ { print; exit }' /tmp/helm_${manager}_detect.out \
+      | tr -d '\r' | sed 's/[[:space:]]\+/ /g' | sed 's/^ //; s/ $//')"
+    if [[ -z "${version}" ]]; then
+      version="$(awk 'NF && $0 !~ /not writable/ { print; exit }' /tmp/helm_${manager}_detect.out \
+        | tr -d '\r' | sed 's/[[:space:]]\+/ /g' | sed 's/^ //; s/ $//')"
+    fi
+    if [[ -z "${version}" ]]; then
+      version="(detected)"
+    fi
+
+    if run_with_timeout 20 /bin/bash -lc "$list_cmd" >/tmp/helm_${manager}_list.out 2>/tmp/helm_${manager}_list.err; then
+      list_status="ok"
+    else
+      list_status="fail"
+    fi
+
+    if run_with_timeout 20 /bin/bash -lc "$outdated_cmd" >/tmp/helm_${manager}_outdated.out 2>/tmp/helm_${manager}_outdated.err; then
+      outdated_status="ok"
+    else
+      outdated_status="fail"
+    fi
+  fi
+
+  printf '| %s | %s | %s | %s | %s |\n' "$manager" "$detected" "$version" "$list_status" "$outdated_status"
+}
+
+{
+  echo '# v0.11.0-beta.2 Priority 2 Smoke Matrix'
+  echo
+  echo "Generated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+  echo
+  echo '| manager | detected | version | list_installed | list_outdated |'
+  echo '|---|---|---|---|---|'
+
+  probe "pnpm" "pnpm --version" "pnpm list -g --depth=0 --json" "pnpm outdated -g --json"
+  probe "yarn" "yarn --version" "yarn global list --depth=0 --json" "yarn outdated --json"
+  probe "poetry" "poetry --version" "poetry self show plugins --no-ansi" "poetry self show plugins --outdated --no-ansi"
+  probe "rubygems" "gem --version" "gem list --local" "gem outdated"
+  probe "bundler" "bundle --version" "gem list --local bundler" "gem outdated bundler"
+
+  echo
+  echo '## Notes'
+  echo '- `detected=no` means the manager binary was not available on PATH in this host environment.'
+  echo '- `list_*` marked `fail` means the command returned non-zero or timed out (>20s).'
+} >"$OUT_FILE"
+
+echo "Wrote ${OUT_FILE}"

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,7 +8,7 @@ It reflects reality, not intention.
 
 ## Version
 
-Current version: **0.10.0**
+Current version: **0.11.0-beta.1**
 
 See:
 - CHANGELOG.md
@@ -27,6 +27,7 @@ See:
 - 0.8.x — Pinning & policy
 - 0.9.x — Internationalization foundation
 - 0.10.x — Core language managers + hardening checkpoint
+- 0.11.x — Extended language managers (beta checkpoint)
 
 ---
 
@@ -73,7 +74,7 @@ Localization coverage:
 - Locale length audit script added at `apps/macos-ui/scripts/check_locale_lengths.sh` for overflow-risk preflight
 - Manager display-name localization keys now cover upgrade-preview/task-fallback manager labels (including software update/app store naming)
 
-Validation snapshot for `v0.10.0` stabilization:
+Validation snapshot for `v0.11.0-beta.1` expansion:
 
 - Priority 1 language-manager local smoke matrix captured on a macOS dev host:
   - Detected and smoke-tested: npm, pip (`python3 -m pip`), cargo
@@ -95,7 +96,7 @@ Validation snapshot for `v0.10.0` stabilization:
 - Priority 1 language manager coverage is complete for the beta checkpoint:
   - Implemented: npm (global), pip (`python3 -m pip`, global), pipx, cargo, cargo-binstall
   - Pending: none
-- Priority 2 extended language-manager expansion has started:
+- Priority 2 extended language-manager expansion is complete at this checkpoint:
   - Implemented: pnpm (global), yarn (global), RubyGems, Poetry (self/plugins), Bundler
   - Pending: none
 - UI/UX redesign milestone is documented in roadmap sequencing but not yet implemented

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -22,10 +22,17 @@ Focus:
 - UI/UX redesign planning
 
 Current checkpoint:
-- `v0.10.0` released (Priority 1 language-manager milestone + hardening checkpoint)
+- `v0.11.0-beta.1` released (Priority 2 extended language-manager milestone)
 
 Next release target:
-- `v0.11.0-beta.1` (extended language-manager expansion)
+- `v0.11.0-beta.2` (stabilization + validation pass)
+
+`v0.11.0-beta.2` stabilization work in progress:
+
+- Added repeatable stabilization check runner at `apps/macos-ui/scripts/run_v0110b2_stabilization_checks.sh`
+- Added Priority 2 manager smoke-matrix generator at `apps/macos-ui/scripts/smoke_priority2_managers.sh` (writes `docs/validation/v0.11.0-beta.2-smoke-matrix.md`)
+- Captured initial smoke matrix snapshot in this environment (`rubygems`/`bundler` detected; `pnpm`/`yarn`/`poetry` not installed)
+- Pending full execution and result capture on a real macOS validation host with all Priority 2 managers installed
 
 ---
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -2,6 +2,47 @@
 
 This checklist is required before creating a release tag on `main`.
 
+## v0.11.0-beta.2 (In Progress)
+
+### Scope and Documentation
+- [ ] `CHANGELOG.md` includes `0.11.0-beta.2` notes for stabilization and validation results.
+- [ ] `README.md` reflects `v0.11.0-beta.2` status.
+- [ ] `docs/CURRENT_STATE.md`, `docs/NEXT_STEPS.md`, and `docs/ROADMAP.md` reflect the beta2 checkpoint.
+- [ ] Website docs status/overview/roadmap pages are updated for `v0.11.0-beta.2`.
+
+### Validation
+- [x] Stabilization script passes: `apps/macos-ui/scripts/run_v0110b2_stabilization_checks.sh`.
+- [x] Priority 2 manager smoke matrix captured: `apps/macos-ui/scripts/smoke_priority2_managers.sh`.
+- [x] Validation notes committed at `docs/validation/v0.11.0-beta.2-smoke-matrix.md`.
+- [ ] Run `HelmTests` on a host without testmanagerd sandbox IPC restrictions (current sandbox run skips this step by design when blocked).
+
+### Branch and Tag
+- [ ] `dev` merged into `main` for release.
+- [ ] Create annotated tag from `main`:
+  - `git tag -a v0.11.0-beta.2 -m "Helm v0.11.0-beta.2"`
+- [ ] Push tag:
+  - `git push origin v0.11.0-beta.2`
+
+## v0.11.0-beta.1 (Completed)
+
+### Scope and Documentation
+- [x] `CHANGELOG.md` includes `0.11.0-beta.1` notes for Priority 2 extended language-manager delivery.
+- [x] `README.md` reflects `v0.11.0-beta.1` status and milestone progression.
+- [x] `docs/CURRENT_STATE.md`, `docs/NEXT_STEPS.md`, and `docs/ROADMAP.md` reflect the `v0.11.0-beta.1` checkpoint.
+- [x] Website-facing docs/state pages are updated for `v0.11.0-beta.1`.
+
+### Validation
+- [x] Rust tests pass (`cargo test -p helm-core -p helm-ffi`).
+- [x] macOS unit tests pass (`xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme HelmTests -destination 'platform=macOS' test`).
+- [x] i18n lint parity is satisfied (`diff -ru locales/en apps/macos-ui/Helm/Resources/locales/en`).
+
+### Branch and Tag
+- [x] Extended manager scope merged to `dev` via PR.
+- [x] Create annotated beta tag from `dev` lineage:
+  - `git tag -a v0.11.0-beta.1 -m "Helm v0.11.0-beta.1"`
+- [x] Push tag:
+  - `git push origin v0.11.0-beta.1`
+
 ## v0.10.0 (Planned)
 
 ### Scope and Documentation

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -280,7 +280,7 @@ Exit Criteria:
 
 ---
 
-## 0.11.x — Extended Language Package Managers (beta)
+## 0.11.x — Extended Language Package Managers (beta) - Completed
 
 Goal:
 
@@ -298,6 +298,11 @@ Exit Criteria:
 - Search returns results for managers that support it
 - Fixture-based parser tests for each adapter's output format
 - Patterns established in 0.10.x reused consistently
+
+Delivered:
+- Implemented `pnpm` (global), `yarn` (global), `poetry` (self/plugins), `RubyGems`, and `bundler` adapters end-to-end.
+- Wired all five managers through core adapter registry, FFI runtime registration, upgrade routing, and macOS UI manager metadata.
+- Added parser fixtures and adapter unit tests for version/list/search/outdated flows where supported.
 
 ---
 

--- a/docs/validation/v0.11.0-beta.2-smoke-matrix.md
+++ b/docs/validation/v0.11.0-beta.2-smoke-matrix.md
@@ -1,0 +1,15 @@
+# v0.11.0-beta.2 Priority 2 Smoke Matrix
+
+Generated: 2026-02-17 04:10:52 UTC
+
+| manager | detected | version | list_installed | list_outdated |
+|---|---|---|---|---|
+| pnpm | no | n/a | not-run | not-run |
+| yarn | no | n/a | not-run | not-run |
+| poetry | no | n/a | not-run | not-run |
+| rubygems | yes | 3.0.3.1 | ok | ok |
+| bundler | yes | Bundler version 1.17.2 | ok | ok |
+
+## Notes
+- `detected=no` means the manager binary was not available on PATH in this host environment.
+- `list_*` marked `fail` means the command returned non-zero or timed out (>20s).


### PR DESCRIPTION
Summary
- add repeatable stabilization runner for beta.2 (run_v0110b2_stabilization_checks.sh)
- add Priority 2 manager smoke matrix generator (smoke_priority2_managers.sh)
- capture and commit baseline smoke matrix at docs/validation/v0.11.0-beta.2-smoke-matrix.md
- update CURRENT_STATE / NEXT_STEPS / ROADMAP / RELEASE_CHECKLIST for 0.11.x completion and beta.2 in-progress tracking

Validation
- apps/macos-ui/scripts/smoke_priority2_managers.sh
- apps/macos-ui/scripts/run_v0110b2_stabilization_checks.sh
- note: in this sandbox, xcodebuild is blocked by testmanagerd IPC restrictions and is explicitly detected/skipped with warning