### PR TITLE
fix: harden orchestration task persistence and error attribution

### DIFF
--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -216,6 +216,11 @@ Completed in `v0.10.0` checkpoint:
 - Replaced panic-prone FFI `lock().unwrap()` usage with poisoned-lock recovery
 - Resolved website duplicate docs-id build warnings for overview/roadmap pages
 
+Completed in `v0.11.0-beta.2` stabilization:
+
+- Added bounded retry handling for transient task-store create/update persistence failures in orchestration runtime paths
+- Added regression coverage for refresh-response error attribution and transient task-persistence recovery
+
 Remaining:
 
 - Stress test orchestration


### PR DESCRIPTION
Summary
- add bounded retries for transient task-store create/update persistence failures in AdapterRuntime orchestration paths
- ensure submit_refresh_request_response returns fully attributed errors (manager/task/action) for wait/failed/cancelled/empty-terminal branches
- add regression tests for transient create-task persistence recovery and refresh-response error attribution
- record beta.2 hardening progress in NEXT_STEPS

Validation
- cargo test -p helm-core --test orchestration_adapter_runtime --test orchestration_adapter_execution --test orchestration_runtime_queue
- cargo test -p helm-core -p helm-ffi