### PR TITLE
docs: publish v0.11.0-beta.2 release docs sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented in this file.
 
 The format is based on Keep a Changelog and follows SemVer-compatible Helm versioning.
 
+## [0.11.0-beta.2] - 2026-02-17
+
+### Added
+- Added repeatable stabilization and validation artifacts for `v0.11.0-beta.2`, including:
+  - Priority 2 manager smoke matrix (`docs/validation/v0.11.0-beta.2-smoke-matrix.md`)
+  - Localization overflow heuristic report (`docs/validation/v0.11.0-beta.2-l10n-overflow.md`)
+- Added bounded retry handling for transient task-store persistence failures in orchestration runtime paths.
+- Added regression coverage for refresh-response error attribution and transient task-persistence recovery behavior.
+
+### Changed
+- Updated release metadata and docs for the `v0.11.0-beta.2` stabilization checkpoint.
+- Clarified localization overflow status as heuristic-pass complete with on-device visual validation still pending.
+
 ## [0.11.0-beta.1] - 2026-02-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <br>
   A native macOS menu bar app for unified package manager control.
   <br>
-  <strong>Pre-1.0 &middot; v0.11.0-beta.1</strong>
+  <strong>Pre-1.0 &middot; v0.11.0-beta.2</strong>
 </p>
 
 <p align="center">
