### PR TITLE
chore: finalize v0.15.0 release preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,13 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
 - Updates section content now scrolls to prevent clipping when execution-plan and failure lists exceed available viewport height.
 - Updates plan rows now use display-order numbering and full-row hit targets for inspector selection.
 - Updates section now shows an in-progress indicator while scoped plan execution is active.
-- Failed-task inspector details now include a suggested repro command when available and a task-scoped Copy Diagnostics action.
+- Task inspector now shows a `Command` field with the resolved repro command when available.
 - Popover failure banner now replaces contradictory `Upgrade All` with `Review` when failures exist, routing directly to Control Center Tasks and selecting the first failed task.
 - Failed-task inspector now uses a single `View Diagnostics` action that opens a 3-tab diagnostics view (`diagnostics`, `stderr`, `stdout`).
+- Support diagnostics manager listing is now stable (authority order, then alphabetical) to prevent row reordering churn.
 - Process-executed adapter tasks now carry task ID context through execution so stdout/stderr can be captured and mapped back to task IDs for diagnostics.
+- Removed the redundant `Dry Run` button from Updates now that equivalent plan visibility is always present inline.
+- Release-prep metadata now targets `0.15.0` across workspace versioning and status documentation (README/website/release checklist).
 - Generated `apps/macos-ui/Generated/HelmVersion.xcconfig` is now ignored and no longer tracked.
 
 ## [0.14.1] - 2026-02-20

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <br>
   A native macOS menu bar app for unified package manager control.
   <br>
-  <strong>Pre-1.0 &middot; v0.14.1</strong>
+  <strong>Pre-1.0 &middot; v0.15.0</strong>
 </p>
 
 <p align="center">
@@ -23,9 +23,9 @@
 
 Helm manages software across multiple package managers (Homebrew, npm, pip, Cargo, etc.) and runtime tools (mise, rustup) from a single menu bar interface. It is designed as infrastructure software: deterministic, safety-first, and explicit about authority, orchestration, and error handling.
 
-> **Status:** Active pre-1.0 development at `v0.14.1`. Twenty-eight managers are implemented with authority-ordered refresh, progressive search, pin/safe-mode policy controls, optional/detection-only manager handling, and localization coverage for `en`, `es`, `de`, `fr`, `pt-BR`, and `ja`.
+> **Status:** Active pre-1.0 development at `v0.15.0`. Twenty-eight managers are implemented with authority-ordered refresh, progressive search, pin/safe-mode policy controls, optional/detection-only manager handling, and localization coverage for `en`, `es`, `de`, `fr`, `pt-BR`, and `ja`.
 >
-> **Testing:** Please test `v0.14.1` and report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Testing:** Please test `v0.15.0` and report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Editions (Beta)
 
@@ -125,7 +125,7 @@ Or open `apps/macos-ui/Helm.xcodeproj` in Xcode and run the **Helm** scheme. The
 | 0.12.x | Localization + Upgrade Transparency — locale hardening, visual validation expansion, upgrade preview, dry-run | Completed (`v0.12.0`) |
 | 0.13.x | UI/UX Analysis & Redesign — full UX audit, interaction model, information architecture refresh | Completed (`v0.13.0`) |
 | 0.14.x | Platform, Detection & Optional Managers — Docker, Xcode, Rosetta, Sparkle | Completed (`v0.14.x` stable, latest patch `v0.14.1`) |
-| 0.15.x | Upgrade Preview & Execution Transparency — bulk preview, dry-run, failure isolation | Planned |
+| 0.15.x | Upgrade Preview & Execution Transparency — bulk preview, scoped execution, failure isolation | Completed (`v0.15.0` release prep on `dev`) |
 | 0.16.x | Self-Update & Installer Hardening — Sparkle integration, signed verification | Planned |
 | 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel | Planned |
 | 0.18.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit | Planned |

