### PR TITLE
test: expand v0.12.0 visual overflow validation coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented in this file.
 
 The format is based on Keep a Changelog and follows SemVer-compatible Helm versioning.
 
+## [0.12.0-beta.2] - 2026-02-17
+
+### Added
+- Expanded `LocalizationOverflowValidationTests` to validate localized width budgets for:
+  - onboarding constrained labels/actions
+  - navigation tabs and search placeholder
+  - package filter controls
+  - manager category/state labels
+- Added visual validation artifact at `docs/validation/v0.12.0-beta.2-visual-overflow-expansion.md`.
+
+### Changed
+- Promoted Priority 3 localization-overflow validation from Settings-only coverage to broader high-constrained app surfaces.
+
 ## [0.12.0-beta.1] - 2026-02-17
 
 ### Added

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,7 +8,7 @@ It reflects reality, not intention.
 
 ## Version
 
-Current version: **0.11.0-beta.2**
+Current version: **0.12.0-beta.1**
 
 See:
 - CHANGELOG.md
@@ -75,6 +75,7 @@ Localization coverage:
 - Locale key/placeholder integrity audit script added at `apps/macos-ui/scripts/check_locale_integrity.sh`
 - `v0.11.0-beta.2` heuristic overflow audit captured at `docs/validation/v0.11.0-beta.2-l10n-overflow.md` (no high-risk candidates flagged)
 - `v0.12.0-beta.1` on-device overflow validation captured at `docs/validation/v0.12.0-beta.1-visual-overflow.md` (Settings surface checks passing)
+- Expanded on-device overflow validation coverage for onboarding/navigation/packages/managers captured at `docs/validation/v0.12.0-beta.2-visual-overflow-expansion.md`
 - Manager display-name localization keys now cover upgrade-preview/task-fallback manager labels (including software update/app store naming)
 
 Validation snapshot for `v0.11.0-beta.1` expansion:
@@ -103,7 +104,7 @@ Validation snapshot for `v0.11.0-beta.1` expansion:
   - Implemented: pnpm (global), yarn (global), RubyGems, Poetry (self/plugins), Bundler
   - Pending: none
 - UI/UX redesign milestone is documented in roadmap sequencing but not yet implemented
-- Overflow validation now has both heuristic and on-device executable coverage for Settings; broader UI surface validation is still in progress
+- Overflow validation now has both heuristic and on-device executable coverage for Settings, onboarding, navigation, package filters, and manager labels/states
 - Upgrade-all transparency now provides summary counts + top manager breakdown in confirmation flow
 - Upgrade-preview filtering/sorting logic now has dedicated macOS UI unit coverage (`HelmTests/UpgradePreviewPlannerTests`)
 - No upgrade preview UI

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -22,10 +22,10 @@ Focus:
 - UI/UX redesign planning
 
 Current checkpoint:
-- `v0.11.0-beta.2` released (stabilization + validation checkpoint)
+- `v0.12.0-beta.1` released (localization hardening + settings overflow validation)
 
 Next release target:
-- `v0.12.0-beta.1` (localization completion and validation hardening)
+- `v0.12.0-beta.2` (expanded visual overflow validation across onboarding/navigation/packages/managers)
 
 `v0.11.0-beta.2` stabilization work completed:
 
@@ -151,10 +151,12 @@ Completed:
 - Added `HelmTests`-based visual overflow validation for `SettingsPopoverView` locale-sensitive controls (`LocalizationOverflowValidationTests`)
 - Captured `v0.12.0-beta.1` visual overflow validation report at `docs/validation/v0.12.0-beta.1-visual-overflow.md`
 - Increased settings popover + language picker widths to resolve validated overflow failures
+- Expanded `LocalizationOverflowValidationTests` coverage to onboarding/navigation/package-filter/manager-surface constrained labels
+- Captured `v0.12.0-beta.2` overflow-expansion validation report at `docs/validation/v0.12.0-beta.2-visual-overflow-expansion.md`
 
 Remaining:
 
-- Expand visual overflow validation coverage beyond Settings (onboarding, package list, managers)
+- None for Priority 3 at this checkpoint
 
 ---
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -2,7 +2,25 @@
 
 This checklist is required before creating a release tag on `main`.
 
