### PR TITLE
docs: sync README and website for v0.12.0-beta.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <br>
   A native macOS menu bar app for unified package manager control.
   <br>
-  <strong>Pre-1.0 &middot; v0.10.0</strong>
+  <strong>Pre-1.0 &middot; v0.12.0-beta.1</strong>
 </p>
 
 <p align="center">
@@ -23,7 +23,7 @@
 
 Helm manages software across multiple package managers (Homebrew, npm, pip, Cargo, etc.) and runtime tools (mise, rustup) from a single menu bar interface. It is designed as infrastructure software: deterministic, safety-first, and explicit about authority, orchestration, and error handling.
 
-> **Status:** Active pre-1.0 development. Ten managers are functional with authority-ordered refresh, progressive search, pin/safe-mode policy controls, and localization coverage for `en`, `es`, `de`, `fr`, `pt-BR`, and `ja`.
+> **Status:** Active pre-1.0 development. Fifteen managers are functional with authority-ordered refresh, progressive search, pin/safe-mode policy controls, and localization coverage for `en`, `es`, `de`, `fr`, `pt-BR`, and `ja`.
 
 ## Features
 
@@ -32,7 +32,7 @@ Helm manages software across multiple package managers (Homebrew, npm, pip, Carg
 - **Package list** — Browse installed, upgradable, and available packages with status filters
 - **Progressive search** — Instant local filtering with debounced remote search and cache enrichment
 - **Background tasks** — Real-time task tracking with per-manager serial execution
-- **Multi-manager refresh** — Authority-ordered refresh across 5 managers (Homebrew, mise, rustup, softwareupdate, mas)
+- **Multi-manager refresh** — Authority-ordered refresh across installed managers with phased execution
 - **Restart detection** — Surface restart-required updates from macOS softwareupdate
 
 ## Architecture
@@ -83,8 +83,8 @@ Or open `apps/macos-ui/Helm.xcodeproj` in Xcode and run the **Helm** scheme. The
 | 0.8.x | Pinning & Policy Enforcement — native/virtual pins, safe mode, guarded updates | Completed |
 | 0.9.x | Internationalization Foundation — centralized localization system, ICU format | Completed |
 | 0.10.x | Core Language Package Managers — npm, pipx, pip, Cargo, cargo-binstall | Completed |
-| 0.11.x | Extended Language Package Managers — pnpm, yarn, poetry, RubyGems, bundler | Planned |
-| 0.12.x | Localization — non-English locales, translation coverage, locale UI | Planned |
+| 0.11.x | Extended Language Package Managers — pnpm, yarn, poetry, RubyGems, bundler | Completed |
+| 0.12.x | Localization — non-English locales, translation coverage, locale UI | In Progress (`v0.12.0-beta.1`) |
 | 0.13.x | UI/UX Analysis & Redesign — full UX audit, interaction model, information architecture refresh | Planned |
 | 0.14.x | Platform, Detection & Optional Managers — Docker, Xcode, Rosetta, Sparkle | Planned |
 | 0.15.x | Upgrade Preview & Execution Transparency — bulk preview, dry-run, failure isolation | Planned |

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -6,6 +6,8 @@ This checklist is required before creating a release tag on `main`.
 
 ### Scope and Documentation
 - [x] `CHANGELOG.md` includes `0.12.0-beta.1` notes for localization validation hardening.
+- [x] `README.md` reflects `v0.12.0-beta.1` status and manager coverage.
+- [x] Website docs status/overview/roadmap pages are updated for `v0.12.0-beta.1`.
 - [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect post-`v0.11.0-beta.2` state and `v0.12.0-beta.1` target kickoff.
 
 ### Validation

--- a/web/src/content/docs/index.mdx
+++ b/web/src/content/docs/index.mdx
@@ -40,6 +40,6 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 ## Current Status
 
-Helm is in active pre-1.0 development at **v0.10.0**. Ten managers are functional with authority-ordered refresh, progressive search, pin/safe-mode policy controls, and broad localization coverage. See the [roadmap](/product-roadmap/) for what's next.
+Helm is in active pre-1.0 development at **v0.12.0-beta.1**. Fifteen managers are functional with authority-ordered refresh, progressive search, pin/safe-mode policy controls, and broad localization coverage. See the [roadmap](/product-roadmap/) for what's next.
 
 Helm is currently source-available under a non-commercial license. See the [licensing page](/licensing/) for details.

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -12,13 +12,14 @@ Developers and power users on macOS who manage software through multiple package
 
 ## What it does today
 
-Helm v0.10.0 supports ten managers:
+Helm v0.12.0-beta.1 supports fifteen managers:
 
 | Category | Managers |
 |---------|----------|
 | **Toolchain / Runtime** | mise, rustup |
 | **System / OS / App Store** | Homebrew, softwareupdate, mas |
-| **Language Package Managers** | npm (global), pipx, pip (global), Cargo, cargo-binstall |
+| **Core Language Package Managers** | npm (global), pipx, pip (global), Cargo, cargo-binstall |
+| **Extended Language Package Managers** | pnpm (global), yarn (global), poetry (self/plugins), RubyGems, bundler |
 
 Key features:
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -25,8 +25,8 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 
 | Version | Milestone |
 |---|---|
-| 0.11.x | Extended Language Package Managers — pnpm, yarn, poetry, RubyGems, bundler |
-| 0.12.x | Localization Expansion — non-English locale coverage hardening and overflow validation |
+| 0.11.x | Extended Language Package Managers — pnpm, yarn, poetry, RubyGems, bundler (completed) |
+| 0.12.x | Localization Expansion — non-English locale coverage hardening and overflow validation (in progress) |
 
 ## Planned
 


### PR DESCRIPTION
## Summary
- update README status/milestones to reflect `v0.12.0-beta.1` and current manager coverage
- update website docs home/overview/roadmap pages to `v0.12.0-beta.1` state
- mark README + website scope items complete in `docs/RELEASE_CHECKLIST.md`

## Validation
- ASTRO_TELEMETRY_DISABLED=1 npm --prefix web run build
