### PR TITLE
merge: fix notarization — suppress get-task-allow injection

### DIFF
--- a/.github/workflows/release-macos-dmg.yml
+++ b/.github/workflows/release-macos-dmg.yml
@@ -77,6 +77,7 @@ jobs:
             CODE_SIGN_STYLE=Manual \
             DEVELOPMENT_TEAM="$APP_TEAM_ID" \
             CODE_SIGN_IDENTITY="Developer ID Application" \
+            CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
             ENABLE_HARDENED_RUNTIME=YES \
             OTHER_CODE_SIGN_FLAGS="--timestamp" \
             build

--- a/apps/macos-ui/Helm.xcodeproj/project.pbxproj
+++ b/apps/macos-ui/Helm.xcodeproj/project.pbxproj
@@ -589,6 +589,7 @@
 				CODE_SIGN_ENTITLEMENTS = Helm/HelmServiceRelease.entitlements;
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
@@ -785,6 +786,7 @@
 				CODE_SIGN_ENTITLEMENTS = Helm/HelmRelease.entitlements;
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;


### PR DESCRIPTION
Merges dev into main to deliver the notarization fix for the `release-macos-dmg` workflow.

## What's included

**PR #37** (`ac9c2f6`) — `CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO` in both Release build configurations (Helm + HelmService) and in the CI `xcodebuild` invocation.

This is the only change relative to the previous `dev → main` merge (PR #35). No re-signing workarounds. No entitlements file changes.

## After merging

Move the `v0.13.0-beta.2` tag to the new main HEAD and re-run the `release-macos-dmg` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)