### PR TITLE
fix: sync release DMG duplicate-run guard to dev

### DIFF
--- a/.github/workflows/release-macos-dmg.yml
+++ b/.github/workflows/release-macos-dmg.yml
@@ -2,7 +2,7 @@ name: Release macOS DMG
 
 on:
   release:
-    types: [published, prereleased]
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -12,6 +12,10 @@ on:
 
 permissions:
   contents: write
+
+concurrency:
+  group: release-dmg-${{ github.event.release.tag_name || github.event.inputs.tag }}
+  cancel-in-progress: true
 
 jobs:
   build-and-upload-dmg:


### PR DESCRIPTION
## Summary
- sync the release DMG duplicate-run hotfix into `dev`
- limit release trigger to `published`
- add tag-keyed workflow `concurrency`

## Why
This keeps `dev` aligned with `main` so future `dev -> main` merges do not regress the duplicate-run fix.
