### PR TITLE
feat: add dry-run mode to upgrade preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented in this file.
 
 The format is based on Keep a Changelog and follows SemVer-compatible Helm versioning.
 
+## [0.12.0-beta.4] - 2026-02-17
+
+### Added
+- Added dry-run support to the dedicated Upgrade Preview sheet in macOS Settings:
+  - localized Dry Run mode toggle
+  - dry-run result dialog with planned execution summary
+  - no task submission when dry-run mode is enabled
+- Added new localized keys for dry-run controls/results across shipped locales (`en`, `es`, `de`, `fr`, `pt-BR`, `ja`).
+
 ## [0.12.0-beta.3] - 2026-02-17
 
 ### Added

--- a/apps/macos-ui/Helm/Core/L10n.swift
+++ b/apps/macos-ui/Helm/Core/L10n.swift
@@ -240,6 +240,9 @@ struct L10n {
                     static let upgradeWithOs = "app.settings.alert.upgrade_all.upgrade_with_os"
                     static let safeModeMessage = "app.settings.alert.upgrade_all.safe_mode_message"
                     static let standardMessage = "app.settings.alert.upgrade_all.standard_message"
+                    static let dryRunToggle = "app.settings.alert.upgrade_all.dry_run_toggle"
+                    static let dryRunResultTitle = "app.settings.alert.upgrade_all.dry_run_result_title"
+                    static let dryRunResultMessage = "app.settings.alert.upgrade_all.dry_run_result_message"
                 }
             }
         }

--- a/apps/macos-ui/Helm/Resources/locales/de/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/de/app.json
@@ -131,5 +131,8 @@
   "app.managers.name.mise": "mise",
   "app.managers.name.rustup": "rustup",
   "app.managers.name.software_update": "Softwareaktualisierung",
-  "app.managers.name.app_store": "App Store"
+  "app.managers.name.app_store": "App Store",
+  "app.settings.alert.upgrade_all.dry_run_toggle": "Trockenlaufmodus (keine Änderungen)",
+  "app.settings.alert.upgrade_all.dry_run_result_title": "Trockenlauf-Ergebnis",
+  "app.settings.alert.upgrade_all.dry_run_result_message": "Trockenlauf abgeschlossen. Es wurden keine Aufgaben eingereiht.\\n\\nGeplante Aktionen:\\n{summary}"
 }

--- a/apps/macos-ui/Helm/Resources/locales/en/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/en/app.json
@@ -131,5 +131,8 @@
   "app.managers.name.mise": "mise",
   "app.managers.name.rustup": "rustup",
   "app.managers.name.software_update": "Software Update",
-  "app.managers.name.app_store": "App Store"
+  "app.managers.name.app_store": "App Store",
+  "app.settings.alert.upgrade_all.dry_run_toggle": "Dry Run Mode (no changes)",
+  "app.settings.alert.upgrade_all.dry_run_result_title": "Dry Run Result",
+  "app.settings.alert.upgrade_all.dry_run_result_message": "Dry run complete. No tasks were queued.\\n\\nPlanned actions:\\n{summary}"
 }

--- a/apps/macos-ui/Helm/Resources/locales/es/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/es/app.json
@@ -131,5 +131,8 @@
   "app.managers.name.mise": "mise",
   "app.managers.name.rustup": "rustup",
   "app.managers.name.software_update": "Actualizacion de software",
-  "app.managers.name.app_store": "App Store"
+  "app.managers.name.app_store": "App Store",
+  "app.settings.alert.upgrade_all.dry_run_toggle": "Modo de simulación (sin cambios)",
+  "app.settings.alert.upgrade_all.dry_run_result_title": "Resultado de simulación",
+  "app.settings.alert.upgrade_all.dry_run_result_message": "Simulación completada. No se encolaron tareas.\\n\\nAcciones planificadas:\\n{summary}"
 }

