### PR TITLE
feat: add support & feedback entry points (rc.2)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: jasoncavinder
+patreon: jasoncavinder

--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ Helm is an independent project.
 
 If you find it useful, consider supporting development:
 
-- GitHub Sponsors (coming soon)
+- [GitHub Sponsors](https://github.com/sponsors/jasoncavinder)
+- [Patreon](https://patreon.com/jasoncavinder)
 - Early access and lifetime licenses (planned)
+
+You can also help by [reporting bugs](https://github.com/jasoncavinder/Helm/issues/new?template=bug_report.yml) or [requesting features](https://github.com/jasoncavinder/Helm/issues/new?template=feature_request.yml). In-app feedback entry points are available in Settings under "Support & Feedback".
 
 Your support helps fund continued development.
 

--- a/apps/macos-ui/Helm/AppDelegate.swift
+++ b/apps/macos-ui/Helm/AppDelegate.swift
@@ -354,6 +354,30 @@ private extension AppDelegate {
         settingsItem.submenu = settingsMenu
         menu.addItem(settingsItem)
 
+        let supportItem = NSMenuItem(
+            title: L10n.App.Settings.SupportFeedback.supportHelm.localized,
+            action: nil,
+            keyEquivalent: ""
+        )
+        let supportMenu = NSMenu()
+        let gitHubSponsorsItem = NSMenuItem(
+            title: L10n.App.Settings.SupportFeedback.gitHubSponsors.localized,
+            action: #selector(openGitHubSponsorsFromMenu),
+            keyEquivalent: ""
+        )
+        gitHubSponsorsItem.target = self
+        supportMenu.addItem(gitHubSponsorsItem)
+
+        let patreonItem = NSMenuItem(
+            title: L10n.App.Settings.SupportFeedback.patreon.localized,
+            action: #selector(openPatreonFromMenu),
+            keyEquivalent: ""
+        )
+        patreonItem.target = self
+        supportMenu.addItem(patreonItem)
+        supportItem.submenu = supportMenu
+        menu.addItem(supportItem)
+
         menu.addItem(.separator())
 
         let refreshItem = NSMenuItem(
@@ -427,6 +451,14 @@ private extension AppDelegate {
 
     @objc func quitFromMenu() {
         NSApplication.shared.terminate(nil)
+    }
+
+    @objc func openGitHubSponsorsFromMenu() {
+        HelmSupport.openURL(HelmSupport.gitHubSponsorsURL)
+    }
+
+    @objc func openPatreonFromMenu() {
+        HelmSupport.openURL(HelmSupport.patreonURL)
     }
 
     @objc func handleSystemAppearanceChanged() {

--- a/apps/macos-ui/Helm/Core/L10n+App.swift
+++ b/apps/macos-ui/Helm/Core/L10n+App.swift
@@ -230,6 +230,19 @@ extension L10n {
                     static let dryRunResultMessage = "app.settings.alert.upgrade_all.dry_run_result_message"
                 }
             }
+            struct SupportFeedback {
+                static let section = "app.settings.section.support_feedback"
+                static let supportHelm = "app.settings.support_feedback.support_helm"
+                static let reportBug = "app.settings.support_feedback.report_bug"
+                static let requestFeature = "app.settings.support_feedback.request_feature"
+                static let sendFeedback = "app.settings.support_feedback.send_feedback"
+                static let copyDiagnostics = "app.settings.support_feedback.copy_diagnostics"
+                static let includeDiagnostics = "app.settings.support_feedback.include_diagnostics"
+                static let copiedConfirmation = "app.settings.support_feedback.copied_confirmation"
+                static let diagnosticsCopiedHint = "app.settings.support_feedback.diagnostics_copied_hint"
+            static let gitHubSponsors = "app.settings.support_feedback.github_sponsors"
+            static let patreon = "app.settings.support_feedback.patreon"
+            }
         }
 
         struct Tasks {

--- a/apps/macos-ui/Helm/Resources/locales/de/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/de/app.json
@@ -276,5 +276,17 @@
   "app.walkthrough.control_center.step7.title": "Upgrade-Vorschau",
   "app.walkthrough.control_center.step7.description": "Sieh genau, was passieren wird, bevor du Upgrades ausführst.",
 
-  "app.settings.action.replay_walkthrough": "Rundgang wiederholen"
+  "app.settings.action.replay_walkthrough": "Rundgang wiederholen",
+
+  "app.settings.section.support_feedback": "Support & Feedback",
+  "app.settings.support_feedback.support_helm": "Helm unterstützen",
+  "app.settings.support_feedback.report_bug": "Fehler melden",
+  "app.settings.support_feedback.request_feature": "Funktion vorschlagen",
+  "app.settings.support_feedback.send_feedback": "Feedback senden",
+  "app.settings.support_feedback.copy_diagnostics": "Diagnose kopieren",
+  "app.settings.support_feedback.include_diagnostics": "Diagnose einschließen",
+  "app.settings.support_feedback.copied_confirmation": "Kopiert!",
+  "app.settings.support_feedback.diagnostics_copied_hint": "Diagnose in die Zwischenablage kopiert",
+  "app.settings.support_feedback.github_sponsors": "GitHub Sponsors",
+  "app.settings.support_feedback.patreon": "Patreon"
 }

--- a/apps/macos-ui/Helm/Resources/locales/en/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/en/app.json
@@ -276,5 +276,17 @@
   "app.walkthrough.control_center.step7.title": "Upgrade Preview",
   "app.walkthrough.control_center.step7.description": "Preview exactly what will happen before running upgrades.",
 
-  "app.settings.action.replay_walkthrough": "Replay Walkthrough"
+  "app.settings.action.replay_walkthrough": "Replay Walkthrough",
+
+  "app.settings.section.support_feedback": "Support & Feedback",
+  "app.settings.support_feedback.support_helm": "Support Helm",
+  "app.settings.support_feedback.report_bug": "Report a Bug",
+  "app.settings.support_feedback.request_feature": "Request a Feature",
+  "app.settings.support_feedback.send_feedback": "Send Feedback",
+  "app.settings.support_feedback.copy_diagnostics": "Copy Diagnostics",
+  "app.settings.support_feedback.include_diagnostics": "Include Diagnostics",
+  "app.settings.support_feedback.copied_confirmation": "Copied!",
+  "app.settings.support_feedback.diagnostics_copied_hint": "Diagnostics copied to clipboard",
+  "app.settings.support_feedback.github_sponsors": "GitHub Sponsors",
+  "app.settings.support_feedback.patreon": "Patreon"
 }

--- a/apps/macos-ui/Helm/Resources/locales/es/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/es/app.json
@@ -276,5 +276,17 @@
   "app.walkthrough.control_center.step7.title": "Vista previa de actualización",
   "app.walkthrough.control_center.step7.description": "Previsualiza exactamente lo que ocurrirá antes de ejecutar actualizaciones.",
 
-  "app.settings.action.replay_walkthrough": "Repetir recorrido"
+  "app.settings.action.replay_walkthrough": "Repetir recorrido",
+
+  "app.settings.section.support_feedback": "Soporte y comentarios",
+  "app.settings.support_feedback.support_helm": "Apoyar Helm",
+  "app.settings.support_feedback.report_bug": "Reportar un error",
+  "app.settings.support_feedback.request_feature": "Solicitar función",
+  "app.settings.support_feedback.send_feedback": "Enviar comentarios",
+  "app.settings.support_feedback.copy_diagnostics": "Copiar diagnósticos",
+  "app.settings.support_feedback.include_diagnostics": "Incluir diagnósticos",
+  "app.settings.support_feedback.copied_confirmation": "¡Copiado!",
+  "app.settings.support_feedback.diagnostics_copied_hint": "Diagnósticos copiados al portapapeles",
+  "app.settings.support_feedback.github_sponsors": "GitHub Sponsors",
+  "app.settings.support_feedback.patreon": "Patreon"
 }

--- a/apps/macos-ui/Helm/Resources/locales/fr/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/fr/app.json
@@ -276,5 +276,17 @@
   "app.walkthrough.control_center.step7.title": "Aperçu des mises à niveau",
   "app.walkthrough.control_center.step7.description": "Prévisualisez exactement ce qui se passera avant d'exécuter les mises à niveau.",
 
-  "app.settings.action.replay_walkthrough": "Rejouer la visite guidée"
+  "app.settings.action.replay_walkthrough": "Rejouer la visite guidée",
+
+  "app.settings.section.support_feedback": "Support et retours",
+  "app.settings.support_feedback.support_helm": "Soutenir Helm",
+  "app.settings.support_feedback.report_bug": "Signaler un bug",
+  "app.settings.support_feedback.request_feature": "Suggérer une fonction",
+  "app.settings.support_feedback.send_feedback": "Envoyer un retour",
+  "app.settings.support_feedback.copy_diagnostics": "Copier les diagnostics",
+  "app.settings.support_feedback.include_diagnostics": "Inclure les diagnostics",
+  "app.settings.support_feedback.copied_confirmation": "Copié !",
+  "app.settings.support_feedback.diagnostics_copied_hint": "Diagnostics copiés dans le presse-papiers",
+  "app.settings.support_feedback.github_sponsors": "GitHub Sponsors",
+  "app.settings.support_feedback.patreon": "Patreon"
 }

--- a/apps/macos-ui/Helm/Resources/locales/ja/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/ja/app.json
@@ -276,5 +276,17 @@
   "app.walkthrough.control_center.step7.title": "アップグレードプレビュー",
   "app.walkthrough.control_center.step7.description": "アップグレードを実行する前に、何が起こるかを正確にプレビューできます。",
 
-  "app.settings.action.replay_walkthrough": "ウォークスルーを再生"
+  "app.settings.action.replay_walkthrough": "ウォークスルーを再生",
+
+  "app.settings.section.support_feedback": "サポートとフィードバック",
+  "app.settings.support_feedback.support_helm": "Helmを支援",
+  "app.settings.support_feedback.report_bug": "バグを報告",
+  "app.settings.support_feedback.request_feature": "機能をリクエスト",
+  "app.settings.support_feedback.send_feedback": "フィードバックを送信",
+  "app.settings.support_feedback.copy_diagnostics": "診断情報をコピー",
+  "app.settings.support_feedback.include_diagnostics": "診断情報を含める",
+  "app.settings.support_feedback.copied_confirmation": "コピーしました",
+  "app.settings.support_feedback.diagnostics_copied_hint": "診断情報をクリップボードにコピーしました",
+  "app.settings.support_feedback.github_sponsors": "GitHub Sponsors",
+  "app.settings.support_feedback.patreon": "Patreon"
 }

--- a/apps/macos-ui/Helm/Resources/locales/pt-BR/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/pt-BR/app.json
@@ -276,5 +276,17 @@
   "app.walkthrough.control_center.step7.title": "Prévia de atualização",
   "app.walkthrough.control_center.step7.description": "Visualize exatamente o que acontecerá antes de executar atualizações.",
 
-  "app.settings.action.replay_walkthrough": "Repetir tour guiado"
+  "app.settings.action.replay_walkthrough": "Repetir tour guiado",
+
+  "app.settings.section.support_feedback": "Suporte e feedback",
+  "app.settings.support_feedback.support_helm": "Apoiar Helm",
+  "app.settings.support_feedback.report_bug": "Reportar um bug",
+  "app.settings.support_feedback.request_feature": "Solicitar recurso",
+  "app.settings.support_feedback.send_feedback": "Enviar feedback",
+  "app.settings.support_feedback.copy_diagnostics": "Copiar diagnósticos",
+  "app.settings.support_feedback.include_diagnostics": "Incluir diagnósticos",
+  "app.settings.support_feedback.copied_confirmation": "Copiado!",
+  "app.settings.support_feedback.diagnostics_copied_hint": "Diagnósticos copiados para a área de transferência",
+  "app.settings.support_feedback.github_sponsors": "GitHub Sponsors",
+  "app.settings.support_feedback.patreon": "Patreon"
 }

