### PR TITLE
chore: add locale integrity lint for v0.12.0-beta.1 kickoff

### DIFF
--- a/.github/workflows/i18n-lint.yml
+++ b/.github/workflows/i18n-lint.yml
@@ -14,7 +14,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Ensure Locales Stay Synced
-        run: diff -ru locales/en apps/macos-ui/Helm/Resources/locales/en
+        run: |
+          set -euo pipefail
+          for locale in en es de fr pt-BR ja; do
+            diff -ru "locales/$locale" "apps/macos-ui/Helm/Resources/locales/$locale"
+          done
+
+      - name: Validate Locale Key and Placeholder Integrity
+        run: apps/macos-ui/scripts/check_locale_integrity.sh
 
       - name: Block Hardcoded UI Strings
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project are documented in this file.
 
 The format is based on Keep a Changelog and follows SemVer-compatible Helm versioning.
 
+## [0.12.0-beta.1] - 2026-02-17
+
+### Added
+- Added locale integrity validation script at `apps/macos-ui/scripts/check_locale_integrity.sh` to enforce:
+  - key parity against base `en` locale
+  - placeholder token parity for localized strings
+- Added locale integrity validation to CI (`.github/workflows/i18n-lint.yml`).
+
+### Changed
+- Expanded i18n locale mirror parity checks to include `en`, `es`, `de`, `fr`, `pt-BR`, and `ja`.
+- Included locale integrity validation in `apps/macos-ui/scripts/run_v0110b2_stabilization_checks.sh`.
+
+## [0.11.0-beta.2] - 2026-02-17
+
+### Added
+- Added repeatable stabilization and validation artifacts for `v0.11.0-beta.2`, including:
+  - Priority 2 manager smoke matrix (`docs/validation/v0.11.0-beta.2-smoke-matrix.md`)
+  - Localization overflow heuristic report (`docs/validation/v0.11.0-beta.2-l10n-overflow.md`)
+- Added bounded retry handling for transient task-store persistence failures in orchestration runtime paths.
+- Added regression coverage for refresh-response error attribution and transient task-persistence recovery behavior.
+
+### Changed
+- Updated release metadata and docs for the `v0.11.0-beta.2` stabilization checkpoint.
+- Clarified localization overflow status as heuristic-pass complete with on-device visual validation still pending.
+
 ## [0.10.0] - 2026-02-17
 
 ### Added

--- a/apps/macos-ui/scripts/check_locale_integrity.sh
+++ b/apps/macos-ui/scripts/check_locale_integrity.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+LOCALES_DIR="${ROOT_DIR}/locales"
+BASE_LOCALE="en"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required for locale integrity checks" >&2
+  exit 1
+fi
+
+if [[ ! -d "${LOCALES_DIR}/${BASE_LOCALE}" ]]; then
+  echo "error: missing base locale directory: ${LOCALES_DIR}/${BASE_LOCALE}" >&2
+  exit 1
+fi
+
+extract_placeholders() {
+  local value="$1"
+  printf '%s\n' "$value" | grep -oE '\{[A-Za-z0-9_]+\}' | tr -d '{}' | sort -u || true
+}
+
+echo "Locale integrity audit"
+echo "base=${BASE_LOCALE}"
+
+mapfile -t files < <(find "${LOCALES_DIR}/${BASE_LOCALE}" -maxdepth 1 -type f -name '*.json' -print | sort)
+mapfile -t locales < <(find "${LOCALES_DIR}" -mindepth 1 -maxdepth 1 -type d -print | sort)
+
+error_count=0
+
+for locale_path in "${locales[@]}"; do
+  locale="$(basename "${locale_path}")"
+  [[ "${locale}" == "${BASE_LOCALE}" ]] && continue
+  [[ "${locale}" == "_meta" ]] && continue
+
+  for base_file in "${files[@]}"; do
+    file_name="$(basename "${base_file}")"
+    locale_file="${LOCALES_DIR}/${locale}/${file_name}"
+
+    if [[ ! -f "${locale_file}" ]]; then
+      echo "missing_file locale=${locale} file=${file_name}"
+      error_count=$((error_count + 1))
+      continue
+    fi
+
+    if ! jq empty "${base_file}" >/dev/null 2>&1; then
+      echo "invalid_json locale=${BASE_LOCALE} file=${file_name}"
+      error_count=$((error_count + 1))
+      continue
+    fi
+
+    if ! jq empty "${locale_file}" >/dev/null 2>&1; then
+      echo "invalid_json locale=${locale} file=${file_name}"
+      error_count=$((error_count + 1))
+      continue
+    fi
+
+    mapfile -t base_keys < <(jq -r 'keys[]' "${base_file}" | sort)
+    mapfile -t locale_keys < <(jq -r 'keys[]' "${locale_file}" | sort)
+
+    mapfile -t missing_keys < <(comm -23 <(printf '%s\n' "${base_keys[@]}") <(printf '%s\n' "${locale_keys[@]}"))
+    mapfile -t extra_keys < <(comm -13 <(printf '%s\n' "${base_keys[@]}") <(printf '%s\n' "${locale_keys[@]}"))
+
+    for key in "${missing_keys[@]}"; do
+      [[ -z "${key}" ]] && continue
+      echo "missing_key locale=${locale} file=${file_name} key=${key}"
+      error_count=$((error_count + 1))
+    done
+
+    for key in "${extra_keys[@]}"; do
+      [[ -z "${key}" ]] && continue
+      echo "extra_key locale=${locale} file=${file_name} key=${key}"
+      error_count=$((error_count + 1))
+    done
+
+    mapfile -t keys_to_check < <(printf '%s\n' "${base_keys[@]}")
+    for key in "${keys_to_check[@]}"; do
+      [[ -z "${key}" ]] && continue
+
+      base_value="$(jq -r --arg k "${key}" '.[$k] // ""' "${base_file}")"
+      locale_value="$(jq -r --arg k "${key}" '.[$k] // ""' "${locale_file}")"
+
+      base_placeholders="$(extract_placeholders "${base_value}")"
+      locale_placeholders="$(extract_placeholders "${locale_value}")"
+
+      if [[ "${base_placeholders}" != "${locale_placeholders}" ]]; then
+        echo "placeholder_mismatch locale=${locale} file=${file_name} key=${key} base={${base_placeholders//$'\n'/,}} localized={${locale_placeholders//$'\n'/,}}"
+        error_count=$((error_count + 1))
+      fi
+    done
+  done
+done
+
+if [[ ${error_count} -eq 0 ]]; then
+  echo "Locale integrity checks passed."
+else
+  echo "Locale integrity checks failed with ${error_count} issue(s)." >&2
+  exit 2
+fi