--- a/apps/macos-ui/Helm/Resources/locales/fr/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/fr/app.json
@@ -131,5 +131,8 @@
   "app.managers.name.mise": "mise",
   "app.managers.name.rustup": "rustup",
   "app.managers.name.software_update": "Mise a jour logicielle",
-  "app.managers.name.app_store": "App Store"
+  "app.managers.name.app_store": "App Store",
+  "app.settings.alert.upgrade_all.dry_run_toggle": "Mode simulation (aucune modification)",
+  "app.settings.alert.upgrade_all.dry_run_result_title": "Résultat de la simulation",
+  "app.settings.alert.upgrade_all.dry_run_result_message": "Simulation terminée. Aucune tâche n’a été mise en file d’attente.\\n\\nActions planifiées :\\n{summary}"
 }

--- a/apps/macos-ui/Helm/Resources/locales/ja/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/ja/app.json
@@ -131,5 +131,8 @@
   "app.managers.name.mise": "mise",
   "app.managers.name.rustup": "rustup",
   "app.managers.name.software_update": "ソフトウェアアップデート",
-  "app.managers.name.app_store": "App Store"
+  "app.managers.name.app_store": "App Store",
+  "app.settings.alert.upgrade_all.dry_run_toggle": "ドライランモード（変更なし）",
+  "app.settings.alert.upgrade_all.dry_run_result_title": "ドライラン結果",
+  "app.settings.alert.upgrade_all.dry_run_result_message": "ドライランが完了しました。タスクはキューに追加されていません。\\n\\n計画されたアクション:\\n{summary}"
 }

--- a/apps/macos-ui/Helm/Resources/locales/pt-BR/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/pt-BR/app.json
@@ -131,5 +131,8 @@
   "app.managers.name.mise": "mise",
   "app.managers.name.rustup": "rustup",
   "app.managers.name.software_update": "Atualizacao de software",
-  "app.managers.name.app_store": "App Store"
+  "app.managers.name.app_store": "App Store",
+  "app.settings.alert.upgrade_all.dry_run_toggle": "Modo de simulação (sem alterações)",
+  "app.settings.alert.upgrade_all.dry_run_result_title": "Resultado da simulação",
+  "app.settings.alert.upgrade_all.dry_run_result_message": "Simulação concluída. Nenhuma tarefa foi enfileirada.\\n\\nAções planejadas:\\n{summary}"
 }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,7 +8,7 @@ It reflects reality, not intention.
 
 ## Version
 
-Current version: **0.12.0-beta.2**
+Current version: **0.12.0-beta.3**
 
 See:
 - CHANGELOG.md
@@ -108,7 +108,7 @@ Validation snapshot for `v0.11.0-beta.1` expansion:
 - Upgrade-all transparency now provides summary counts + top manager breakdown in confirmation flow
 - Upgrade-preview filtering/sorting logic now has dedicated macOS UI unit coverage (`HelmTests/UpgradePreviewPlannerTests`)
 - Dedicated upgrade preview UI surface is implemented in macOS Settings (execution-plan sections with manager breakdown)
-- No dry-run mode exposed in UI
+- Dry-run mode is exposed in the upgrade preview UI (simulation path with no task submission)
 - No self-update mechanism yet
 - Limited diagnostics UI
 - No CLI interface

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -22,10 +22,10 @@ Focus:
 - UI/UX redesign planning
 
 Current checkpoint:
-- `v0.12.0-beta.2` released (visual-overflow validation expansion)
+- `v0.12.0-beta.3` released (dedicated upgrade-preview UI surface)
 
 Next release target:
-- `v0.12.0-beta.3` (dedicated upgrade-preview UI surface)
+- `v0.12.0-beta.4` (dry-run support for upgrade preview flow)
 
 `v0.11.0-beta.2` stabilization work completed:
 