--- a/apps/macos-ui/Helm/Views/SettingsPopoverView.swift
+++ b/apps/macos-ui/Helm/Views/SettingsPopoverView.swift
@@ -10,6 +10,8 @@ struct SettingsSectionView: View {
     @State private var checkFrequency = 60
     @State private var showResetConfirmation = false
     @State private var isResetting = false
+    @State private var includeDiagnostics = false
+    @State private var showCopiedConfirmation = false
 
     private var selectedFrequencyLabel: String {
         switch checkFrequency {
@@ -29,6 +31,17 @@ struct SettingsSectionView: View {
             return AnyShapeStyle(.thinMaterial)
         }
         return AnyShapeStyle(Color.white.opacity(0.92))
+    }
+
+    private func showCopiedBriefly() {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            showCopiedConfirmation = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                showCopiedConfirmation = false
+            }
+        }
     }
 
     var body: some View {
@@ -147,6 +160,79 @@ struct SettingsSectionView: View {
                             walkthrough.resetWalkthroughs()
                             walkthrough.startPopoverWalkthrough()
                         }
+                    }
+                }
+
+                SettingsCard(title: L10n.App.Settings.SupportFeedback.section.localized, icon: "heart.fill", fill: cardFill) {
+                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
+                        SettingsActionButton(
+                            title: L10n.App.Settings.SupportFeedback.supportHelm.localized,
+                            badges: [],
+                            isProminent: false,
+                            useSystemStyle: true
+                        ) {
+                            HelmSupport.openURL(HelmSupport.gitHubSponsorsURL)
+                        }
+
+                        SettingsActionButton(
+                            title: L10n.App.Settings.SupportFeedback.sendFeedback.localized,
+                            badges: [],
+                            isProminent: false,
+                            useSystemStyle: true
+                        ) {
+                            HelmSupport.emailFeedback()
+                        }
+
+                        SettingsActionButton(
+                            title: L10n.App.Settings.SupportFeedback.reportBug.localized,
+                            badges: [],
+                            isProminent: false,
+                            useSystemStyle: true
+                        ) {
+                            HelmSupport.reportBug(includeDiagnostics: includeDiagnostics)
+                            if includeDiagnostics {
+                                showCopiedBriefly()
+                            }
+                        }
+
+                        SettingsActionButton(
+                            title: L10n.App.Settings.SupportFeedback.requestFeature.localized,
+                            badges: [],
+                            isProminent: false,
+                            useSystemStyle: true
+                        ) {
+                            HelmSupport.requestFeature(includeDiagnostics: includeDiagnostics)
+                            if includeDiagnostics {
+                                showCopiedBriefly()
+                            }
+                        }
+
+                        SettingsActionButton(
+                            title: L10n.App.Settings.SupportFeedback.copyDiagnostics.localized,
+                            badges: [],
+                            isProminent: false,
+                            useSystemStyle: true
+                        ) {
+                            HelmSupport.copyDiagnosticsToClipboard()
+                            showCopiedBriefly()
+                        }
+                    }
+
+                    Divider()
+
+                    Toggle(L10n.App.Settings.SupportFeedback.includeDiagnostics.localized, isOn: $includeDiagnostics)
+                        .toggleStyle(.switch)
+                        .font(.subheadline)
+
+                    if showCopiedConfirmation {
+                        HStack(spacing: 4) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                            Text(L10n.App.Settings.SupportFeedback.copiedConfirmation.localized)
+                                .foregroundStyle(.secondary)
+                        }
+                        .font(.caption)
+                        .transition(.opacity.combined(with: .scale))
                     }
                 }
             }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -186,6 +186,22 @@ Based on the full codebase audit conducted on 2026-02-17 and subsequent beta.3 r
 
 ---
 