-## v0.12.0-beta.1 (In Progress)
+## v0.12.0-beta.2 (In Progress)
+
+### Scope and Documentation
+- [x] `CHANGELOG.md` includes `0.12.0-beta.2` notes for expanded visual-overflow validation coverage.
+- [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect Priority 3 overflow-validation expansion status.
+- [x] Validation report committed at `docs/validation/v0.12.0-beta.2-visual-overflow-expansion.md`.
+
+### Validation
+- [x] Run full on-device visual overflow validation across `es`, `fr`, `de`, `pt-BR`, and `ja` (`HelmTests/LocalizationOverflowValidationTests`) with expanded surface checks.
+- [x] `HelmTests` pass (`xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme HelmTests -destination 'platform=macOS' -derivedDataPath /tmp/helmtests-deriveddata CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test`).
+
+### Branch and Tag
+- [ ] `dev` merged into `main` for release.
+- [ ] Create annotated tag from `main`:
+  - `git tag -a v0.12.0-beta.2 -m "Helm v0.12.0-beta.2"`
+- [ ] Push tag:
+  - `git push origin v0.12.0-beta.2`
+
+## v0.12.0-beta.1 (Completed)
 
 ### Scope and Documentation
 - [x] `CHANGELOG.md` includes `0.12.0-beta.1` notes for localization validation hardening.
@@ -17,10 +35,10 @@ This checklist is required before creating a release tag on `main`.
 - [x] Validation report committed at `docs/validation/v0.12.0-beta.1-visual-overflow.md`.
 
 ### Branch and Tag
-- [ ] `dev` merged into `main` for release.
-- [ ] Create annotated tag from `main`:
+- [x] `dev` merged into `main` for release.
+- [x] Create annotated tag from `main`:
   - `git tag -a v0.12.0-beta.1 -m "Helm v0.12.0-beta.1"`
-- [ ] Push tag:
+- [x] Push tag:
   - `git push origin v0.12.0-beta.1`
 
 ## v0.11.0-beta.2 (Completed)

--- a/docs/validation/v0.12.0-beta.2-visual-overflow-expansion.md
+++ b/docs/validation/v0.12.0-beta.2-visual-overflow-expansion.md
@@ -1,0 +1,45 @@
+# v0.12.0-beta.2 Visual Overflow Expansion Validation
+
+Generated: 2026-02-17 06:32:24 UTC
+
+## Scope
+
+- Locales: `es`, `fr`, `de`, `pt-BR`, `ja`
+- Surfaces:
+  - `SettingsPopoverView` (existing checks retained)
+  - onboarding constrained labels/actions
+  - navigation tabs + search placeholder
+  - package-list filter controls
+  - managers category/state labels
+- Test suite: `LocalizationOverflowValidationTests`
+
+## Method
+
+Expanded `HelmTests/LocalizationOverflowValidationTests.swift` with additional deterministic width checks aligned to constrained panel/layout widths used by the macOS UI (`360` panel width and surface-specific control budgets).
+
+Notes:
+- Checks target labels/actions that are rendered as constrained, single-line UI text in the relevant surfaces.
+- ICU plural-template keys are intentionally excluded from direct width assertions in this suite because runtime message formatting is applied at render time.
+
+## Results
+
+- New overflow validation methods passed for all target locales:
+  - `testOnboardingStringsFitPanelLayoutsAcrossLocales`
+  - `testNavigationAndFilterStringsFitPanelLayoutsAcrossLocales`
+  - `testManagerSectionLabelsFitPanelLayoutsAcrossLocales`
+- Existing settings overflow validation methods remain passing:
+  - `testLanguagePickerOptionsFitConfiguredWidthAcrossLocales`
+  - `testFrequencyPickerOptionsFitConfiguredWidthAcrossLocales`
+  - `testSettingsToggleAndLabelStringsFitPopoverContentAcrossLocales`
+- Full `HelmTests` suite passed in the same run.
+
+## Command
+
+```bash
+xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme HelmTests -destination 'platform=macOS' -derivedDataPath /tmp/helmtests-deriveddata CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test
+```
+
+## Notes
+
+- Validation run succeeded in this environment without additional sandbox escalation.
+- This closes the previously-tracked Priority 3 residual item for broadening overflow validation beyond Settings.


### PR DESCRIPTION
Summary
- expand LocalizationOverflowValidationTests beyond Settings to cover onboarding, navigation, package filter, and managers constrained labels
- add deterministic max-line width checks for es, fr, de, pt-BR, and ja using panel/layout-aligned width budgets
- document the validation expansion in release docs and add a dedicated validation artifact for v0.12.0-beta.2

Validation
- xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme HelmTests -destination 'platform=macOS' -derivedDataPath /tmp/helmtests-deriveddata CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test

Docs Updated
- CHANGELOG.md
- docs/CURRENT_STATE.md
- docs/NEXT_STEPS.md
- docs/RELEASE_CHECKLIST.md
- docs/validation/v0.12.0-beta.2-visual-overflow-expansion.md