--- a/apps/macos-ui/Helm/Core/L10n+App.swift
+++ b/apps/macos-ui/Helm/Core/L10n+App.swift
@@ -333,6 +333,8 @@ extension L10n {
             static let taskType = "app.inspector.task_type"
             static let taskStatus = "app.inspector.task_status"
             static let taskManager = "app.inspector.task_manager"
+            static let taskCommand = "app.inspector.task_command"
+            static let taskCommandUnavailable = "app.inspector.task_command_unavailable"
             static let taskLabelKey = "app.inspector.task_label_key"
             static let taskLabelArgs = "app.inspector.task_label_args"
             static let taskFailureFeedback = "app.inspector.task_failure_feedback"

--- a/apps/macos-ui/Helm/Resources/locales/de/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/de/app.json
@@ -184,6 +184,8 @@
   "app.inspector.task_type": "Aufgabentyp",
   "app.inspector.task_status": "Status",
   "app.inspector.task_manager": "Manager",
+  "app.inspector.task_command": "Befehl",
+  "app.inspector.task_command_unavailable": "Nicht verfügbar",
   "app.inspector.task_label_key": "Label-Schlüssel",
   "app.inspector.task_label_args": "Label-Argumente",
   "app.inspector.package_id": "Paket-ID",

--- a/apps/macos-ui/Helm/Resources/locales/en/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/en/app.json
@@ -184,6 +184,8 @@
   "app.inspector.task_type": "Task Type",
   "app.inspector.task_status": "Status",
   "app.inspector.task_manager": "Manager",
+  "app.inspector.task_command": "Command",
+  "app.inspector.task_command_unavailable": "Not available",
   "app.inspector.task_label_key": "Label Key",
   "app.inspector.task_label_args": "Label Arguments",
   "app.inspector.package_id": "Package ID",

--- a/apps/macos-ui/Helm/Resources/locales/es/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/es/app.json
@@ -184,6 +184,8 @@
   "app.inspector.task_type": "Tipo de tarea",
   "app.inspector.task_status": "Estado",
   "app.inspector.task_manager": "Gestor",
+  "app.inspector.task_command": "Comando",
+  "app.inspector.task_command_unavailable": "No disponible",
   "app.inspector.task_label_key": "Clave de etiqueta",
   "app.inspector.task_label_args": "Argumentos de etiqueta",
   "app.inspector.package_id": "ID de paquete",

--- a/apps/macos-ui/Helm/Resources/locales/fr/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/fr/app.json
@@ -184,6 +184,8 @@
   "app.inspector.task_type": "Type de tâche",
   "app.inspector.task_status": "Statut",
   "app.inspector.task_manager": "Gestionnaire",
+  "app.inspector.task_command": "Commande",
+  "app.inspector.task_command_unavailable": "Indisponible",
   "app.inspector.task_label_key": "Clé de libellé",
   "app.inspector.task_label_args": "Arguments du libellé",
   "app.inspector.package_id": "ID du paquet",

--- a/apps/macos-ui/Helm/Resources/locales/ja/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/ja/app.json
@@ -184,6 +184,8 @@
   "app.inspector.task_type": "タスクタイプ",
   "app.inspector.task_status": "ステータス",
   "app.inspector.task_manager": "マネージャー",
+  "app.inspector.task_command": "コマンド",
+  "app.inspector.task_command_unavailable": "利用できません",
   "app.inspector.task_label_key": "ラベルキー",
   "app.inspector.task_label_args": "ラベル引数",
   "app.inspector.package_id": "パッケージID",

--- a/apps/macos-ui/Helm/Resources/locales/pt-BR/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/pt-BR/app.json
@@ -184,6 +184,8 @@
   "app.inspector.task_type": "Tipo de tarefa",
   "app.inspector.task_status": "Status",
   "app.inspector.task_manager": "Gerenciador",
+  "app.inspector.task_command": "Comando",
+  "app.inspector.task_command_unavailable": "Indisponível",
   "app.inspector.task_label_key": "Chave do rótulo",
   "app.inspector.task_label_args": "Argumentos do rótulo",
   "app.inspector.package_id": "ID do pacote",

--- a/apps/macos-ui/Helm/Views/ControlCenterSectionViews.swift
+++ b/apps/macos-ui/Helm/Views/ControlCenterSectionViews.swift
@@ -86,21 +86,6 @@ struct RedesignUpdatesSectionView: View {
     @State private var includeOsUpdates = false
     @State private var managerScopeId = HelmCore.allManagersScopeId
     @State private var packageScopeQuery = ""
-    @State private var showDryRun = false
-    @State private var dryRunMessage = ""
-
-    private var previewBreakdown: [(manager: String, count: Int)] {
-        Dictionary(grouping: scopedPlanSteps, by: \.managerId)
-            .map { key, value in
-                (manager: localizedManagerDisplayName(key), count: value.count)
-            }
-            .sorted { lhs, rhs in
-                if lhs.count == rhs.count {
-                    return lhs.manager.localizedCaseInsensitiveCompare(rhs.manager) == .orderedAscending
-                }
-                return lhs.count > rhs.count
-            }
-    }
 
     private var totalCount: Int {
         scopedPlanSteps.count
@@ -397,16 +382,6 @@ struct RedesignUpdatesSectionView: View {
                     }
                     .buttonStyle(HelmSecondaryButtonStyle())
 
-                    Button(L10n.App.Action.dryRun.localized) {
-                        let lines = previewBreakdown.prefix(8).map { "\($0.manager): \($0.count)" }
-                        dryRunMessage = L10n.App.DryRun.message.localized(with: [
-                            "count": totalCount,
-                            "summary": lines.joined(separator: "\n")
-                        ])
-                        showDryRun = true
-                    }
-                    .buttonStyle(HelmSecondaryButtonStyle())
-
                     Button(L10n.App.Action.runPlan.localized) {
                         core.runUpgradePlanScoped(
                             managerScopeId: managerScopeId,
@@ -420,11 +395,6 @@ struct RedesignUpdatesSectionView: View {
                 }
             }
             .padding(20)
-        }
-        .alert(L10n.App.DryRun.title.localized, isPresented: $showDryRun) {
-            Button(L10n.Common.ok.localized, role: .cancel) {}
-        } message: {
-            Text(dryRunMessage)
         }
         .onAppear {
             core.refreshUpgradePlan(includePinned: false, allowOsUpdates: includeOsUpdates)

--- a/apps/macos-ui/Helm/Views/InspectorViews.swift
+++ b/apps/macos-ui/Helm/Views/InspectorViews.swift
@@ -122,6 +122,13 @@ private struct InspectorTaskDetailView: View {
                 }
             }
 
+            InspectorField(label: L10n.App.Inspector.taskCommand.localized) {
+                Text(taskCommandText())
+                    .font(.caption.monospaced())
+                    .foregroundStyle(diagnosticCommandHint() == nil ? .secondary : .primary)
+                    .textSelection(.enabled)
+            }
+
             if let labelKey = task.labelKey {
                 InspectorField(label: L10n.App.Inspector.taskLabelKey.localized) {
                     Text(labelKey)
@@ -157,12 +164,6 @@ private struct InspectorTaskDetailView: View {
                         Text(failureHintText())
                             .font(.caption)
                             .foregroundStyle(.secondary)
-
-                        if let commandHint = diagnosticCommandHint() {
-                            Text(commandHint)
-                                .font(.caption.monospaced())
-                                .textSelection(.enabled)
-                        }
 
                         if hasNumericTaskId {
                             Button(L10n.App.Inspector.viewDiagnostics.localized) {
@@ -215,6 +216,10 @@ private struct InspectorTaskDetailView: View {
 
     private func diagnosticCommandHint() -> String? {
         core.diagnosticCommandHint(for: task)
+    }
+
+    private func taskCommandText() -> String {
+        diagnosticCommandHint() ?? L10n.App.Inspector.taskCommandUnavailable.localized
     }
 
     private var hasNumericTaskId: Bool {

--- a/core/rust/Cargo.lock
+++ b/core/rust/Cargo.lock
@@ -238,7 +238,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helm-core"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "libc",
  "rusqlite",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "helm-ffi"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "cbindgen",
  "helm-core",

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -3,4 +3,4 @@ members = ["crates/helm-core", "crates/helm-ffi"]
 resolver = "2"
 
 [workspace.package]
-version = "0.14.1"
+version = "0.15.0"

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,13 +8,13 @@ It reflects reality, not intention.
 
 ## Version
 
-Current version: **0.14.1**
+Current version: **0.15.0** (release prep on `dev`; latest stable release on `main` is `v0.14.1`)
 
 See:
 - CHANGELOG.md
 
 Active milestone:
-- 0.15.x — Upgrade Preview & Execution Transparency (kickoff)
+- 0.15.0 — Upgrade Preview & Execution Transparency (release finalization)
 - 0.14.1 — Released on `main` (PR `#65`, tag `v0.14.1`)
 
 ---
@@ -237,7 +237,7 @@ Validation:
 
 ---
 
-## v0.15.0-alpha.4 Status (In Progress)
+## v0.15.0-alpha.4 Status (Completed)
 
 ### Final 0.15.0 Cut Readiness
 
@@ -262,8 +262,11 @@ Implemented on `feat/v0.15.x-alpha.1-kickoff` (current progress):
 - Updates section content now renders in a scrollable container so large execution-plan lists no longer clip top/bottom content in the control center
 - Updates plan rows now use display-order numbering, full-row inspector selection hit targets, and an in-progress scoped-run indicator
 - Failed task inspector content now includes manager/task-aware suggested repro command hints and a single `View Diagnostics` action
+- Task inspector now surfaces a dedicated `Command` field with the resolved repro command (or unavailable fallback)
 - Diagnostics modal now includes three tabs: `diagnostics`, `stderr`, and `stdout`
+- Support diagnostics manager rows now render in a stable order (authoritative → standard → guarded, then alphabetical)
 - Popover failure banner now shows a `Review` action (instead of `Upgrade All`) while failures exist, opening Control Center Tasks and selecting the first failed task
+- Removed redundant Updates `Dry Run` action now that plan/risk context is continuously visible inline
 - Added task-output capture plumbing across Rust execution and FFI/XPC:
   - adapter executions now propagate runtime task ID context into process-spawn requests
   - process stdout/stderr is captured per task ID and exposed through `helm_get_task_output`
@@ -273,6 +276,8 @@ Validation:
 
 - `cargo test -p helm-core -p helm-ffi --manifest-path core/rust/Cargo.toml`
 - `xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' test`
+- `apps/macos-ui/scripts/check_locale_integrity.sh`
+- `apps/macos-ui/scripts/check_locale_lengths.sh`
 
 ---
 

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -18,6 +18,7 @@ Focus:
 - 0.15.x upgrade preview and execution transparency
 
 Current checkpoint:
+- `v0.15.0` release prep in progress on `dev` (final stabilization/validation complete; pending PR flow)
 - `v0.14.0` released (merged to `main`, tagged, manager rollout + docs/version alignment complete)
 - `v0.14.1` released (merged to `main` via `#65`, tagged `v0.14.1`)
 - `v0.13.0` stable released (website updates, documentation alignment, version bump)
@@ -37,7 +38,7 @@ Next release targets:
 
 ---
 
-## v0.15.x Kickoff Plan (In Progress)
+## v0.15.x Kickoff Plan (Completed)
 
 ### Alpha.1 — Plan Model + Inspector Foundations (Completed on `feat/v0.15.x-alpha.1-kickoff`)
 
@@ -80,7 +81,7 @@ Validation:
 - `cargo test -p helm-core -p helm-ffi --manifest-path core/rust/Cargo.toml`
 - `xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' test`
 
-### Alpha.4 — Final 0.15.0 Cut Readiness (In Progress on `feat/v0.15.x-alpha.1-kickoff`)
+### Alpha.4 — Final 0.15.0 Cut Readiness (Completed on `feat/v0.15.x-alpha.1-kickoff`)
 
 Progress so far:
 
@@ -99,17 +100,19 @@ Progress so far:
 - Updates section now scrolls end-to-end so long plan/failure lists remain fully accessible during manual validation
 - Updates rows now support full-row inspector hit targets, display-order numbering, and scoped-run in-progress feedback
 - Failed-task inspector now provides suggested repro command hints and a single `View Diagnostics` action
+- Task inspector now includes a dedicated `Command` field with resolved repro command text (or unavailable fallback)
 - Diagnostics modal now includes dedicated `diagnostics`, `stderr`, and `stdout` tabs
+- Support diagnostics manager rows now remain stable via authority-first + alphabetical ordering
 - Popover failure banner now uses a `Review` action (instead of `Upgrade All`) when failures exist, routing to Control Center Tasks and selecting the first failed task
+- Removed redundant Updates `Dry Run` button since equivalent plan context is already visible inline
 - Added execution-to-inspector task-output plumbing:
   - per-task runtime context now flows into process requests
   - process output capture is keyed by task ID and exposed via FFI/XPC (`helm_get_task_output` / `getTaskOutput`)
   - inspector fetches task output on demand for diagnostics without adding payload bloat to task polling
 
 Deliver:
-
-- merge alpha branch into `dev` for manual end-to-end validation of scoped run/cancel/retry behavior
-- capture manual validation notes and fold follow-up fixes into the `v0.15.0` stabilization pass
+- open PR with final `v0.15.0` prep deltas into `dev` for verified commit lineage
+- after merge to `dev`, open `dev` -> `main` PR and complete CI before tagging
 
 ### Exit Gate
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -2,12 +2,12 @@
 
 This checklist is required before creating a release tag on `main`.
 
-## v0.15.0-alpha.1 (In Progress)
+## v0.15.0 (In Progress)
 
 ### Scope and Documentation
-- [x] `CHANGELOG.md` `[Unreleased]` notes track alpha delivery and scoped-run sequencing hardening.
-- [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect `v0.15.0` alpha.1–alpha.4 progress.
-- [x] Pre-release checklist scaffolded for `v0.15.0-alpha.1`.
+- [x] `CHANGELOG.md` `[Unreleased]` notes track final `v0.15.0` delivery and stabilization changes.
+- [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect completed `v0.15.0` alpha.1–alpha.4 scope plus final prep changes.
+- [x] README/website status text aligned to `v0.15.0` pre-release testing.
 
 ### Validation
 - [x] Rust tests pass (`cargo test -p helm-core -p helm-ffi --manifest-path core/rust/Cargo.toml`).
@@ -15,14 +15,17 @@ This checklist is required before creating a release tag on `main`.
 - [x] Locale checks pass (`apps/macos-ui/scripts/check_locale_integrity.sh` and `apps/macos-ui/scripts/check_locale_lengths.sh`).
 
 ### Versioning
-- [ ] Workspace version bumped to `0.15.0-alpha.1` in `core/rust/Cargo.toml`.
-- [ ] Rust lockfile package versions aligned to `0.15.0-alpha.1` in `core/rust/Cargo.lock`.
-- [ ] Generated app version artifacts aligned to `0.15.0-alpha.1`.
+- [x] Workspace version bumped to `0.15.0` in `core/rust/Cargo.toml`.
+- [x] Rust lockfile package versions aligned to `0.15.0` in `core/rust/Cargo.lock`.
+- [ ] Generated app version artifacts aligned to `0.15.0` by build flow (build-generated, not tracked in git).
 
 ### Branch and Tag
-- [ ] Merge alpha branch into `dev`.
-- [ ] Create pre-release tag from `dev` lineage: `git tag -a v0.15.0-alpha.1 -m "Helm v0.15.0-alpha.1"`.
-- [ ] Push tag: `git push origin v0.15.0-alpha.1`.
+- [ ] Open PR with final prep deltas into `dev` (for verified commit provenance).
+- [ ] Merge prep PR into `dev`.
+- [ ] Open PR from `dev` to `main` for `v0.15.0` and complete CI checks.
+- [ ] Merge `dev` into `main` for release.
+- [ ] Create annotated tag from `main`: `git tag -a v0.15.0 -m "Helm v0.15.0"`.
+- [ ] Push tag: `git push origin v0.15.0`.
 
 ## v0.14.1 (Completed)
 

--- a/locales/de/app.json
+++ b/locales/de/app.json
@@ -184,6 +184,8 @@
   "app.inspector.task_type": "Aufgabentyp",
   "app.inspector.task_status": "Status",
   "app.inspector.task_manager": "Manager",
+  "app.inspector.task_command": "Befehl",
+  "app.inspector.task_command_unavailable": "Nicht verfügbar",
   "app.inspector.task_label_key": "Label-Schlüssel",
   "app.inspector.task_label_args": "Label-Argumente",
   "app.inspector.package_id": "Paket-ID",

--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -184,6 +184,8 @@
   "app.inspector.task_type": "Task Type",
   "app.inspector.task_status": "Status",
   "app.inspector.task_manager": "Manager",
+  "app.inspector.task_command": "Command",
+  "app.inspector.task_command_unavailable": "Not available",
   "app.inspector.task_label_key": "Label Key",
   "app.inspector.task_label_args": "Label Arguments",
   "app.inspector.package_id": "Package ID",

--- a/locales/es/app.json
+++ b/locales/es/app.json
@@ -184,6 +184,8 @@
   "app.inspector.task_type": "Tipo de tarea",
   "app.inspector.task_status": "Estado",
   "app.inspector.task_manager": "Gestor",
+  "app.inspector.task_command": "Comando",
+  "app.inspector.task_command_unavailable": "No disponible",
   "app.inspector.task_label_key": "Clave de etiqueta",
   "app.inspector.task_label_args": "Argumentos de etiqueta",
   "app.inspector.package_id": "ID de paquete",

--- a/locales/fr/app.json
+++ b/locales/fr/app.json
@@ -184,6 +184,8 @@
   "app.inspector.task_type": "Type de tâche",
   "app.inspector.task_status": "Statut",
   "app.inspector.task_manager": "Gestionnaire",
+  "app.inspector.task_command": "Commande",
+  "app.inspector.task_command_unavailable": "Indisponible",
   "app.inspector.task_label_key": "Clé de libellé",
   "app.inspector.task_label_args": "Arguments du libellé",
   "app.inspector.package_id": "ID du paquet",

--- a/locales/ja/app.json
+++ b/locales/ja/app.json
@@ -184,6 +184,8 @@
   "app.inspector.task_type": "タスクタイプ",
   "app.inspector.task_status": "ステータス",
   "app.inspector.task_manager": "マネージャー",
+  "app.inspector.task_command": "コマンド",
+  "app.inspector.task_command_unavailable": "利用できません",
   "app.inspector.task_label_key": "ラベルキー",
   "app.inspector.task_label_args": "ラベル引数",
   "app.inspector.package_id": "パッケージID",

--- a/locales/pt-BR/app.json
+++ b/locales/pt-BR/app.json
@@ -184,6 +184,8 @@
   "app.inspector.task_type": "Tipo de tarefa",
   "app.inspector.task_status": "Status",
   "app.inspector.task_manager": "Gerenciador",
+  "app.inspector.task_command": "Comando",
+  "app.inspector.task_command_unavailable": "Indisponível",
   "app.inspector.task_label_key": "Chave do rótulo",
   "app.inspector.task_label_args": "Argumentos do rótulo",
   "app.inspector.package_id": "ID do pacote",

--- a/web/src/content/docs/index.mdx
+++ b/web/src/content/docs/index.mdx
@@ -44,8 +44,8 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 ## Current Status
 
-Helm is in active pre-1.0 development at **v0.14.1**. Twenty-eight managers are implemented with authority-ordered refresh, progressive search, pin/safe-mode policy controls, optional/detection-only manager handling, broad localization coverage, and a redesigned menu bar/control-center shell with inspector sidebar. See the [roadmap](/product-roadmap/) for what's next.
+Helm is in active pre-1.0 development at **v0.15.0**. Twenty-eight managers are implemented with authority-ordered refresh, progressive search, pin/safe-mode policy controls, optional/detection-only manager handling, broad localization coverage, and a redesigned menu bar/control-center shell with inspector sidebar. See the [roadmap](/product-roadmap/) for what's next.
 
-> **Testing Program:** `v0.14.1` is available for pre-1.0 testing. Please file feedback and bug reports via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Testing Program:** `v0.15.0` is available for pre-1.0 testing. Please file feedback and bug reports via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 Helm is currently source-available under a non-commercial license. See the [licensing page](/licensing/) for details.

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -12,7 +12,7 @@ Developers and power users on macOS who manage software through multiple package
 
 ## What it does today
 
-Helm v0.14.1 supports twenty-eight managers:
+Helm v0.15.0 supports twenty-eight managers:
 
 | Category | Managers |
 |---------|----------|
@@ -38,9 +38,9 @@ Key features:
 - **Background tasks** — real-time task tracking with per-manager serial execution
 - **Onboarding walkthrough** — guided first-launch experience with spotlight highlights across popover and control center
 - **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, and `ja` with locale override in Settings
-- **Upgrade transparency** — dedicated upgrade preview surface with dry-run simulation mode
+- **Upgrade transparency** — dedicated upgrade preview surface with scoped execution and failure-attribution visibility
 
-> **Testing Program:** `v0.14.1` is available for pre-1.0 testing. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Testing Program:** `v0.15.0` is available for pre-1.0 testing. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## How it works
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -29,14 +29,14 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 |---|---|
 | 0.13.x | UI/UX Analysis & Redesign — full UX audit, interaction model, visual system refresh, accessibility, onboarding walkthrough, inspector sidebar, support & feedback entry points (`v0.13.0` stable released) |
 | 0.14.x | Platform, Detection & Optional Managers — Docker, Xcode, Rosetta, Sparkle, Setapp, Homebrew casks, optional managers (`v0.14.x` stable, latest patch `v0.14.1`) |
+| 0.15.x | Advanced Upgrade Transparency — richer execution-plan visibility, failure isolation, and operator controls (`v0.15.0` release prep on `dev`) |
 
-> **Testing:** `v0.14.1` is available. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Testing:** `v0.15.0` is available. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Planned
 
 | Version | Milestone |
 |---|---|
-| 0.15.x | Advanced Upgrade Transparency — richer execution-plan visibility, failure isolation, and operator controls |
 | 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification |
 | 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel |
 | 0.18.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit |


### PR DESCRIPTION
## Summary
- finalize the remaining v0.15.0 UI polish items: stable diagnostics manager ordering, task inspector command field, and remove the redundant Updates dry-run action
- bump workspace version metadata to 0.15.0 and align release/readme/website status docs
- update v0.15.0 release checklist for the verified-commit PR flow into dev and dev->main release flow

## Validation
- cargo test -p helm-core -p helm-ffi --manifest-path core/rust/Cargo.toml
- xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' test
- apps/macos-ui/scripts/check_locale_integrity.sh
- apps/macos-ui/scripts/check_locale_lengths.sh
- ASTRO_TELEMETRY_DISABLED=1 npm --prefix web run build