+## v0.13.0-rc.2 Status
+
+### Support & Feedback Entry Points
+- New "Support & Feedback" card added to Settings surface with 5 actions:
+  - Support Helm (opens GitHub Sponsors)
+  - Report a Bug (opens GitHub issue template with optional diagnostics copy)
+  - Request a Feature (opens GitHub issue template with optional diagnostics copy)
+  - Send Feedback (opens mailto: with structured feedback form)
+  - Copy Diagnostics (copies system info to clipboard with transient confirmation)
+- "Include Diagnostics" toggle: when enabled, Report a Bug and Request a Feature copy diagnostics to clipboard before opening the issue template
+- All 9 new L10n keys translated across all 6 locales (en, es, de, fr, pt-BR, ja)
+- `.github/FUNDING.yml` created for GitHub Sponsors integration
+- README.md updated with working sponsor and issue template links
+
+---
+
 ## UI Redesign Artifacts (Integrated Baseline)
 
 - A complete redesign concept package now exists under `docs/ui/`:

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -23,6 +23,7 @@ Focus:
 - Validation and hardening
 
 Current checkpoint:
+- `v0.13.0-rc.2` released (support & feedback entry points, diagnostics copy, GitHub Sponsors integration)
 - `v0.13.0-rc.1` released (inspector sidebar, upgrade reliability, status menu, documentation)
 - Full codebase audit completed 2026-02-17 (Rust core, SwiftUI UI, XPC, localization, CI/CD)
 
