### PR TITLE
chore(deps): ship devalue 5.6.3 bump

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2524,9 +2524,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
-      "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.3.tgz",
+      "integrity": "sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==",
       "license": "MIT"
     },
     "node_modules/devlop": {


### PR DESCRIPTION
## Summary
- ship dependency bump for `devalue` from `5.6.2` to `5.6.3` in `web/package-lock.json`
- merge of PR #62 from `chore/deps-devalue-5.6.3` into `dev`

## Validation
- `ASTRO_TELEMETRY_DISABLED=1 npm --prefix web run build`
- CI will run on this `dev -> main` PR path
