### PR TITLE
fix: harden available package cache and summary enrichment

### DIFF
--- a/core/rust/crates/helm-core/tests/sqlite_store_skeleton.rs
+++ b/core/rust/crates/helm-core/tests/sqlite_store_skeleton.rs
@@ -569,6 +569,61 @@ fn upsert_and_query_search_cache_roundtrip() {
 }
 
 #[test]
+fn search_cache_keeps_single_package_entry_and_preserves_summary() {
+    let path = test_db_path("search-preserve-summary");
+    let store = SqliteStore::new(&path);
+    store.migrate_to_latest().unwrap();
+
+    let now = SystemTime::now();
+    let first = CachedSearchResult {
+        result: PackageCandidate {
+            package: PackageRef {
+                manager: ManagerId::HomebrewFormula,
+                name: "ripgrep".to_string(),
+            },
+            version: Some("14.1.0".to_string()),
+            summary: Some("line-oriented search tool".to_string()),
+        },
+        source_manager: ManagerId::HomebrewFormula,
+        originating_query: "rip".to_string(),
+        cached_at: now,
+    };
+    store.upsert_search_results(&[first]).unwrap();
+
+    let second = CachedSearchResult {
+        result: PackageCandidate {
+            package: PackageRef {
+                manager: ManagerId::HomebrewFormula,
+                name: "ripgrep".to_string(),
+            },
+            version: None,
+            summary: None,
+        },
+        source_manager: ManagerId::HomebrewFormula,
+        originating_query: "rg".to_string(),
+        cached_at: now + Duration::from_secs(5),
+    };
+    store.upsert_search_results(&[second]).unwrap();
+
+    let all = store.query_local("", 10).unwrap();
+    assert_eq!(
+        all.len(),
+        1,
+        "package cache should deduplicate by manager/name"
+    );
+    assert_eq!(all[0].result.package.name, "ripgrep");
+    assert_eq!(all[0].result.version.as_deref(), Some("14.1.0"));
+    assert_eq!(
+        all[0].result.summary.as_deref(),
+        Some("line-oriented search tool"),
+        "summary should be preserved when newer response omits it"
+    );
+    assert_eq!(all[0].originating_query, "rg");
+
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
 fn create_update_and_list_recent_tasks_roundtrip() {
     let path = test_db_path("tasks-roundtrip");
     let store = SqliteStore::new(&path);

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -15,6 +15,7 @@ See:
 
 Active milestone:
 - 0.15.x — Upgrade Preview & Execution Transparency (planning)
+- 0.14.1 — Patch-track fix slices in review branches off `dev`
 
 ---
 
@@ -98,6 +99,18 @@ Validation snapshot for `v0.11.0-beta.1` expansion:
 - XPC service: stable (code-signing validation, graceful reconnection with exponential backoff, timeout enforcement on all calls)
 - FFI boundary: functional (poisoned-lock recovery, JSON interchange, thread-safe static state, lifecycle documented in module-level docs)
 - UI: feature-complete for current scope; VoiceOver accessibility labels, semantic grouping, and state-change announcements implemented; HelmCore decomposed into 5 files; UI layer purity cleanup completed (business logic extracted from views to HelmCore/ManagerInfo); inspector sidebar with task/package/manager detail views; keyboard Tab traversal still pending (macOS SwiftUI limitation)
+
+---
+
+## v0.14.1 Patch-Track Status (In Progress)
+
+Completed in cache/persistence slice branch:
+
+- Search-cache persistence now deduplicates records by `(manager, package)` so repeated queries do not accumulate duplicate available-package rows
+- Search-cache metadata persistence preserves existing non-empty version/summary when newer remote responses omit those fields
+- Control-center available package cache refresh now deduplicates entries and keeps non-empty summaries during merges
+- Package aggregation (`allKnownPackages`) now enriches installed/outdated package rows with cached summaries when available
+- Package filtering now includes summary text and merges remote-search summary/latest metadata into local rows for fresher inspector/detail context
 
 ---
 

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -19,6 +19,7 @@ Focus:
 
 Current checkpoint:
 - `v0.14.0` released (merged to `main`, tagged, manager rollout + docs/version alignment complete)
+- `v0.14.1` patch-track started (pre-merge fix slices being implemented off `dev` for review)
 - `v0.13.0` stable released (website updates, documentation alignment, version bump)
 - `v0.13.0-rc.2` released (support & feedback entry points, diagnostics copy, GitHub Sponsors integration)
 - `v0.13.0-rc.1` released (inspector sidebar, upgrade reliability, status menu, documentation)
@@ -32,7 +33,29 @@ Current checkpoint:
 - `v0.14.0` distribution/licensing architecture planning docs aligned (future-state, no implementation changes)
 
 Next release targets:
+- `v0.14.1` — Stability + UX + adapter behavior fixes (patch release after review)
 - `v0.15.x` — Upgrade Preview & Execution Transparency
+
+---
+
+## v0.14.1 Patch Track (In Progress)
+
+### Cache/Persistence Slice (Completed on branch)
+
+Delivered:
+
+- Search cache persistence now keeps one row per `(manager, package)` instead of accumulating duplicates by query/version tuple
+- Search cache upserts preserve previously known non-empty version/summary metadata when newer search responses omit those fields
+- Added regression coverage for search-cache deduplication and summary preservation semantics
+- Control-center available-cache refresh now deduplicates by package ID and preserves non-empty summaries across cache rows
+- Package aggregation now enriches installed/outdated package records with cached summaries when available
+- Package filtering now matches query text against package summaries and merges remote-search summary/latest metadata into local package rows
+
+Remaining slices before merge to `dev`:
+
+- UI/UX fixes (onboarding row density, package selection highlight, search field cleanup, inspector package actions)
+- Task lifecycle fixes (duplicate in-flight task rows; prune policy for long-running/pending tasks)
+- Adapter behavior fixes (RubyGems update action path; `mas` install dependency handling/failure messaging)
 
 ---
 


### PR DESCRIPTION
## Summary
- deduplicate persisted search cache entries by manager/package and preserve non-empty version/summary metadata across refreshes
- deduplicate cached available packages in Swift, enrich installed/outdated rows with cached summaries, and merge remote search metadata into local results
- update CURRENT_STATE/NEXT_STEPS for the v0.14.1 cache/persistence slice

## Validation
- cargo test -p helm-core --manifest-path core/rust/Cargo.toml
- xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm test -destination 'platform=macOS'