### PR TITLE
fix: suppress get-task-allow injection via CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO

### DIFF
--- a/.github/workflows/release-macos-dmg.yml
+++ b/.github/workflows/release-macos-dmg.yml
@@ -77,6 +77,7 @@ jobs:
             CODE_SIGN_STYLE=Manual \
             DEVELOPMENT_TEAM="$APP_TEAM_ID" \
             CODE_SIGN_IDENTITY="Developer ID Application" \
+            CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
             ENABLE_HARDENED_RUNTIME=YES \
             OTHER_CODE_SIGN_FLAGS="--timestamp" \
             build

--- a/apps/macos-ui/Helm.xcodeproj/project.pbxproj
+++ b/apps/macos-ui/Helm.xcodeproj/project.pbxproj
@@ -589,6 +589,7 @@
 				CODE_SIGN_ENTITLEMENTS = Helm/HelmServiceRelease.entitlements;
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
@@ -785,6 +786,7 @@
 				CODE_SIGN_ENTITLEMENTS = Helm/HelmRelease.entitlements;
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;


### PR DESCRIPTION
## What I reverted

Nothing needed reverting from `main`/`dev` — the post-build re-signing workaround (PR #36 / branch `agent/claude/fix-notarization-resign`) was **never merged**. It only existed on its own branch and has been superseded by this PR. PR #36 can be closed.

---

## What I found in pbxproj (Release, both targets, on current main)

| Setting | HelmService Release | Helm Release |
|---|---|---|
| `CODE_SIGN_STYLE` | `Manual` | `Manual` |
| `CODE_SIGN_IDENTITY` | `"-"` (base) / `"Developer ID Application"` (macosx\*) | same |
| `DEVELOPMENT_TEAM` | `""` (base) / `V73WPJR9M4` (macosx\*) | same |
| `CODE_SIGN_ENTITLEMENTS` | `Helm/HelmServiceRelease.entitlements` | `Helm/HelmRelease.entitlements` |
| `PROVISIONING_PROFILE_SPECIFIER` | `""` | `""` |
| `OTHER_CODE_SIGN_FLAGS` | `"--timestamp"` | `"--timestamp"` |
| `ENABLE_HARDENED_RUNTIME` | `YES` | `YES` |
| `CODE_SIGN_INJECT_BASE_ENTITLEMENTS` | ❌ missing | ❌ missing ← root cause |

---

## Root cause

Xcode's *Process Product Packaging* phase runs before `codesign` and writes a derived `.xcent` file. When `DEVELOPMENT_TEAM` is non-empty and `CODE_SIGN_INJECT_BASE_ENTITLEMENTS` is at its default (`YES`), Xcode injects `get-task-allow=true` into that derived file regardless of certificate type or `CODE_SIGN_STYLE`. The final `codesign` call signs exactly what the packaging phase prepared — which is why the binary was Developer-ID-signed and had hardened runtime + timestamp correct, but still carried `get-task-allow`.

---

## What I changed

**`apps/macos-ui/Helm.xcodeproj/project.pbxproj`** — 2 lines added  
- `CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;` in **HelmService Release** config  
- `CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;` in **Helm Release** config  

**`.github/workflows/release-macos-dmg.yml`** — 1 line added  
- `CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO` in the `xcodebuild` invocation (belt-and-suspenders; the project setting is authoritative, the CI override is insurance)

No entitlements files changed. No re-signing steps. No new build phases.

---

## How to verify (local)

After a Release build with Developer ID cert in keychain:
```bash
APP=build/DerivedData/Build/Products/Release/Helm.app

# 1. No get-task-allow in either binary
codesign -d --entitlements :- "$APP/Contents/MacOS/Helm"
codesign -d --entitlements :- "$APP/Contents/XPCServices/HelmService.xpc/Contents/MacOS/HelmService"
# Expected: neither output contains "get-task-allow"

# 2. Timestamp and hardened runtime present
codesign -dv --verbose=4 "$APP/Contents/MacOS/Helm" 2>&1 | grep -E "^Timestamp|^flags"
# Expected: "Timestamp=..." line present, "flags=0x10000(runtime)"
```

---

## CI workflow notes

The existing "Verify signature, architecture, and notarization prerequisites" step (added in PR #34) already:
- Prints `codesign -d --entitlements :-` for both binaries
- Prints `codesign -dv --verbose=4` for both binaries
- Fails the build if `get-task-allow` is detected pre-notarization
- Warns if hardened runtime flag is absent
- Prints `notarytool log` on failure and only staples on `Accepted`

No changes to diagnostic steps needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)