@@ -230,6 +231,35 @@ Delivered:
 
 ---
 
+## v0.13.0-rc.2 — Support & Feedback Entry Points (Completed)
+
+### Support & Feedback Card (Completed)
+
+Delivered:
+
+- New "Support & Feedback" SettingsCard in control-center Settings surface
+- 5 action buttons: Support Helm, Send Feedback, Report a Bug, Request a Feature, Copy Diagnostics
+- "Include Diagnostics" toggle (default OFF): copies diagnostics to clipboard before opening GitHub issue template
+- Transient "Copied!" confirmation with animated opacity transition
+- `HelmSupport` updated with template-specific URLs (`reportBug`, `requestFeature` methods)
+
+### Localization (Completed)
+
+Delivered:
+
+- 9 new L10n keys (`app.settings.support_feedback.*`) added to all 6 locales (en, es, de, fr, pt-BR, ja)
+- Canonical and mirror locale files synchronized
+
+### GitHub & Documentation (Completed)
+
+Delivered:
+
+- `.github/FUNDING.yml` created for GitHub Sponsors button
+- README.md updated with working sponsor link and issue template links
+- CURRENT_STATE.md, NEXT_STEPS.md updated for rc.2
+
+---
+
 ## Completed Priorities (Pre-0.13.x)
 
 ### Priority 1 — Core Language Managers (Completed)
