### PR TITLE
fix: prevent duplicate release DMG workflow runs

### DIFF
--- a/.github/workflows/release-macos-dmg.yml
+++ b/.github/workflows/release-macos-dmg.yml
@@ -2,7 +2,7 @@ name: Release macOS DMG
 
 on:
   release:
-    types: [published, prereleased]
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -12,6 +12,10 @@ on:
 
 permissions:
   contents: write
+
+concurrency:
+  group: release-dmg-${{ github.event.release.tag_name || github.event.inputs.tag }}
+  cancel-in-progress: true
 
 jobs:
   build-and-upload-dmg:


### PR DESCRIPTION
## Summary
- trigger release DMG workflow only on `release.published` (remove `prereleased` trigger)
- add `concurrency` keyed by tag name to guarantee single in-flight run per tag

## Why
Pre-release publication emitted overlapping events that started duplicate DMG jobs for the same tag.

## Change
```yaml
on:
  release:
    types: [published]

concurrency:
  group: release-dmg-${{ github.event.release.tag_name || github.event.inputs.tag }}
  cancel-in-progress: true
```

## Validation
- YAML parse check: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-macos-dmg.yml"); puts "ok"'`