@@ -175,10 +175,11 @@ Completed:
 - Localized manager labels used in the Upgrade All breakdown output
 - Added focused unit tests for upgrade-preview filtering and breakdown ordering (`UpgradePreviewPlannerTests`)
 - Added a dedicated Upgrade Preview UI surface in macOS Settings with execution-plan sections and manager-level package breakdowns for both no-OS and with-OS modes
+- Added dry-run mode support in the upgrade-preview UI with explicit simulation results and no task submission
 
 Remaining:
 
-- Add dry-run support
+- None for Priority 4 at this checkpoint
 
 ---
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -2,7 +2,25 @@
 
 This checklist is required before creating a release tag on `main`.
 
-## v0.12.0-beta.3 (In Progress)
+## v0.12.0-beta.4 (In Progress)
+
+### Scope and Documentation
+- [x] `CHANGELOG.md` includes `0.12.0-beta.4` notes for dry-run support in upgrade preview flow.
+- [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect dry-run support completion for Priority 4.
+- [x] Locale files updated for new dry-run strings across shipped locales and resource mirrors.
+
+### Validation
+- [x] Locale integrity checks pass (`apps/macos-ui/scripts/check_locale_integrity.sh`).
+- [x] `HelmTests` pass (`xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme HelmTests -destination 'platform=macOS' -derivedDataPath /tmp/helmtests-deriveddata CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test`).
+
+### Branch and Tag
+- [ ] `dev` merged into `main` for release.
+- [ ] Create annotated tag from `main`:
+  - `git tag -a v0.12.0-beta.4 -m "Helm v0.12.0-beta.4"`
+- [ ] Push tag:
+  - `git push origin v0.12.0-beta.4`
+
+## v0.12.0-beta.3 (Completed)
 
 ### Scope and Documentation
 - [x] `CHANGELOG.md` includes `0.12.0-beta.3` notes for dedicated upgrade-preview UI delivery.
@@ -12,10 +30,10 @@ This checklist is required before creating a release tag on `main`.
 - [x] `HelmTests` pass (`xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme HelmTests -destination 'platform=macOS' -derivedDataPath /tmp/helmtests-deriveddata CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test`).
 
 ### Branch and Tag
-- [ ] `dev` merged into `main` for release.
-- [ ] Create annotated tag from `main`:
+- [x] `dev` merged into `main` for release.
+- [x] Create annotated tag from `main`:
   - `git tag -a v0.12.0-beta.3 -m "Helm v0.12.0-beta.3"`
-- [ ] Push tag:
+- [x] Push tag:
   - `git push origin v0.12.0-beta.3`
 
 ## v0.12.0-beta.2 (Completed)

--- a/locales/de/app.json
+++ b/locales/de/app.json
@@ -131,5 +131,8 @@
   "app.managers.name.mise": "mise",
   "app.managers.name.rustup": "rustup",
   "app.managers.name.software_update": "Softwareaktualisierung",
-  "app.managers.name.app_store": "App Store"
+  "app.managers.name.app_store": "App Store",
+  "app.settings.alert.upgrade_all.dry_run_toggle": "Trockenlaufmodus (keine Änderungen)",
+  "app.settings.alert.upgrade_all.dry_run_result_title": "Trockenlauf-Ergebnis",
+  "app.settings.alert.upgrade_all.dry_run_result_message": "Trockenlauf abgeschlossen. Es wurden keine Aufgaben eingereiht.\\n\\nGeplante Aktionen:\\n{summary}"
 }

--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -131,5 +131,8 @@
   "app.managers.name.mise": "mise",
   "app.managers.name.rustup": "rustup",
   "app.managers.name.software_update": "Software Update",
-  "app.managers.name.app_store": "App Store"
+  "app.managers.name.app_store": "App Store",
+  "app.settings.alert.upgrade_all.dry_run_toggle": "Dry Run Mode (no changes)",
+  "app.settings.alert.upgrade_all.dry_run_result_title": "Dry Run Result",
+  "app.settings.alert.upgrade_all.dry_run_result_message": "Dry run complete. No tasks were queued.\\n\\nPlanned actions:\\n{summary}"
 }

