### PR TITLE
feat: add dedicated upgrade preview UI surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented in this file.
 
 The format is based on Keep a Changelog and follows SemVer-compatible Helm versioning.
 
+## [0.12.0-beta.3] - 2026-02-17
+
+### Added
+- Added a dedicated Upgrade Preview sheet in macOS Settings that shows:
+  - a no-OS-updates execution plan section
+  - an optional include-OS-updates section (when Safe Mode is off)
+  - manager-level package-count breakdown for each execution mode
+- Wired direct execution actions from the preview surface for both upgrade modes.
+
+### Changed
+- Replaced the previous Upgrade All confirmation alert with a dedicated preview UI surface.
+
 ## [0.12.0-beta.2] - 2026-02-17
 
 ### Added

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,7 +8,7 @@ It reflects reality, not intention.
 
 ## Version
 
-Current version: **0.12.0-beta.1**
+Current version: **0.12.0-beta.2**
 
 See:
 - CHANGELOG.md
@@ -107,7 +107,7 @@ Validation snapshot for `v0.11.0-beta.1` expansion:
 - Overflow validation now has both heuristic and on-device executable coverage for Settings, onboarding, navigation, package filters, and manager labels/states
 - Upgrade-all transparency now provides summary counts + top manager breakdown in confirmation flow
 - Upgrade-preview filtering/sorting logic now has dedicated macOS UI unit coverage (`HelmTests/UpgradePreviewPlannerTests`)
-- No upgrade preview UI
+- Dedicated upgrade preview UI surface is implemented in macOS Settings (execution-plan sections with manager breakdown)
 - No dry-run mode exposed in UI
 - No self-update mechanism yet
 - Limited diagnostics UI

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -22,10 +22,10 @@ Focus:
 - UI/UX redesign planning
 
 Current checkpoint:
-- `v0.12.0-beta.1` released (localization hardening + settings overflow validation)
+- `v0.12.0-beta.2` released (visual-overflow validation expansion)
 
 Next release target:
-- `v0.12.0-beta.2` (expanded visual overflow validation across onboarding/navigation/packages/managers)
+- `v0.12.0-beta.3` (dedicated upgrade-preview UI surface)
 
 `v0.11.0-beta.2` stabilization work completed:
 
@@ -174,10 +174,10 @@ Completed:
 - Added manager-level package-count breakdown (top managers) in the Upgrade All confirmation alert
 - Localized manager labels used in the Upgrade All breakdown output
 - Added focused unit tests for upgrade-preview filtering and breakdown ordering (`UpgradePreviewPlannerTests`)
+- Added a dedicated Upgrade Preview UI surface in macOS Settings with execution-plan sections and manager-level package breakdowns for both no-OS and with-OS modes
 
 Remaining:
 
-- Add dedicated upgrade preview UI surface
 - Add dry-run support
 
 ---

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -2,7 +2,23 @@
 
 This checklist is required before creating a release tag on `main`.
 
-## v0.12.0-beta.2 (In Progress)
+## v0.12.0-beta.3 (In Progress)
+
+### Scope and Documentation
+- [x] `CHANGELOG.md` includes `0.12.0-beta.3` notes for dedicated upgrade-preview UI delivery.
+- [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect Priority 4 preview-surface completion status.
+
+### Validation
+- [x] `HelmTests` pass (`xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme HelmTests -destination 'platform=macOS' -derivedDataPath /tmp/helmtests-deriveddata CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test`).
+
+### Branch and Tag
+- [ ] `dev` merged into `main` for release.
+- [ ] Create annotated tag from `main`:
+  - `git tag -a v0.12.0-beta.3 -m "Helm v0.12.0-beta.3"`
+- [ ] Push tag:
+  - `git push origin v0.12.0-beta.3`
+
+## v0.12.0-beta.2 (Completed)
 
 ### Scope and Documentation
 - [x] `CHANGELOG.md` includes `0.12.0-beta.2` notes for expanded visual-overflow validation coverage.
@@ -14,10 +30,10 @@ This checklist is required before creating a release tag on `main`.
 - [x] `HelmTests` pass (`xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme HelmTests -destination 'platform=macOS' -derivedDataPath /tmp/helmtests-deriveddata CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test`).
 
 ### Branch and Tag
-- [ ] `dev` merged into `main` for release.
-- [ ] Create annotated tag from `main`:
+- [x] `dev` merged into `main` for release.
+- [x] Create annotated tag from `main`:
   - `git tag -a v0.12.0-beta.2 -m "Helm v0.12.0-beta.2"`
-- [ ] Push tag:
+- [x] Push tag:
   - `git push origin v0.12.0-beta.2`
 
 ## v0.12.0-beta.1 (Completed)


### PR DESCRIPTION
Summary
- replace the Upgrade All confirmation alert with a dedicated Upgrade Preview sheet in Settings
- show execution-plan sections for no-OS updates and (when Safe Mode is off) include-OS updates
- include manager-level package-count breakdown for each execution mode and execute directly from the preview surface
- update release docs/checklists and Priority 4 status to reflect preview-surface completion

Validation
- xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme HelmTests -destination 'platform=macOS' -derivedDataPath /tmp/helmtests-deriveddata CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test

Files
- apps/macos-ui/Helm/Views/SettingsPopoverView.swift
- CHANGELOG.md
- docs/CURRENT_STATE.md
- docs/NEXT_STEPS.md
- docs/RELEASE_CHECKLIST.md
