### PR TITLE
docs: mark v0.14.0 release completion

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -391,11 +391,11 @@ Based on the full codebase audit conducted on 2026-02-17 and subsequent beta.3 r
 - Fleet lifecycle is documented as separate from consumer lifecycle.
 - These are roadmap/planning decisions only; channel-specific implementation work is still pending future milestones.
 
-### Remaining for Final Release Execution
-- Execute branch/release flow from `docs/RELEASE_CHECKLIST.md`:
-  - monitor/resolve CI on PR `#60` (`dev` -> `main`)
-  - merge `dev` into `main`
-  - create/push `v0.14.0` annotated tag
+### Final Release Execution (Completed)
+- Completed branch/release flow from `docs/RELEASE_CHECKLIST.md`:
+  - merged release finalization branch into `dev`
+  - merged `dev` into `main` via PR `#60` after CI completion
+  - created/pushed `v0.14.0` annotated tag
 
 ---
 
@@ -488,4 +488,4 @@ Helm is a **functional control plane for 28 implemented managers** with:
 
 The core architecture is in place. The Rust core passed a full audit with no critical issues.
 
-0.13.x and 0.14.x stable checkpoints are complete in-repo, including version and docs alignment. Remaining release execution is CI completion on `dev` -> `main`, final main merge, and `v0.14.0` tag cut, then 0.15.x delivery.
+0.13.x and 0.14.x stable checkpoints are complete, with `v0.14.0` now merged to `main` and tagged. Next delivery focus is 0.15.x.

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -18,7 +18,7 @@ Focus:
 - 0.15.x upgrade preview and execution transparency
 
 Current checkpoint:
-- `v0.14.0` stable release alignment completed (manager rollout + docs/version alignment)
+- `v0.14.0` released (merged to `main`, tagged, manager rollout + docs/version alignment complete)
 - `v0.13.0` stable released (website updates, documentation alignment, version bump)
 - `v0.13.0-rc.2` released (support & feedback entry points, diagnostics copy, GitHub Sponsors integration)
 - `v0.13.0-rc.1` released (inspector sidebar, upgrade reliability, status menu, documentation)
@@ -430,7 +430,7 @@ Delivered:
 
 ---
 
-## v0.14.0 — Stable Release Cut (In Progress)
+## v0.14.0 — Stable Release Cut (Completed)
 
 ### Delivered
 
@@ -447,14 +447,14 @@ Delivered:
   - consumer vs fleet lifecycle separation
   - roadmap phases for Sparkle, MAS, Setapp, Fleet, PKG/MDM, and offline licensing
 
-### Next Up (Release Execution)
+### Release Execution (Completed)
 
 - Branch/PR execution:
   - ✅ merge release finalization branch into `dev`
   - ✅ open PR from `dev` to `main` and run CI checks (`#60`)
 - Release finalization:
-  - merge `dev` into `main`
-  - create/push annotated tag `v0.14.0`
+  - ✅ merge `dev` into `main` (via `#60`)
+  - ✅ create/push annotated tag `v0.14.0`
 
 ---
 
@@ -567,4 +567,4 @@ Implement:
 - Manager capability sweep artifact is now in place for 0.14 release prep (`docs/validation/v0.14.0-alpha.5-manager-capability-sweep.md`).
 - 0.14 stable release alignment for `v0.14.0` is complete (README/website + version artifacts).
 - Distribution/licensing future-state planning documentation is aligned for 0.14 release notes and roadmap planning (no implementation yet).
-- Remaining slice is CI completion on PR `#60`, final merge/tag execution for `v0.14.0`, then 0.15.x delivery.
+- 0.14 release execution is complete on `main` with tag `v0.14.0`; next delivery slice is 0.15.x.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -2,7 +2,7 @@
 
 This checklist is required before creating a release tag on `main`.
 
-## v0.14.0 (In Progress)
+## v0.14.0 (Completed)
 
 ### Scope and Documentation
 - [x] 0.14 manager delivery slices completed through `v0.14.0-alpha.5` (container/VM, detection-only, security/firmware, optional managers, Homebrew cask status).
@@ -26,10 +26,10 @@ This checklist is required before creating a release tag on `main`.
 
 ### Branch and Tag
 - [x] Release finalization branch merged to `dev`.
-- [x] PR opened from `dev` to `main` for `v0.14.0` and CI checks running (`#60`).
-- [ ] `dev` merged into `main` for release.
-- [ ] Create annotated tag: `git tag -a v0.14.0 -m "Helm v0.14.0"`
-- [ ] Push tag: `git push origin v0.14.0`
+- [x] PR opened from `dev` to `main` for `v0.14.0` and CI checks completed (`#60`).
+- [x] `dev` merged into `main` for release (via `#60`).
+- [x] Create annotated tag: `git tag -a v0.14.0 -m "Helm v0.14.0"`
+- [x] Push tag: `git push origin v0.14.0`
 
 ## v0.13.0-rc.1 (In Progress)
 


### PR DESCRIPTION
## Summary\n- mark v0.14.0 release execution complete in CURRENT_STATE, NEXT_STEPS, and RELEASE_CHECKLIST\n- record that PR #60 merged to main and tag `v0.14.0` was created/pushed\n- align docs to post-release reality with 0.15.x as active delivery focus