### PR TITLE
fix: re-sign app after xcodebuild to strip injected get-task-allow

### DIFF
--- a/.github/workflows/release-macos-dmg.yml
+++ b/.github/workflows/release-macos-dmg.yml
@@ -81,6 +81,34 @@ jobs:
             OTHER_CODE_SIGN_FLAGS="--timestamp" \
             build
 
+      - name: Re-sign with clean entitlements (strip Xcode-injected get-task-allow)
+        run: |
+          set -euo pipefail
+          APP_PATH="$PWD/build/DerivedData/Build/Products/Release/Helm.app"
+
+          # Xcode's Process Product Packaging phase injects get-task-allow from the
+          # resolved provisioning profile even in Manual signing mode when
+          # DEVELOPMENT_TEAM is set.  Bypass this by re-signing with codesign
+          # directly, which uses exactly the entitlements file specified and nothing
+          # else.  Must sign inside-out so the outer bundle seals the updated inner
+          # component signatures.
+
+          # 1. XPC service — inner bundle first
+          codesign --force \
+            --sign "Developer ID Application" \
+            --timestamp \
+            --options runtime \
+            --entitlements "apps/macos-ui/Helm/HelmServiceRelease.entitlements" \
+            "$APP_PATH/Contents/XPCServices/HelmService.xpc"
+
+          # 2. Main app bundle — last, seals everything inside
+          codesign --force \
+            --sign "Developer ID Application" \
+            --timestamp \
+            --options runtime \
+            --entitlements "apps/macos-ui/Helm/HelmRelease.entitlements" \
+            "$APP_PATH"
+
       - name: Verify signature, architecture, and notarization prerequisites
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Follow-up to PR #34. Hardened runtime and timestamp are now correct; `get-task-allow` is still being injected.

**Root cause (confirmed from CI output):** Xcode's *Process Product Packaging* phase merges entitlements from a resolved provisioning profile into the signed binary at build time, even in Manual signing mode, because `DEVELOPMENT_TEAM` is set. The injected profile (a wildcard or development profile matched on the runner) always includes `get-task-allow=true`. Our explicit `CODE_SIGN_ENTITLEMENTS` file is used as a base but the profile entitlements are merged on top.

**Fix:** Add a post-build re-signing step using `codesign` directly. Unlike Xcode's signing path, `codesign --force --sign ... --entitlements <file>` uses *exactly* the provided entitlements file with no injection from any profile. Steps are signed inside-out (XPC service first, then the outer app bundle) so the bundle seal covers the updated inner signatures.

## What changes

`.github/workflows/release-macos-dmg.yml` — new step between build and verify:
1. Re-sign `HelmService.xpc` with `HelmServiceRelease.entitlements` (empty — no `get-task-allow`, no sandbox)
2. Re-sign `Helm.app` with `HelmRelease.entitlements` (`app-sandbox` only, no `get-task-allow`)

Both retain `--options runtime` (hardened runtime) and `--timestamp`.

## Test plan

- [ ] Merge to dev → merge dev to main → move tag → re-run workflow
- [ ] Verify step should show no `get-task-allow` in either binary
- [ ] `notarytool` should return `Accepted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)