@@ -336,6 +366,7 @@ The 0.13.x milestone beta and rc releases are complete:
 - **beta.5**: Architecture cleanup (UI purity fixes, legacy removal, XPC robustness, keyboard traversal) — **completed**
 - **beta.6**: Validation + hardening + documentation (tracing spans, unit tests, FFI docs, INTERFACES.md, validation report, usability test plan) — **completed**
 - **rc.1**: Inspector sidebar, upgrade reliability (post-upgrade validation on all 11 adapters), status menu, documentation — **completed**
+- **rc.2**: Support & feedback entry points (GitHub Sponsors, bug report, feature request, email feedback, copy diagnostics), FUNDING.yml — **completed**
 
 Remaining for 0.13.0 stable: execute the validation sweep and usability test plan, resolve any findings, and cut the stable release.
 

--- a/locales/de/app.json
+++ b/locales/de/app.json
@@ -276,5 +276,17 @@
   "app.walkthrough.control_center.step7.title": "Upgrade-Vorschau",
   "app.walkthrough.control_center.step7.description": "Sieh genau, was passieren wird, bevor du Upgrades ausführst.",
 
-  "app.settings.action.replay_walkthrough": "Rundgang wiederholen"
+  "app.settings.action.replay_walkthrough": "Rundgang wiederholen",
+
+  "app.settings.section.support_feedback": "Support & Feedback",
+  "app.settings.support_feedback.support_helm": "Helm unterstützen",
+  "app.settings.support_feedback.report_bug": "Fehler melden",
+  "app.settings.support_feedback.request_feature": "Funktion vorschlagen",
+  "app.settings.support_feedback.send_feedback": "Feedback senden",
+  "app.settings.support_feedback.copy_diagnostics": "Diagnose kopieren",
+  "app.settings.support_feedback.include_diagnostics": "Diagnose einschließen",
+  "app.settings.support_feedback.copied_confirmation": "Kopiert!",
+  "app.settings.support_feedback.diagnostics_copied_hint": "Diagnose in die Zwischenablage kopiert",
+  "app.settings.support_feedback.github_sponsors": "GitHub Sponsors",
+  "app.settings.support_feedback.patreon": "Patreon"
 }

--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -276,5 +276,17 @@
   "app.walkthrough.control_center.step7.title": "Upgrade Preview",
   "app.walkthrough.control_center.step7.description": "Preview exactly what will happen before running upgrades.",
 