@@ -32,7 +32,7 @@ Helm manages software across multiple package managers (Homebrew, npm, pip, Carg
 - **Package list** — Browse installed, upgradable, and available packages with status filters
 - **Progressive search** — Instant local filtering with debounced remote search and cache enrichment
 - **Background tasks** — Real-time task tracking with per-manager serial execution
-- **Multi-manager refresh** — Authority-ordered refresh across 5 managers (Homebrew, mise, rustup, softwareupdate, mas)
+- **Multi-manager refresh** — Authority-ordered refresh across installed managers with phased execution
 - **Restart detection** — Surface restart-required updates from macOS softwareupdate
 
 ## Architecture
@@ -83,7 +83,7 @@ Or open `apps/macos-ui/Helm.xcodeproj` in Xcode and run the **Helm** scheme. The
 | 0.8.x | Pinning & Policy Enforcement — native/virtual pins, safe mode, guarded updates | Completed |
 | 0.9.x | Internationalization Foundation — centralized localization system, ICU format | Completed |
 | 0.10.x | Core Language Package Managers — npm, pipx, pip, Cargo, cargo-binstall | Completed |
-| 0.11.x | Extended Language Package Managers — pnpm, yarn, poetry, RubyGems, bundler | Completed (`v0.11.0-beta.1`) |
+| 0.11.x | Extended Language Package Managers — pnpm, yarn, poetry, RubyGems, bundler | In progress (`v0.11.0-beta.2` stabilization) |
 | 0.12.x | Localization — non-English locales, translation coverage, locale UI | Planned |
 | 0.13.x | UI/UX Analysis & Redesign — full UX audit, interaction model, information architecture refresh | Planned |
 | 0.14.x | Platform, Detection & Optional Managers — Docker, Xcode, Rosetta, Sparkle | Planned |

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,7 +8,7 @@ It reflects reality, not intention.
 
 ## Version
 
-Current version: **0.11.0-beta.1**
+Current version: **0.11.0-beta.2**
 
 See:
 - CHANGELOG.md
@@ -72,6 +72,7 @@ Localization coverage:
 - en, es, de: broad app/service coverage
 - fr, pt-BR, ja: full app/common/service key coverage
 - Locale length audit script added at `apps/macos-ui/scripts/check_locale_lengths.sh` for overflow-risk preflight
+- `v0.11.0-beta.2` heuristic overflow audit captured at `docs/validation/v0.11.0-beta.2-l10n-overflow.md` (no high-risk candidates flagged)
 - Manager display-name localization keys now cover upgrade-preview/task-fallback manager labels (including software update/app store naming)
 
 Validation snapshot for `v0.11.0-beta.1` expansion:
@@ -100,7 +101,7 @@ Validation snapshot for `v0.11.0-beta.1` expansion:
   - Implemented: pnpm (global), yarn (global), RubyGems, Poetry (self/plugins), Bundler
   - Pending: none
 - UI/UX redesign milestone is documented in roadmap sequencing but not yet implemented
-- Overflow validation is still heuristic/script-based until full on-device visual pass is completed
+- Overflow validation now has a documented heuristic pass (`v0.11.0-beta.2`), with full on-device visual pass still pending
 - Upgrade-all transparency now provides summary counts + top manager breakdown in confirmation flow
 - Upgrade-preview filtering/sorting logic now has dedicated macOS UI unit coverage (`HelmTests/UpgradePreviewPlannerTests`)
 - No upgrade preview UI

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -22,10 +22,18 @@ Focus:
 - UI/UX redesign planning
 
 Current checkpoint:
-- `v0.11.0-beta.1` released (Priority 2 extended language-manager milestone)
+- `v0.11.0-beta.2` stabilization in progress (Priority 2 hardening + validation)
 
 Next release target:
 - `v0.11.0-beta.2` (stabilization + validation pass)
+
+`v0.11.0-beta.2` stabilization work in progress:
+
+- Added repeatable stabilization check runner at `apps/macos-ui/scripts/run_v0110b2_stabilization_checks.sh`
+- Added Priority 2 manager smoke-matrix generator at `apps/macos-ui/scripts/smoke_priority2_managers.sh` (writes `docs/validation/v0.11.0-beta.2-smoke-matrix.md`)
+- Captured initial smoke matrix snapshot in this environment (`rubygems`/`bundler` detected; `pnpm`/`yarn`/`poetry` not installed)
+- Captured localization overflow heuristic validation at `docs/validation/v0.11.0-beta.2-l10n-overflow.md` (no high-risk candidates flagged)
+- Pending full execution and result capture on a real macOS validation host with all Priority 2 managers installed
 
 ---
 
@@ -140,7 +148,7 @@ Completed:
 
 Remaining:
 
-- Validate UI overflow across es, fr, de, pt-BR, ja
+- Run full on-device visual overflow validation across es, fr, de, pt-BR, ja
 
 ---
 
@@ -207,6 +215,11 @@ Completed in `v0.10.0` checkpoint:
 - Shared cargo/cargo-binstall outdated synthesis logic to reduce duplication and drift risk
 - Replaced panic-prone FFI `lock().unwrap()` usage with poisoned-lock recovery
 - Resolved website duplicate docs-id build warnings for overview/roadmap pages
+
+Completed in `v0.11.0-beta.2` stabilization:
+
+- Added bounded retry handling for transient task-store create/update persistence failures in orchestration runtime paths
+- Added regression coverage for refresh-response error attribution and transient task-persistence recovery
 
 Remaining:
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -2,6 +2,28 @@
 
 This checklist is required before creating a release tag on `main`.
 
+## v0.11.0-beta.2 (In Progress)
+
+### Scope and Documentation
+- [x] `CHANGELOG.md` includes `0.11.0-beta.2` notes for stabilization and validation results.
+- [x] `README.md` reflects `v0.11.0-beta.2` status.
+- [x] `docs/CURRENT_STATE.md`, `docs/NEXT_STEPS.md`, and `docs/ROADMAP.md` reflect the beta2 checkpoint.
+- [x] Website docs status/overview/roadmap pages are updated for `v0.11.0-beta.2`.
+
+### Validation
+- [x] Stabilization script passes: `apps/macos-ui/scripts/run_v0110b2_stabilization_checks.sh`.
+- [x] Priority 2 manager smoke matrix captured: `apps/macos-ui/scripts/smoke_priority2_managers.sh`.
+- [x] Validation notes committed at `docs/validation/v0.11.0-beta.2-smoke-matrix.md`.
+- [x] Localization overflow heuristic validation notes committed at `docs/validation/v0.11.0-beta.2-l10n-overflow.md`.
+- [ ] Run `HelmTests` on a host without testmanagerd sandbox IPC restrictions (current sandbox run skips this step by design when blocked).
+
+### Branch and Tag
+- [ ] `dev` merged into `main` for release.
+- [ ] Create annotated tag from `main`:
+  - `git tag -a v0.11.0-beta.2 -m "Helm v0.11.0-beta.2"`
+- [ ] Push tag:
+  - `git push origin v0.11.0-beta.2`
+
 ## v0.11.0-beta.1 (Completed)
 
 ### Scope and Documentation

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -303,6 +303,11 @@ Delivered:
 - Implemented `pnpm` (global), `yarn` (global), `poetry` (self/plugins), `RubyGems`, and `bundler` adapters end-to-end.
 - Wired all five managers through core adapter registry, FFI runtime registration, upgrade routing, and macOS UI manager metadata.
 - Added parser fixtures and adapter unit tests for version/list/search/outdated flows where supported.
+- Added bounded retry handling for transient task-store persistence failures in orchestration runtime paths.
+- Added regression coverage for refresh-response error attribution and transient task-persistence recovery behavior.
+- Added repeatable stabilization artifacts for beta checkpoint validation:
+  - `docs/validation/v0.11.0-beta.2-smoke-matrix.md`
+  - `docs/validation/v0.11.0-beta.2-l10n-overflow.md`
 
 ---
 

--- a/web/src/content/docs/index.mdx
+++ b/web/src/content/docs/index.mdx
@@ -40,6 +40,6 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 ## Current Status
 
-Helm is in active pre-1.0 development at **v0.10.0**. Ten managers are functional with authority-ordered refresh, progressive search, pin/safe-mode policy controls, and broad localization coverage. See the [roadmap](/product-roadmap/) for what's next.
+Helm is in active pre-1.0 development at **v0.11.0-beta.2**. Fifteen managers are functional with authority-ordered refresh, progressive search, pin/safe-mode policy controls, and broad localization coverage. See the [roadmap](/product-roadmap/) for what's next.
 
 Helm is currently source-available under a non-commercial license. See the [licensing page](/licensing/) for details.

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -12,13 +12,14 @@ Developers and power users on macOS who manage software through multiple package
 
 ## What it does today
 
-Helm v0.10.0 supports ten managers:
+Helm v0.11.0-beta.2 supports fifteen managers:
 
 | Category | Managers |
 |---------|----------|
 | **Toolchain / Runtime** | mise, rustup |
 | **System / OS / App Store** | Homebrew, softwareupdate, mas |
-| **Language Package Managers** | npm (global), pipx, pip (global), Cargo, cargo-binstall |
+| **Core Language Package Managers** | npm (global), pipx, pip (global), Cargo, cargo-binstall |
+| **Extended Language Package Managers** | pnpm (global), yarn (global), poetry (self/plugins), RubyGems, bundler |
 
 Key features:
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -25,7 +25,7 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 
 | Version | Milestone |
 |---|---|
-| 0.11.x | Extended Language Package Managers — pnpm, yarn, poetry, RubyGems, bundler |
+| 0.11.x | Extended Language Package Managers — pnpm, yarn, poetry, RubyGems, bundler (beta.1 delivered; beta.2 stabilization in progress) |
 | 0.12.x | Localization Expansion — non-English locale coverage hardening and overflow validation |
 
 ## Planned


### PR DESCRIPTION
## Summary
- add 0.11.0-beta.2 changelog notes for stabilization and validation scope
- sync README/current state/next steps/roadmap/release checklist to the beta.2 checkpoint
- update website docs home/overview/roadmap pages to reflect v0.11.0-beta.2 and 15-manager coverage

## Validation
- ASTRO_TELEMETRY_DISABLED=1 npm --prefix web run build
