### PR TITLE
docs: capture v0.11.0-beta.2 localization overflow validation

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -72,6 +72,7 @@ Localization coverage:
 - en, es, de: broad app/service coverage
 - fr, pt-BR, ja: full app/common/service key coverage
 - Locale length audit script added at `apps/macos-ui/scripts/check_locale_lengths.sh` for overflow-risk preflight
+- `v0.11.0-beta.2` heuristic overflow audit captured at `docs/validation/v0.11.0-beta.2-l10n-overflow.md` (no high-risk candidates flagged)
 - Manager display-name localization keys now cover upgrade-preview/task-fallback manager labels (including software update/app store naming)
 
 Validation snapshot for `v0.11.0-beta.1` expansion:
@@ -100,7 +101,7 @@ Validation snapshot for `v0.11.0-beta.1` expansion:
   - Implemented: pnpm (global), yarn (global), RubyGems, Poetry (self/plugins), Bundler
   - Pending: none
 - UI/UX redesign milestone is documented in roadmap sequencing but not yet implemented
-- Overflow validation is still heuristic/script-based until full on-device visual pass is completed
+- Overflow validation now has a documented heuristic pass (`v0.11.0-beta.2`), with full on-device visual pass still pending
 - Upgrade-all transparency now provides summary counts + top manager breakdown in confirmation flow
 - Upgrade-preview filtering/sorting logic now has dedicated macOS UI unit coverage (`HelmTests/UpgradePreviewPlannerTests`)
 - No upgrade preview UI

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -32,6 +32,7 @@ Next release target:
 - Added repeatable stabilization check runner at `apps/macos-ui/scripts/run_v0110b2_stabilization_checks.sh`
 - Added Priority 2 manager smoke-matrix generator at `apps/macos-ui/scripts/smoke_priority2_managers.sh` (writes `docs/validation/v0.11.0-beta.2-smoke-matrix.md`)
 - Captured initial smoke matrix snapshot in this environment (`rubygems`/`bundler` detected; `pnpm`/`yarn`/`poetry` not installed)
+- Captured localization overflow heuristic validation at `docs/validation/v0.11.0-beta.2-l10n-overflow.md` (no high-risk candidates flagged)
 - Pending full execution and result capture on a real macOS validation host with all Priority 2 managers installed
 
 ---
@@ -148,7 +149,7 @@ Completed:
 
 Remaining:
 
-- Validate UI overflow across es, fr, de, pt-BR, ja
+- Run full on-device visual overflow validation across es, fr, de, pt-BR, ja
 
 ---
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -14,6 +14,7 @@ This checklist is required before creating a release tag on `main`.
 - [x] Stabilization script passes: `apps/macos-ui/scripts/run_v0110b2_stabilization_checks.sh`.
 - [x] Priority 2 manager smoke matrix captured: `apps/macos-ui/scripts/smoke_priority2_managers.sh`.
 - [x] Validation notes committed at `docs/validation/v0.11.0-beta.2-smoke-matrix.md`.
+- [x] Localization overflow heuristic validation notes committed at `docs/validation/v0.11.0-beta.2-l10n-overflow.md`.
 - [ ] Run `HelmTests` on a host without testmanagerd sandbox IPC restrictions (current sandbox run skips this step by design when blocked).
 
 ### Branch and Tag

--- a/docs/validation/v0.11.0-beta.2-l10n-overflow.md
+++ b/docs/validation/v0.11.0-beta.2-l10n-overflow.md
@@ -1,0 +1,36 @@
+# v0.11.0-beta.2 Localization Overflow Validation
+
+Generated: 2026-02-17 04:27:15 UTC
+
+## Scope
+
+- Audit script: `apps/macos-ui/scripts/check_locale_lengths.sh`
+- Base locale: `en`
+- Checked locales: `es`, `de`, `fr`, `pt-BR`, `ja`
+- Checked files: `common.json`, `app.json`, `service.json`
+- Heuristic thresholds:
+  - ratio > `1.35`
+  - absolute length delta > `24`
+
+## Command
+
+```bash
+apps/macos-ui/scripts/check_locale_lengths.sh
+```
+
+## Result
+
+- Script exit code: `0`
+- Outcome: no high-risk overflow candidates were flagged by the configured heuristic thresholds.
+
+### Output
+
+```text
+Locale overflow audit
+base=en ratio>1.35 abs_delta>24
+No high-risk overflow candidates found by heuristic thresholds.
+```
+
+## Notes
+
+- This is a heuristic preflight check and does not replace on-device visual validation.


### PR DESCRIPTION
## Summary
- add a dedicated v0.11.0-beta.2 localization overflow validation report artifact
- record heuristic overflow audit completion in NEXT_STEPS and CURRENT_STATE
- mark overflow validation artifact as complete in RELEASE_CHECKLIST

## Validation
- apps/macos-ui/scripts/check_locale_lengths.sh