-  "app.settings.action.replay_walkthrough": "Replay Walkthrough"
+  "app.settings.action.replay_walkthrough": "Replay Walkthrough",
+
+  "app.settings.section.support_feedback": "Support & Feedback",
+  "app.settings.support_feedback.support_helm": "Support Helm",
+  "app.settings.support_feedback.report_bug": "Report a Bug",
+  "app.settings.support_feedback.request_feature": "Request a Feature",
+  "app.settings.support_feedback.send_feedback": "Send Feedback",
+  "app.settings.support_feedback.copy_diagnostics": "Copy Diagnostics",
+  "app.settings.support_feedback.include_diagnostics": "Include Diagnostics",
+  "app.settings.support_feedback.copied_confirmation": "Copied!",
+  "app.settings.support_feedback.diagnostics_copied_hint": "Diagnostics copied to clipboard",
+  "app.settings.support_feedback.github_sponsors": "GitHub Sponsors",
+  "app.settings.support_feedback.patreon": "Patreon"
 }

--- a/locales/es/app.json
+++ b/locales/es/app.json
@@ -276,5 +276,17 @@
   "app.walkthrough.control_center.step7.title": "Vista previa de actualización",
   "app.walkthrough.control_center.step7.description": "Previsualiza exactamente lo que ocurrirá antes de ejecutar actualizaciones.",
 
-  "app.settings.action.replay_walkthrough": "Repetir recorrido"
+  "app.settings.action.replay_walkthrough": "Repetir recorrido",
+
+  "app.settings.section.support_feedback": "Soporte y comentarios",
+  "app.settings.support_feedback.support_helm": "Apoyar Helm",
+  "app.settings.support_feedback.report_bug": "Reportar un error",
+  "app.settings.support_feedback.request_feature": "Solicitar función",
+  "app.settings.support_feedback.send_feedback": "Enviar comentarios",
+  "app.settings.support_feedback.copy_diagnostics": "Copiar diagnósticos",
+  "app.settings.support_feedback.include_diagnostics": "Incluir diagnósticos",
+  "app.settings.support_feedback.copied_confirmation": "¡Copiado!",
+  "app.settings.support_feedback.diagnostics_copied_hint": "Diagnósticos copiados al portapapeles",
+  "app.settings.support_feedback.github_sponsors": "GitHub Sponsors",
+  "app.settings.support_feedback.patreon": "Patreon"
 }

--- a/locales/fr/app.json
+++ b/locales/fr/app.json
@@ -276,5 +276,17 @@
   "app.walkthrough.control_center.step7.title": "Aperçu des mises à niveau",
   "app.walkthrough.control_center.step7.description": "Prévisualisez exactement ce qui se passera avant d'exécuter les mises à niveau.",
 
-  "app.settings.action.replay_walkthrough": "Rejouer la visite guidée"
+  "app.settings.action.replay_walkthrough": "Rejouer la visite guidée",
+
+  "app.settings.section.support_feedback": "Support et retours",
+  "app.settings.support_feedback.support_helm": "Soutenir Helm",
+  "app.settings.support_feedback.report_bug": "Signaler un bug",
+  "app.settings.support_feedback.request_feature": "Suggérer une fonction",
+  "app.settings.support_feedback.send_feedback": "Envoyer un retour",
+  "app.settings.support_feedback.copy_diagnostics": "Copier les diagnostics",
+  "app.settings.support_feedback.include_diagnostics": "Inclure les diagnostics",
+  "app.settings.support_feedback.copied_confirmation": "Copié !",
+  "app.settings.support_feedback.diagnostics_copied_hint": "Diagnostics copiés dans le presse-papiers",
+  "app.settings.support_feedback.github_sponsors": "GitHub Sponsors",
+  "app.settings.support_feedback.patreon": "Patreon"
 }

--- a/locales/ja/app.json
+++ b/locales/ja/app.json
@@ -276,5 +276,17 @@
   "app.walkthrough.control_center.step7.title": "アップグレードプレビュー",
   "app.walkthrough.control_center.step7.description": "アップグレードを実行する前に、何が起こるかを正確にプレビューできます。",
 