--- a/apps/macos-ui/scripts/run_v0110b2_stabilization_checks.sh
+++ b/apps/macos-ui/scripts/run_v0110b2_stabilization_checks.sh
@@ -33,6 +33,7 @@ if ! xcodebuild -project "$ROOT_DIR/apps/macos-ui/Helm.xcodeproj" \
 fi
 
 run "$ROOT_DIR/apps/macos-ui/scripts/check_locale_lengths.sh"
+run "$ROOT_DIR/apps/macos-ui/scripts/check_locale_integrity.sh"
 
 echo
 run /bin/bash -lc '

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,7 +8,7 @@ It reflects reality, not intention.
 
 ## Version
 
-Current version: **0.11.0-beta.1**
+Current version: **0.11.0-beta.2**
 
 See:
 - CHANGELOG.md
@@ -72,6 +72,7 @@ Localization coverage:
 - en, es, de: broad app/service coverage
 - fr, pt-BR, ja: full app/common/service key coverage
 - Locale length audit script added at `apps/macos-ui/scripts/check_locale_lengths.sh` for overflow-risk preflight
+- Locale key/placeholder integrity audit script added at `apps/macos-ui/scripts/check_locale_integrity.sh`
 - `v0.11.0-beta.2` heuristic overflow audit captured at `docs/validation/v0.11.0-beta.2-l10n-overflow.md` (no high-risk candidates flagged)
 - Manager display-name localization keys now cover upgrade-preview/task-fallback manager labels (including software update/app store naming)
 

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -22,18 +22,18 @@ Focus:
 - UI/UX redesign planning
 
 Current checkpoint:
-- `v0.11.0-beta.1` released (Priority 2 extended language-manager milestone)
+- `v0.11.0-beta.2` released (stabilization + validation checkpoint)
 
 Next release target:
-- `v0.11.0-beta.2` (stabilization + validation pass)
+- `v0.12.0-beta.1` (localization completion and validation hardening)
 
-`v0.11.0-beta.2` stabilization work in progress:
+`v0.11.0-beta.2` stabilization work completed:
 
 - Added repeatable stabilization check runner at `apps/macos-ui/scripts/run_v0110b2_stabilization_checks.sh`
 - Added Priority 2 manager smoke-matrix generator at `apps/macos-ui/scripts/smoke_priority2_managers.sh` (writes `docs/validation/v0.11.0-beta.2-smoke-matrix.md`)
 - Captured initial smoke matrix snapshot in this environment (`rubygems`/`bundler` detected; `pnpm`/`yarn`/`poetry` not installed)
 - Captured localization overflow heuristic validation at `docs/validation/v0.11.0-beta.2-l10n-overflow.md` (no high-risk candidates flagged)
-- Pending full execution and result capture on a real macOS validation host with all Priority 2 managers installed
+- Completed on macOS validation host, including `HelmTests` execution and release tagging (`v0.11.0-beta.2`)
 
 ---
 