--- a/locales/es/app.json
+++ b/locales/es/app.json
@@ -131,5 +131,8 @@
   "app.managers.name.mise": "mise",
   "app.managers.name.rustup": "rustup",
   "app.managers.name.software_update": "Actualizacion de software",
-  "app.managers.name.app_store": "App Store"
+  "app.managers.name.app_store": "App Store",
+  "app.settings.alert.upgrade_all.dry_run_toggle": "Modo de simulación (sin cambios)",
+  "app.settings.alert.upgrade_all.dry_run_result_title": "Resultado de simulación",
+  "app.settings.alert.upgrade_all.dry_run_result_message": "Simulación completada. No se encolaron tareas.\\n\\nAcciones planificadas:\\n{summary}"
 }

--- a/locales/fr/app.json
+++ b/locales/fr/app.json
@@ -131,5 +131,8 @@
   "app.managers.name.mise": "mise",
   "app.managers.name.rustup": "rustup",
   "app.managers.name.software_update": "Mise a jour logicielle",
-  "app.managers.name.app_store": "App Store"
+  "app.managers.name.app_store": "App Store",
+  "app.settings.alert.upgrade_all.dry_run_toggle": "Mode simulation (aucune modification)",
+  "app.settings.alert.upgrade_all.dry_run_result_title": "Résultat de la simulation",
+  "app.settings.alert.upgrade_all.dry_run_result_message": "Simulation terminée. Aucune tâche n’a été mise en file d’attente.\\n\\nActions planifiées :\\n{summary}"
 }

--- a/locales/ja/app.json
+++ b/locales/ja/app.json
@@ -131,5 +131,8 @@
   "app.managers.name.mise": "mise",
   "app.managers.name.rustup": "rustup",
   "app.managers.name.software_update": "ソフトウェアアップデート",
-  "app.managers.name.app_store": "App Store"
+  "app.managers.name.app_store": "App Store",
+  "app.settings.alert.upgrade_all.dry_run_toggle": "ドライランモード（変更なし）",
+  "app.settings.alert.upgrade_all.dry_run_result_title": "ドライラン結果",
+  "app.settings.alert.upgrade_all.dry_run_result_message": "ドライランが完了しました。タスクはキューに追加されていません。\\n\\n計画されたアクション:\\n{summary}"
 }

--- a/locales/pt-BR/app.json
+++ b/locales/pt-BR/app.json
@@ -131,5 +131,8 @@
   "app.managers.name.mise": "mise",
   "app.managers.name.rustup": "rustup",
   "app.managers.name.software_update": "Atualizacao de software",
-  "app.managers.name.app_store": "App Store"
+  "app.managers.name.app_store": "App Store",
+  "app.settings.alert.upgrade_all.dry_run_toggle": "Modo de simulação (sem alterações)",
+  "app.settings.alert.upgrade_all.dry_run_result_title": "Resultado da simulação",
+  "app.settings.alert.upgrade_all.dry_run_result_message": "Simulação concluída. Nenhuma tarefa foi enfileirada.\\n\\nAções planejadas:\\n{summary}"
 }


### PR DESCRIPTION
Summary
- add dry-run mode to the Settings Upgrade Preview sheet via a localized toggle
- when dry-run mode is enabled, upgrade actions no longer queue tasks and instead show a localized dry-run result with planned actions summary
- add i18n keys for dry-run controls/results across en/es/de/fr/pt-BR/ja and mirror them into app resources
- update changelog/state/next-steps/release-checklist for v0.12.0-beta.4 scope

Validation
- apps/macos-ui/scripts/check_locale_integrity.sh
- xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme HelmTests -destination 'platform=macOS' -derivedDataPath /tmp/helmtests-deriveddata CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test

Notes
- i18n parity maintained between locales/* and apps/macos-ui/Helm/Resources/locales/*