-  "app.settings.action.replay_walkthrough": "ウォークスルーを再生"
+  "app.settings.action.replay_walkthrough": "ウォークスルーを再生",
+
+  "app.settings.section.support_feedback": "サポートとフィードバック",
+  "app.settings.support_feedback.support_helm": "Helmを支援",
+  "app.settings.support_feedback.report_bug": "バグを報告",
+  "app.settings.support_feedback.request_feature": "機能をリクエスト",
+  "app.settings.support_feedback.send_feedback": "フィードバックを送信",
+  "app.settings.support_feedback.copy_diagnostics": "診断情報をコピー",
+  "app.settings.support_feedback.include_diagnostics": "診断情報を含める",
+  "app.settings.support_feedback.copied_confirmation": "コピーしました",
+  "app.settings.support_feedback.diagnostics_copied_hint": "診断情報をクリップボードにコピーしました",
+  "app.settings.support_feedback.github_sponsors": "GitHub Sponsors",
+  "app.settings.support_feedback.patreon": "Patreon"
 }

--- a/locales/pt-BR/app.json
+++ b/locales/pt-BR/app.json
@@ -276,5 +276,17 @@
   "app.walkthrough.control_center.step7.title": "Prévia de atualização",
   "app.walkthrough.control_center.step7.description": "Visualize exatamente o que acontecerá antes de executar atualizações.",
 
-  "app.settings.action.replay_walkthrough": "Repetir tour guiado"
+  "app.settings.action.replay_walkthrough": "Repetir tour guiado",
+
+  "app.settings.section.support_feedback": "Suporte e feedback",
+  "app.settings.support_feedback.support_helm": "Apoiar Helm",
+  "app.settings.support_feedback.report_bug": "Reportar um bug",
+  "app.settings.support_feedback.request_feature": "Solicitar recurso",
+  "app.settings.support_feedback.send_feedback": "Enviar feedback",
+  "app.settings.support_feedback.copy_diagnostics": "Copiar diagnósticos",
+  "app.settings.support_feedback.include_diagnostics": "Incluir diagnósticos",
+  "app.settings.support_feedback.copied_confirmation": "Copiado!",
+  "app.settings.support_feedback.diagnostics_copied_hint": "Diagnósticos copiados para a área de transferência",
+  "app.settings.support_feedback.github_sponsors": "GitHub Sponsors",
+  "app.settings.support_feedback.patreon": "Patreon"
 }


### PR DESCRIPTION
## Summary

- Adds a **Support & Feedback** card to the Settings surface with 5 action buttons: Support Helm, Send Feedback, Report a Bug, Request a Feature, Copy Diagnostics
- Adds **Include Diagnostics** toggle (default OFF) that copies diagnostics to clipboard before opening GitHub issue templates
- Adds **Support Helm** submenu to the right-click status menu with GitHub Sponsors and Patreon links
- Creates `.github/FUNDING.yml` for GitHub Sponsors + Patreon integration
- Updates README with working sponsor links and issue template links
- 11 new L10n keys translated across all 6 locales (en, es, de, fr, pt-BR, ja)
- Adds `import AppKit` to `HelmCore+Settings.swift` to fix `NSWorkspace`/`NSPasteboard` scope for the pre-existing `HelmSupport` struct

## Test plan

- [ ] Open Control Center → Settings → verify "Support & Feedback" card renders with 5 buttons and toggle
- [ ] Click "Support Helm" → opens GitHub Sponsors page
- [ ] Click "Send Feedback" → opens email client with structured feedback form
- [ ] Click "Report a Bug" → opens bug report template on GitHub
- [ ] Click "Request a Feature" → opens feature request template on GitHub
- [ ] Toggle "Include Diagnostics" ON → click Report/Request → verify diagnostics copied to clipboard and "Copied!" confirmation appears
- [ ] Click "Copy Diagnostics" → verify text copied to clipboard and "Copied!" confirmation appears
- [ ] Right-click status bar icon → verify "Support Helm" submenu with "GitHub Sponsors" and "Patreon" items
- [ ] Click each submenu item → verify correct URL opens
- [ ] Switch locale (e.g. es, ja) → verify all new labels render correctly
- [ ] Verify locale parity: `diff -ru locales/ apps/macos-ui/Helm/Resources/locales/` shows only `_meta`

🤖 Generated with [Claude Code](https://claude.com/claude-code)