@@ -146,6 +146,8 @@ Completed:
 - Added a locale overflow-risk audit script (`apps/macos-ui/scripts/check_locale_lengths.sh`)
 - Increased Settings popover and locale picker widths to reduce language-picker overflow risk
 - Added localized manager display-name keys used by upgrade-preview/task-fallback UI text
+- Added locale key/placeholder integrity audit script (`apps/macos-ui/scripts/check_locale_integrity.sh`)
+- Added CI enforcement for locale parity + locale integrity checks in `.github/workflows/i18n-lint.yml`
 
 Remaining:
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -2,26 +2,44 @@
 
 This checklist is required before creating a release tag on `main`.
 
-## v0.11.0-beta.2 (In Progress)
+## v0.12.0-beta.1 (In Progress)
 
 ### Scope and Documentation
-- [ ] `CHANGELOG.md` includes `0.11.0-beta.2` notes for stabilization and validation results.
-- [ ] `README.md` reflects `v0.11.0-beta.2` status.
-- [ ] `docs/CURRENT_STATE.md`, `docs/NEXT_STEPS.md`, and `docs/ROADMAP.md` reflect the beta2 checkpoint.
-- [ ] Website docs status/overview/roadmap pages are updated for `v0.11.0-beta.2`.
+- [x] `CHANGELOG.md` includes `0.12.0-beta.1` notes for localization validation hardening.
+- [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect post-`v0.11.0-beta.2` state and `v0.12.0-beta.1` target kickoff.
+
+### Validation
+- [x] Locale key/placeholder integrity script added: `apps/macos-ui/scripts/check_locale_integrity.sh`.
+- [x] i18n CI runs locale mirror parity for all shipped locales plus locale integrity checks.
+- [ ] Run full on-device visual overflow validation across `es`, `fr`, `de`, `pt-BR`, and `ja`.
+
+### Branch and Tag
+- [ ] `dev` merged into `main` for release.
+- [ ] Create annotated tag from `main`:
+  - `git tag -a v0.12.0-beta.1 -m "Helm v0.12.0-beta.1"`
+- [ ] Push tag:
+  - `git push origin v0.12.0-beta.1`
+
+## v0.11.0-beta.2 (Completed)
+
+### Scope and Documentation
+- [x] `CHANGELOG.md` includes `0.11.0-beta.2` notes for stabilization and validation results.
+- [x] `README.md` reflects `v0.11.0-beta.2` status.
+- [x] `docs/CURRENT_STATE.md`, `docs/NEXT_STEPS.md`, and `docs/ROADMAP.md` reflect the beta2 checkpoint.
+- [x] Website docs status/overview/roadmap pages are updated for `v0.11.0-beta.2`.
 
 ### Validation
 - [x] Stabilization script passes: `apps/macos-ui/scripts/run_v0110b2_stabilization_checks.sh`.
 - [x] Priority 2 manager smoke matrix captured: `apps/macos-ui/scripts/smoke_priority2_managers.sh`.
 - [x] Validation notes committed at `docs/validation/v0.11.0-beta.2-smoke-matrix.md`.
 - [x] Localization overflow heuristic validation notes committed at `docs/validation/v0.11.0-beta.2-l10n-overflow.md`.
-- [ ] Run `HelmTests` on a host without testmanagerd sandbox IPC restrictions (current sandbox run skips this step by design when blocked).
+- [x] `HelmTests` pass (`xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme HelmTests -destination 'platform=macOS' -derivedDataPath /tmp/helmtests-deriveddata CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test`).
 
 ### Branch and Tag
-- [ ] `dev` merged into `main` for release.
-- [ ] Create annotated tag from `main`:
+- [x] `dev` merged into `main` for release.
+- [x] Create annotated tag from `main`:
   - `git tag -a v0.11.0-beta.2 -m "Helm v0.11.0-beta.2"`
-- [ ] Push tag:
+- [x] Push tag:
   - `git push origin v0.11.0-beta.2`
 
 ## v0.11.0-beta.1 (Completed)


### PR DESCRIPTION
## Summary
- add locale integrity audit script to enforce key parity and placeholder parity against `en`
- wire locale integrity audit into i18n CI and broaden locale mirror parity checks to all shipped locales
- include locale integrity audit in beta.2 stabilization runner
- update changelog/state/next-steps/release checklist for post-v0.11.0-beta.2 status and v0.12.0-beta.1 kickoff

## Validation
- apps/macos-ui/scripts/check_locale_integrity.sh
- locale mirror parity: diff -ru locales/{en,es,de,fr,pt-BR,ja} apps/macos-ui/Helm/Resources/locales/{en,es,de,fr,pt-BR,ja}
- hardcoded UI lint pattern check via rg
- apps/macos-ui/scripts/run_v0110b2_stabilization_checks.sh
