### PR TITLE
feat: redesign Astro website with Helm editorial theme

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -102,6 +102,22 @@ Validation snapshot for `v0.11.0-beta.1` expansion:
 
 ---
 
+## Website Status
+
+- Astro + Starlight website now uses a Helm-brand custom theme layer via `web/src/styles/helm-theme.css`
+- Landing page (`web/src/content/docs/index.mdx`) has been redesigned to match brand/copy structure:
+  - Hero
+  - Problem
+  - Solution
+  - Command Bridge
+  - Helm Pro
+  - Footer CTA
+- Website redesign planning artifacts added:
+  - `docs/website/WEBSITE_REDESIGN_PLAN.md`
+  - `docs/website/DESIGN_TOKENS.md`
+
+---
+
 ## v0.14.1 Patch-Track Status (Released)
 
 Released in `v0.14.1` (UI/UX slice):

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -38,6 +38,30 @@ Next release targets:
 
 ---
 
+## Website Workstream (2026-02-20)
+
+Completed:
+
+- Added website redesign planning docs aligned to the Helm brand system:
+  - `docs/website/WEBSITE_REDESIGN_PLAN.md`
+  - `docs/website/DESIGN_TOKENS.md`
+- Implemented a custom Helm visual theme for the Astro/Starlight site:
+  - `web/src/styles/helm-theme.css`
+  - wired through `web/astro.config.mjs`
+- Rebuilt landing page structure and copy hierarchy in `web/src/content/docs/index.mdx` to match:
+  - Hero
+  - Problem
+  - Solution
+  - Command Bridge
+  - Helm Pro
+  - Footer CTA
+
+Immediate follow-up:
+
+- Perform manual visual QA in both light and dark theme across mobile/tablet/desktop breakpoints before release publishing.
+
+---
+
 ## v0.15.x Kickoff Plan (Completed)
 
 ### Alpha.1 — Plan Model + Inspector Foundations (Completed on `feat/v0.15.x-alpha.1-kickoff`)

--- a/docs/website/DESIGN_TOKENS.md
+++ b/docs/website/DESIGN_TOKENS.md
@@ -1,0 +1,257 @@
+# Helm Website Design Tokens (Proposed)
+
+## Purpose
+Define CSS variable tokens for the redesigned Helm website, aligned to the official brand system. This is a proposal for design and implementation planning.
+
+## Token Principles
+- Helm Blue is the primary interactive and brand color family.
+- Rope Gold is Pro-only accent color.
+- Semantic tokens should be consumed by components; raw palette tokens stay foundational.
+- Gold usage should remain below 10% of total visual weight on any page.
+
+## 1) Foundation Tokens
+```css
+:root {
+  /* Brand - Helm Blue */
+  --color-blue-900: #1b3a66;
+  --color-blue-700: #2a5da8;
+  --color-blue-500: #3c7dd9;
+  --color-blue-300: #6ca6e8;
+
+  /* Accent - Rope Gold (Pro only) */
+  --color-gold-700: #a97e2a;
+  --color-gold-500: #c89c3d;
+
+  /* Neutrals - light */
+  --color-bg-light: #f5f7fa;
+  --color-panel-light: #ffffff;
+  --color-divider-light: #e2e6ec;
+  --color-text-primary-light: #1c1f26;
+  --color-text-secondary-light: #4b5563;
+
+  /* Neutrals - dark */
+  --color-bg-dark: #0e1624;
+  --color-panel-dark: #141e2f;
+  --color-divider-dark: #24324a;
+  --color-text-primary-dark: #e6edf6;
+  --color-text-secondary-dark: #9fb0c7;
+
+  /* Status */
+  --color-critical-500: #d64545;
+
+  /* Typography */
+  --font-sans: "SF Pro Text", "SF Pro Display", "Inter", "IBM Plex Sans",
+    -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: "SF Mono", "IBM Plex Mono", "SFMono-Regular", Menlo, monospace;
+
+  /* Radius */
+  --radius-sm: 12px;
+  --radius-md: 14px;
+  --radius-lg: 16px;
+
+  /* Elevation */
+  --shadow-soft: 0 6px 24px rgba(16, 28, 48, 0.08);
+  --shadow-soft-dark: 0 10px 30px rgba(0, 0, 0, 0.28);
+
+  /* Motion */
+  --motion-duration-fast: 180ms;
+  --motion-duration-base: 220ms;
+  --motion-duration-slow: 240ms;
+  --motion-ease-standard: ease-out;
+
+  /* Layout */
+  --container-max: 1200px;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+  --space-9: 80px;
+}
+```
+
+## 2) Semantic Tokens
+```css
+:root,
+[data-theme="light"] {
+  --color-bg: var(--color-bg-light);
+  --color-surface: var(--color-panel-light);
+  --color-surface-elevated: #ffffff;
+  --color-divider: var(--color-divider-light);
+  --color-text-primary: var(--color-text-primary-light);
+  --color-text-secondary: var(--color-text-secondary-light);
+
+  --color-brand: var(--color-blue-700);
+  --color-brand-hover: var(--color-blue-500);
+  --color-brand-active: var(--color-blue-900);
+  --color-focus-ring: var(--color-blue-500);
+
+  --color-info-border: var(--color-blue-700);
+  --color-info-bg: rgba(42, 93, 168, 0.08);
+
+  --color-warning-border: var(--color-gold-500);
+  --color-warning-bg: rgba(200, 156, 61, 0.1);
+
+  --color-critical-border: var(--color-critical-500);
+  --color-critical-bg: rgba(214, 69, 69, 0.1);
+}
+
+[data-theme="dark"] {
+  --color-bg: var(--color-bg-dark);
+  --color-surface: var(--color-panel-dark);
+  --color-surface-elevated: #19263a;
+  --color-divider: var(--color-divider-dark);
+  --color-text-primary: var(--color-text-primary-dark);
+  --color-text-secondary: var(--color-text-secondary-dark);
+
+  --color-brand: var(--color-blue-500);
+  --color-brand-hover: var(--color-blue-300);
+  --color-brand-active: var(--color-blue-700);
+  --color-focus-ring: var(--color-blue-300);
+
+  --color-info-border: var(--color-blue-500);
+  --color-info-bg: rgba(60, 125, 217, 0.16);
+
+  --color-warning-border: var(--color-gold-500);
+  --color-warning-bg: rgba(200, 156, 61, 0.16);
+
+  --color-critical-border: var(--color-critical-500);
+  --color-critical-bg: rgba(214, 69, 69, 0.16);
+}
+```
+
+## 3) Component Tokens
+```css
+:root {
+  /* Buttons */
+  --btn-primary-bg: var(--color-brand);
+  --btn-primary-bg-hover: var(--color-brand-hover);
+  --btn-primary-bg-active: var(--color-brand-active);
+  --btn-primary-text: #ffffff;
+  --btn-primary-radius: var(--radius-md);
+
+  --btn-secondary-bg: transparent;
+  --btn-secondary-border: var(--color-blue-500);
+  --btn-secondary-text: var(--color-blue-700);
+  --btn-secondary-bg-hover: rgba(60, 125, 217, 0.08);
+
+  --btn-tertiary-bg: transparent;
+  --btn-tertiary-text: var(--color-text-secondary);
+
+  --btn-pro-bg: var(--color-gold-500);
+  --btn-pro-bg-hover: var(--color-gold-700);
+  --btn-pro-text: #1c1f26;
+
+  /* Cards */
+  --card-bg: var(--color-surface);
+  --card-border: var(--color-divider);
+  --card-radius: var(--radius-lg);
+  --card-shadow: var(--shadow-soft);
+  --card-highlight-border: var(--color-brand);
+  --card-pro-badge-bg: var(--color-gold-500);
+
+  /* Lists */
+  --list-row-padding-y: 14px;
+  --list-row-divider: var(--color-divider);
+  --list-row-hover-bg: rgba(60, 125, 217, 0.05);
+  --list-row-selected-bar: var(--color-brand);
+
+  /* Alerts */
+  --alert-info-border: var(--color-info-border);
+  --alert-info-bg: var(--color-info-bg);
+  --alert-warning-border: var(--color-warning-border);
+  --alert-warning-bg: var(--color-warning-bg);
+  --alert-critical-border: var(--color-critical-border);
+  --alert-critical-bg: var(--color-critical-bg);
+
+  /* Navigation */
+  --nav-active-text: var(--color-brand);
+  --nav-active-bg: rgba(60, 125, 217, 0.1);
+
+  /* Badges */
+  --badge-standard-bg: rgba(75, 85, 99, 0.14);
+  --badge-standard-text: var(--color-text-secondary);
+  --badge-pro-bg: var(--color-gold-500);
+  --badge-pro-text: #1c1f26;
+  --badge-ai-bg: var(--color-blue-700);
+  --badge-ai-text: #ffffff;
+}
+```
+
+## 4) Typography Scale Tokens
+```css
+:root {
+  --text-display: clamp(2.25rem, 4vw, 3.5rem);
+  --text-h1: clamp(2rem, 3.2vw, 3rem);
+  --text-h2: clamp(1.5rem, 2.2vw, 2.25rem);
+  --text-h3: clamp(1.25rem, 1.6vw, 1.5rem);
+  --text-body-lg: 1.125rem;
+  --text-body: 1rem;
+  --text-body-sm: 0.9375rem;
+  --text-label: 0.8125rem;
+
+  --line-height-tight: 1.2;
+  --line-height-body: 1.55;
+  --line-height-relaxed: 1.7;
+}
+```
+
+## 5) Responsive Tokens
+```css
+:root {
+  --breakpoint-sm: 640px;
+  --breakpoint-md: 1024px;
+  --breakpoint-lg: 1440px;
+
+  --section-space-mobile: 56px;
+  --section-space-tablet: 72px;
+  --section-space-desktop: 96px;
+  --section-space-wide: 120px;
+}
+```
+
+## 6) Visual Enhancement Tokens
+```css
+:root {
+  /* Subtle atmospheric backgrounds */
+  --bg-gradient-light:
+    radial-gradient(1200px 600px at 75% -10%, rgba(60, 125, 217, 0.14), transparent 60%),
+    linear-gradient(180deg, #f7f9fc 0%, #f5f7fa 100%);
+
+  --bg-gradient-dark:
+    radial-gradient(900px 520px at 70% -5%, rgba(60, 125, 217, 0.22), transparent 60%),
+    linear-gradient(180deg, #0f1828 0%, #0e1624 100%);
+
+  /* Grid overlay */
+  --grid-line-color-light: rgba(42, 93, 168, 0.08);
+  --grid-line-color-dark: rgba(159, 176, 199, 0.08);
+  --grid-size: 32px;
+}
+```
+
+## 7) Motion and Accessibility Tokens
+```css
+:root {
+  --anim-reveal-distance: 8px;
+  --anim-hover-lift: -2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --motion-duration-fast: 0ms;
+    --motion-duration-base: 0ms;
+    --motion-duration-slow: 0ms;
+    --anim-reveal-distance: 0px;
+    --anim-hover-lift: 0px;
+  }
+}
+```
+
+## 8) Usage Rules
+- Use semantic/component tokens in UI code, not raw palette values.
+- Reserve all `--color-gold-*` tokens for Pro-specific badges, borders, and actions.
+- Keep focus states in Helm Blue for clear consistency and accessibility.
+- Keep contrast compliant in both themes before visual refinements are approved.

--- a/docs/website/WEBSITE_REDESIGN_PLAN.md
+++ b/docs/website/WEBSITE_REDESIGN_PLAN.md
@@ -1,0 +1,228 @@
+# Helm Website Redesign Plan
+
+## Purpose
+Define a full website redesign direction for Helm that aligns with:
+
+- `docs/brand/HELM_DESIGN_SYSTEM.md`
+- `docs/brand/UI_COMPONENT_SPEC.md`
+- `docs/brand/VISUAL_IDENTITY_GUIDE.md`
+- `docs/brand/LANDING_COPY_REWRITE.md`
+
+This plan is design-only. No feature or product-positioning changes are included.
+
+## Brand Alignment Summary
+- Tagline remains: "Take the helm."
+- Tone remains: commanding, calm, professional, technical.
+- Visual priority: Helm Blue is primary.
+- Rope Gold is reserved for Pro UI only and kept below 10% visual weight.
+- Style direction: high clarity and hierarchy (inspired by Avast/Docker structure), without flashy startup aesthetics.
+
+## 1) Proposed Layout Structure (Section by Section)
+## 0. Global Frame
+- Max content width: `1200px` (marketing body), with wider hero background treatment.
+- Page rhythm: large section spacing (`80-120px` desktop, `56-72px` mobile).
+- Consistent section headers with short supporting text.
+- Sticky top navigation for orientation and CTA persistence.
+
+## 1. Header / Navigation
+- Left: Helm logo + wordmark.
+- Center/right: anchor links (`Problem`, `Solution`, `Helm Pro`).
+- Right actions:
+  - Secondary: `View on GitHub`
+  - Primary: `Download Helm`
+- Behavior:
+  - Minimal chrome, subtle bottom divider.
+  - On scroll, add slight panel blur/tint for readability.
+
+## 2. Hero (Primary Value)
+- Copy (from rewrite):
+  - Eyebrow: `macOS-native toolchain control`
+  - H1: `Take the helm.`
+  - Supporting line: `Helm centralizes your toolchain and restores operational clarity across package managers.`
+- Actions:
+  - Primary: `Download Helm`
+  - Secondary: `View on GitHub`
+- Visual:
+  - Product screenshot or UI crop in framed command-deck card.
+  - Subtle radial blue glow behind product frame.
+  - Optional tiny status chips (deterministic, auditable, centralized) as supporting proof points.
+
+## 3. Problem Section
+- Heading: `Modern development environments are fragmented.`
+- Body references manager fragmentation (`Homebrew`, `npm`, `pip`, `cargo`, `RubyGems`).
+- Layout:
+  - Left: concise narrative copy.
+  - Right: structured "fragmentation map" card stack (not decorative blobs).
+- Goal: show loss of visibility before presenting solution.
+
+## 4. Solution Section
+- Heading: `Helm restores control.`
+- Content cards for:
+  - Unified visibility across managers
+  - Centralized upgrade strategy
+  - Deterministic system state
+  - Clear update history
+  - CVE awareness (Helm Pro, visually tagged)
+- Layout:
+  - Desktop: 2-column card grid (or 3+2 split).
+  - Mobile: single-column stack.
+- Visual hierarchy:
+  - Standard cards use blue-neutral styling.
+  - Pro capability card gets subtle gold badge only.
+
+## 5. Command Bridge Section
+- Heading: `Think of Helm as your command bridge.`
+- Supporting lines:
+  - `One interface.`
+  - `All managers.`
+  - `Total visibility.`
+- Layout:
+  - Left: concise conceptual copy.
+  - Right: structured diagram panel showing manager inputs -> Helm control plane -> clear state.
+- Direction:
+  - Technical and literal, not metaphor-heavy.
+
+## 6. Helm Pro Section
+- Heading: `Helm Pro adds advanced system intelligence.`
+- List:
+  - CVE detection
+  - Priority upgrade recommendations
+  - Audit-ready update history
+  - Proactive risk insights
+- Visual rules:
+  - Use gold accents only on Pro badge, border highlights, and Pro CTA.
+  - Keep section mostly blue/neutral with premium contrast accents.
+- CTA:
+  - Secondary Pro-focused action (for future pricing/details route) without changing base product positioning.
+
+## 7. Footer CTA
+- Heading: `Take the helm.`
+- Supporting text: `Download Helm for macOS.`
+- Primary action: `Download Helm`
+- Optional secondary: `View on GitHub`
+
+## 8. Footer
+- Left: logo + short product line.
+- Right: compact links (`Docs`, `GitHub`, `Privacy`, `Support`).
+- Subtle legal/meta row.
+
+## 2) Updated Component Hierarchy
+```text
+WebsitePage
+- BackgroundLayer
+  - GradientBase
+  - GridOverlay (subtle, optional by section)
+- SiteHeader
+  - BrandLockup
+  - NavLinks
+  - HeaderActions
+    - SecondaryButton (GitHub)
+    - PrimaryButton (Download)
+- MainContent
+  - HeroSection
+    - HeroCopy
+    - HeroActions
+    - ProductFrameCard
+  - ProblemSection
+    - SectionHeading
+    - ProblemNarrative
+    - FragmentationCards
+  - SolutionSection
+    - SectionHeading
+    - CapabilityCardGrid
+      - CapabilityCard (standard)
+      - CapabilityCard (pro-tagged)
+  - CommandBridgeSection
+    - BridgeCopy
+    - BridgeDiagramCard
+  - ProSection
+    - ProIntro
+    - ProFeatureList
+    - ProBadge
+    - ProAction
+  - FooterCTASection
+    - CTAHeading
+    - CTAActions
+- SiteFooter
+  - FooterLinks
+  - MetaRow
+```
+
+Shared primitives:
+- `Button` (primary, secondary, tertiary, pro)
+- `Card` (standard, highlighted, pro)
+- `Badge` (standard, pro)
+- `SectionHeader`
+- `Divider`
+- `ListRow`
+
+## 3) Responsive Strategy
+## Breakpoints
+- `sm`: 0-639px
+- `md`: 640-1023px
+- `lg`: 1024-1439px
+- `xl`: 1440px+
+
+## Layout Behavior
+- `sm`:
+  - Single-column flow.
+  - Hero screenshot below copy.
+  - Collapsible nav menu.
+  - Full-width CTAs with clear vertical stacking.
+- `md`:
+  - Two-column hero where space allows.
+  - 2-column capability grid.
+  - Slightly denser section spacing than desktop.
+- `lg/xl`:
+  - Full two-column hero.
+  - Problem and Command Bridge use split layouts.
+  - Capability cards balance into 3-column or 2+3 composition.
+
+## Type and Spacing Scaling
+- H1 uses fluid scale with hard min/max to prevent oversized headline behavior.
+- Body and label sizes step by breakpoint, never below readable contrast standards.
+- Increase hit areas for touch devices while preserving desktop precision.
+
+## 4) Suggested Visual Enhancements
+## Background and Atmosphere
+- Base background:
+  - Light mode: cool neutral with faint blue lift.
+  - Dark mode: deep navy gradient with restrained radial glow.
+- Add subtle compass/grid overlay:
+  - Very low opacity.
+  - Applied to hero and bridge sections only.
+  - Must not reduce text contrast.
+
+## Depth and Framing
+- Use soft elevation cards for content grouping.
+- Frame product visuals like a macOS workspace panel.
+- Use thin neutral dividers to keep section boundaries explicit.
+
+## Contrast Discipline
+- Keep major CTAs and selected states in Helm Blue.
+- Use gold accents only for Pro indicators and Pro CTA.
+- Avoid bright multi-hue gradients and decorative color noise.
+
+## 5) Minimal Animation Guidance
+- Timing:
+  - Standard transitions: `180-240ms`.
+  - Ease: `ease-out` for entrances and state changes.
+- Allowed motions:
+  - Fade + slight upward translate for section reveal.
+  - Soft hover elevation on cards/buttons.
+  - Nav background transition on scroll.
+- Disallowed motions:
+  - Bounce, elastic, springy playful effects.
+  - Continuous looping ornamentation.
+- Accessibility:
+  - Respect `prefers-reduced-motion`.
+  - In reduced mode, use instant or opacity-only transitions.
+
+## 6) Copy and Hierarchy Guardrails
+- Keep rewritten landing copy structure intact.
+- Do not reframe Helm as a different product category.
+- Prioritize scanability:
+  - Clear section headers
+  - Short body blocks
+  - Strong CTA consistency
+- Maintain a professional command-center feel over marketing spectacle.

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -9,6 +9,7 @@ export default defineConfig({
 		starlight({
 			title: 'Helm',
 			tagline: 'Take the helm.',
+			customCss: ['./src/styles/helm-theme.css'],
 			logo: {
 				src: './src/assets/helm-icon.png',
 			},

--- a/web/src/content/docs/index.mdx
+++ b/web/src/content/docs/index.mdx
@@ -1,51 +1,138 @@
 ---
 title: Helm
-description: Take the helm. Unified package management for macOS.
+description: Take the helm. Operational clarity for macOS toolchains.
 template: splash
 hero:
-  tagline: "<strong>Take the helm.</strong> One control plane for all your package managers on macOS."
+  title: "Take the helm."
+  tagline: "Helm centralizes your toolchain and restores operational clarity across package managers."
   image:
-    file: ../../assets/helm-icon.png
+    file: ../../assets/tour/control-center-overview.png
+    alt: "Helm Control Center showing manager and package status."
   actions:
-    - text: Download DMG
+    - text: Download Helm
       link: https://github.com/jasoncavinder/Helm/releases/latest/download/Helm.dmg
       icon: download
       variant: primary
-    - text: Get Started
-      link: /product-overview/
-      icon: right-arrow
-      variant: secondary
     - text: View on GitHub
       link: https://github.com/jasoncavinder/Helm
       icon: external
-    - text: Roadmap
-      link: /product-roadmap/
-      icon: document
+      variant: secondary
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
+import { LinkButton } from '@astrojs/starlight/components';
+import menuBarPopover from '../../assets/tour/menu-bar-popover-dark.png';
 
-## Why Helm?
+<div class="landing-shell">
+  <section id="problem" class="landing-section">
+    <div class="section-head">
+      <p class="landing-kicker"><span class="section-index">01</span> Problem</p>
+      <h2>Modern development environments are fragmented.</h2>
+    </div>
+    <div class="landing-problem-grid">
+      <div class="landing-problem-copy">
+        <p>Homebrew. npm. pip. cargo. RubyGems.</p>
+        <p>Each manages its own universe.</p>
+        <p>Your system state becomes opaque.</p>
+        <p>Updates break silently.</p>
+        <p>You lose visibility.</p>
+      </div>
+      <div class="fragmentation-map">
+        <p class="fragmentation-map-title">Typical fragmented manager surface</p>
+        <div class="manager-chip-grid">
+          <div class="manager-chip">Homebrew</div>
+          <div class="manager-chip">npm</div>
+          <div class="manager-chip">pip</div>
+          <div class="manager-chip">cargo</div>
+          <div class="manager-chip">RubyGems</div>
+          <div class="manager-chip">rustup</div>
+        </div>
+      </div>
+    </div>
+  </section>
 
-<CardGrid stagger>
-	<Card title="Unified Control Plane" icon="laptop">
-		Manage Homebrew, mise, rustup, softwareupdate, mas, and more from one native macOS menu bar app. No more switching between terminals.
-	</Card>
-	<Card title="Safety First" icon="approve-check-circle">
-		Structured process execution, authority-ordered refresh, and no shell injection risks. Your system stays predictable.
-	</Card>
-	<Card title="Smart Orchestration" icon="rocket">
-		Toolchain managers refresh before package managers. Parallel execution across managers, serial within each. Failures are isolated.
-	</Card>
-	<Card title="Native & Fast" icon="apple">
-		Built with Rust and SwiftUI. Instant search, low memory usage, and real-time task tracking from your menu bar.
-	</Card>
-</CardGrid>
+  <section id="solution" class="landing-section">
+    <div class="section-head">
+      <p class="landing-kicker"><span class="section-index">02</span> Solution</p>
+      <h2>Helm restores control.</h2>
+    </div>
+    <ul class="feature-list">
+      <li class="feature-item">
+        <h3>Unified visibility across managers</h3>
+        <p>One control plane for package and toolchain state.</p>
+      </li>
+      <li class="feature-item">
+        <h3>Centralized upgrade strategy</h3>
+        <p>Operator-friendly execution order with clear manager context.</p>
+      </li>
+      <li class="feature-item">
+        <h3>Deterministic system state</h3>
+        <p>Deterministic actions and traceable outcomes.</p>
+      </li>
+      <li class="feature-item">
+        <h3>Clear update history</h3>
+        <p>Auditable task records and explicit status.</p>
+      </li>
+      <li class="feature-item pro">
+        <h3>CVE awareness <span class="pro-inline-badge">Pro</span></h3>
+        <p>Security context for risk-aware upgrade decisions.</p>
+      </li>
+    </ul>
+    <p class="landing-close-line">Your system. Clearly understood.</p>
+  </section>
 
-## Current Status
+  <section id="command-bridge" class="landing-section">
+    <div class="section-head">
+      <p class="landing-kicker"><span class="section-index">03</span> Command Bridge</p>
+      <h2>Think of Helm as your command bridge.</h2>
+    </div>
+    <div class="landing-command-grid">
+      <div>
+        <p>One interface. All managers. Total visibility.</p>
+        <p>Helm gives operators a stable, centralized control surface for routine maintenance.</p>
+      </div>
+      <div class="bridge-diagram">
+        <div class="bridge-grid">
+          <div class="bridge-node"><strong>Inputs</strong><br />brew, npm, pip, cargo, rustup</div>
+          <div class="bridge-arrow">-&gt;</div>
+          <div class="bridge-core"><strong>Helm Core</strong><br />Orchestration + task visibility</div>
+          <div class="bridge-arrow">-&gt;</div>
+          <div class="bridge-node"><strong>Output</strong><br />Clear system state</div>
+        </div>
+        <img class="bridge-shot" src={menuBarPopover.src} alt="Helm menu bar popover with update status and tasks." loading="lazy" />
+      </div>
+    </div>
+  </section>
 
-Helm is in active pre-1.0 development at **v0.15.0**. Twenty-eight managers are implemented with authority-ordered refresh, progressive search, pin/safe-mode policy controls, optional/detection-only manager handling, broad localization coverage, and a redesigned menu bar/control-center shell with inspector sidebar. See the [roadmap](/product-roadmap/) for what's next.
+  <section id="helm-pro" class="landing-section">
+    <div class="section-head">
+      <p class="landing-kicker"><span class="section-index">04</span> Helm Pro</p>
+      <h2>Helm Pro adds advanced system intelligence.</h2>
+    </div>
+    <div class="pro-panel">
+      <ul class="pro-list">
+        <li>CVE detection</li>
+        <li>Priority upgrade recommendations</li>
+        <li>Audit-ready update history</li>
+        <li>Proactive risk insights</li>
+      </ul>
+      <p>Professional-grade control for serious builders.</p>
+    </div>
+  </section>
 
-> **Testing Program:** `v0.15.0` is available for pre-1.0 testing. Please file feedback and bug reports via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
-
-Helm is currently source-available under a non-commercial license. See the [licensing page](/licensing/) for details.
+  <section class="landing-section footer-cta">
+    <div class="section-head">
+      <p class="landing-kicker"><span class="section-index">05</span> Get Helm</p>
+    </div>
+    <h2>Take the helm.</h2>
+    <p>Download Helm for macOS.</p>
+    <div class="footer-cta-actions">
+      <LinkButton href="https://github.com/jasoncavinder/Helm/releases/latest/download/Helm.dmg" icon="download" variant="primary">Download Helm</LinkButton>
+      <LinkButton href="https://github.com/jasoncavinder/Helm" icon="external" variant="secondary">View on GitHub</LinkButton>
+      <LinkButton href="/product-overview/" icon="right-arrow" variant="minimal">Product overview</LinkButton>
+      <LinkButton href="/product-roadmap/" icon="document" variant="minimal">Roadmap</LinkButton>
+    </div>
+    <p class="release-note">
+      Helm is currently source-available under a non-commercial license. See the <a href="/licensing/">licensing page</a> for details.
+    </p>
+  </section>
+</div>

--- a/web/src/styles/helm-theme.css
+++ b/web/src/styles/helm-theme.css
@@ -1,0 +1,666 @@
+:root,
+::backdrop {
+  --helm-blue-900: #1b3a66;
+  --helm-blue-700: #2a5da8;
+  --helm-blue-500: #3c7dd9;
+  --helm-blue-300: #6ca6e8;
+  --helm-gold-700: #a97e2a;
+  --helm-gold-500: #c89c3d;
+  --helm-bg-dark: #0e1624;
+  --helm-panel-dark: #141e2f;
+  --helm-divider-dark: #24324a;
+  --helm-text-dark: #e6edf6;
+  --helm-text-dark-secondary: #9fb0c7;
+  --helm-bg-light: #f5f7fa;
+  --helm-panel-light: #ffffff;
+  --helm-divider-light: #e2e6ec;
+  --helm-text-light: #1c1f26;
+  --helm-text-light-secondary: #4b5563;
+  --helm-critical: #d64545;
+
+  --sl-font:
+    "Inter",
+    "SF Pro Text",
+    "SF Pro Display",
+    "IBM Plex Sans",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  --helm-font-display:
+    "IBM Plex Sans",
+    "Inter",
+    "SF Pro Display",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  --sl-font-mono:
+    "SF Mono",
+    "IBM Plex Mono",
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace;
+
+  --sl-color-accent-low: #1b3a66;
+  --sl-color-accent: #3c7dd9;
+  --sl-color-accent-high: #6ca6e8;
+  --sl-color-bg: var(--helm-bg-dark);
+  --sl-color-bg-nav: rgba(14, 22, 36, 0.92);
+  --sl-color-bg-sidebar: #111b2a;
+  --sl-color-bg-inline-code: #1a2740;
+  --sl-color-text: #c4d3e8;
+  --sl-color-text-accent: #d9e8ff;
+  --sl-color-text-invert: #f4f8ff;
+  --sl-color-hairline: var(--helm-divider-dark);
+  --sl-color-hairline-light: #2d3e5d;
+  --sl-color-hairline-shade: #0c1421;
+  --sl-color-white: var(--helm-text-dark);
+  --sl-color-black: var(--helm-bg-dark);
+  --sl-color-blue-low: #16253e;
+  --sl-color-blue: var(--helm-blue-500);
+  --sl-color-blue-high: #9dc5f2;
+  --sl-color-purple-low: #16253e;
+  --sl-color-purple: var(--helm-blue-500);
+  --sl-color-purple-high: #9dc5f2;
+  --sl-color-orange-low: #31260f;
+  --sl-color-orange: var(--helm-gold-500);
+  --sl-color-orange-high: #e8cc92;
+  --sl-color-red-low: #3f1f25;
+  --sl-color-red: var(--helm-critical);
+  --sl-color-red-high: #f0a8b2;
+  --sl-color-gray-1: #f3f7fc;
+  --sl-color-gray-2: #d3deee;
+  --sl-color-gray-3: #9fb0c7;
+  --sl-color-gray-4: #7489a6;
+  --sl-color-gray-5: #2a3a55;
+  --sl-color-gray-6: #162334;
+
+  --sl-shadow-sm: 0 3px 10px rgba(4, 11, 21, 0.22);
+  --sl-shadow-md: 0 8px 24px rgba(4, 10, 20, 0.28);
+  --sl-shadow-lg: 0 18px 36px rgba(2, 7, 15, 0.32);
+
+  --helm-page-gradient-dark:
+    radial-gradient(900px 420px at 80% -10%, rgba(60, 125, 217, 0.16), transparent 65%),
+    linear-gradient(180deg, #0f1828 0%, #0e1624 100%);
+  --helm-page-gradient-light:
+    radial-gradient(900px 420px at 80% -10%, rgba(60, 125, 217, 0.1), transparent 65%),
+    linear-gradient(180deg, #f7f9fc 0%, #f5f7fa 100%);
+
+  --helm-radius-sm: 12px;
+  --helm-radius-md: 14px;
+  --helm-radius-lg: 16px;
+  --helm-section-space: clamp(3.25rem, 5vw, 6rem);
+  --helm-transition-fast: 180ms ease-out;
+  --helm-transition-base: 220ms ease-out;
+}
+
+:root[data-theme="light"],
+[data-theme="light"] ::backdrop {
+  --sl-color-accent-low: #d5e4f7;
+  --sl-color-accent: #2a5da8;
+  --sl-color-accent-high: #1b3a66;
+  --sl-color-bg: var(--helm-bg-light);
+  --sl-color-bg-nav: rgba(245, 247, 250, 0.98);
+  --sl-color-bg-sidebar: #f6f8fb;
+  --sl-color-bg-inline-code: #e9eff8;
+  --sl-color-text: #3f4a5c;
+  --sl-color-text-accent: var(--helm-blue-700);
+  --sl-color-text-invert: #ffffff;
+  --sl-color-hairline: var(--helm-divider-light);
+  --sl-color-hairline-light: #d8dee9;
+  --sl-color-hairline-shade: #e3e8f0;
+  --sl-color-white: var(--helm-text-light);
+  --sl-color-black: var(--helm-panel-light);
+  --sl-color-blue-low: #e6effb;
+  --sl-color-blue: #2a5da8;
+  --sl-color-blue-high: #1b3a66;
+  --sl-color-purple-low: #e6effb;
+  --sl-color-purple: #2a5da8;
+  --sl-color-purple-high: #1b3a66;
+  --sl-color-orange-low: #f7efde;
+  --sl-color-orange: var(--helm-gold-500);
+  --sl-color-orange-high: #6b511b;
+  --sl-color-red-low: #fbecef;
+  --sl-color-red: var(--helm-critical);
+  --sl-color-red-high: #801925;
+  --sl-color-gray-1: #1c1f26;
+  --sl-color-gray-2: #2f3742;
+  --sl-color-gray-3: #4b5563;
+  --sl-color-gray-4: #6f7b8d;
+  --sl-color-gray-5: #c6cfde;
+  --sl-color-gray-6: #e9edf5;
+  --sl-color-gray-7: #ffffff;
+
+  --sl-shadow-sm: 0 2px 8px rgba(16, 28, 48, 0.08);
+  --sl-shadow-md: 0 8px 22px rgba(16, 28, 48, 0.11);
+  --sl-shadow-lg: 0 16px 30px rgba(16, 28, 48, 0.13);
+}
+
+html,
+body {
+  background: var(--helm-page-gradient-dark);
+}
+
+:root[data-theme="light"] body {
+  background: var(--helm-page-gradient-light);
+}
+
+.header {
+  background-color: #111c2d;
+  backdrop-filter: blur(6px);
+  border-bottom-color: var(--sl-color-hairline);
+}
+
+:root[data-theme="light"] .header {
+  background-color: #f5f7fa;
+}
+
+.site-title {
+  color: var(--sl-color-text-accent);
+}
+
+.header :is(a, button, label, select) {
+  color: var(--sl-color-white);
+}
+
+:root[data-theme="light"] .header :is(a, button, label, select) {
+  color: var(--helm-text-light);
+}
+
+button[data-open-modal] {
+  color: var(--sl-color-white);
+}
+
+@media (min-width: 50rem) {
+  button[data-open-modal] {
+    background-color: rgba(20, 30, 47, 0.9);
+    border-color: var(--sl-color-hairline);
+    color: #d9e8ff;
+  }
+
+  :root[data-theme="light"] button[data-open-modal] {
+    background-color: #ffffff;
+    border-color: var(--sl-color-hairline);
+    color: #2f3742;
+  }
+}
+
+.header :is(a, button, select):focus-visible,
+.sl-link-button:focus-visible,
+.landing-shell a:focus-visible {
+  outline: 2px solid var(--helm-blue-500);
+  outline-offset: 2px;
+  border-radius: 8px;
+}
+
+.sl-link-button {
+  border-radius: var(--helm-radius-md);
+  font-weight: 600;
+  transition:
+    transform var(--helm-transition-base),
+    background-color var(--helm-transition-base),
+    border-color var(--helm-transition-base),
+    color var(--helm-transition-base),
+    box-shadow var(--helm-transition-base);
+}
+
+.sl-link-button.primary {
+  background: var(--helm-blue-700);
+  border-color: var(--helm-blue-700);
+  color: #ffffff;
+}
+
+.sl-link-button.primary:hover {
+  background: var(--helm-blue-500);
+  border-color: var(--helm-blue-500);
+  color: #ffffff;
+  transform: translateY(-1px);
+  box-shadow: var(--sl-shadow-sm);
+}
+
+.sl-link-button.secondary {
+  background: transparent;
+  border-color: var(--helm-blue-500);
+  color: var(--helm-blue-300);
+}
+
+.sl-link-button.secondary:hover {
+  background: rgba(60, 125, 217, 0.08);
+  border-color: var(--helm-blue-300);
+  color: #e4f1ff;
+}
+
+:root[data-theme="light"] .sl-link-button.secondary {
+  color: var(--helm-blue-700);
+}
+
+:root[data-theme="light"] .sl-link-button.secondary:hover {
+  color: var(--helm-blue-900);
+}
+
+.sl-link-button.minimal {
+  color: var(--sl-color-text);
+}
+
+.sl-link-button.minimal:hover {
+  color: var(--sl-color-white);
+}
+
+[data-has-hero] .sl-container {
+  max-width: min(74rem, 100%);
+}
+
+[data-has-hero] .hero {
+  position: relative;
+  gap: 1.5rem;
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: calc(var(--helm-radius-lg) + 2px);
+  padding: clamp(1.1rem, 2.1vw, 1.9rem);
+  background: linear-gradient(180deg, rgba(20, 30, 47, 0.92), rgba(16, 25, 39, 0.92));
+}
+
+:root[data-theme="light"] [data-has-hero] .hero {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(247, 249, 252, 0.96));
+}
+
+[data-has-hero] .hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(to right, rgba(159, 176, 199, 0.05) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(159, 176, 199, 0.05) 1px, transparent 1px);
+  background-size: 42px 42px;
+  opacity: 0.2;
+}
+
+:root[data-theme="light"] [data-has-hero] .hero::after {
+  background:
+    linear-gradient(to right, rgba(42, 93, 168, 0.05) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(42, 93, 168, 0.05) 1px, transparent 1px);
+  opacity: 0.35;
+}
+
+[data-has-hero] .hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+[data-has-hero] .hero .copy {
+  background: rgba(10, 18, 30, 0.55);
+  border: 1px solid rgba(159, 176, 199, 0.18);
+  border-radius: 14px;
+  padding: 0.75rem 0.9rem;
+}
+
+:root[data-theme="light"] [data-has-hero] .hero .copy {
+  background: rgba(255, 255, 255, 0.9);
+  border-color: rgba(42, 93, 168, 0.16);
+}
+
+[data-has-hero] .hero > img,
+[data-has-hero] .hero > .hero-html {
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: var(--helm-radius-lg);
+  background: rgba(10, 18, 30, 0.7);
+  box-shadow: var(--sl-shadow-md);
+}
+
+:root[data-theme="light"] [data-has-hero] .hero > img,
+:root[data-theme="light"] [data-has-hero] .hero > .hero-html {
+  background: #ffffff;
+}
+
+[data-has-hero] .hero h1 {
+  font-family: var(--helm-font-display);
+  font-size: clamp(2.2rem, 5vw, 3.5rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: #f4f8ff;
+  text-shadow: 0 1px 2px rgba(2, 8, 18, 0.45);
+}
+
+[data-has-hero] .hero .tagline {
+  font-size: clamp(1.06rem, 1.35vw, 1.24rem);
+  color: #d5e2f6;
+  max-width: 44ch;
+  text-shadow: 0 1px 1px rgba(2, 8, 18, 0.35);
+}
+
+:root[data-theme="light"] [data-has-hero] .hero h1 {
+  color: #1c1f26;
+  text-shadow: none;
+}
+
+:root[data-theme="light"] [data-has-hero] .hero .tagline {
+  color: #3f4a5c;
+  text-shadow: none;
+}
+
+.landing-shell {
+  margin-top: 1rem;
+  max-width: 71rem;
+  margin-inline: auto;
+}
+
+.landing-section {
+  margin-top: var(--helm-section-space);
+  position: relative;
+}
+
+.section-head {
+  margin-bottom: 1rem;
+}
+
+.landing-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin: 0 0 0.5rem;
+  color: var(--helm-blue-300);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+:root[data-theme="light"] .landing-kicker {
+  color: var(--helm-blue-700);
+}
+
+.section-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2ch;
+  padding: 0.12rem 0.35rem;
+  border: 1px solid rgba(108, 166, 232, 0.42);
+  border-radius: 999px;
+  font-family: var(--sl-font-mono);
+  font-size: 0.68rem;
+  color: #b8d5f8;
+}
+
+:root[data-theme="light"] .section-index {
+  color: var(--helm-blue-700);
+  border-color: rgba(42, 93, 168, 0.28);
+}
+
+.sl-markdown-content h2 {
+  font-family: var(--helm-font-display);
+  font-size: clamp(1.65rem, 2.2vw, 2.28rem);
+  line-height: 1.22;
+  letter-spacing: -0.012em;
+  max-width: 22ch;
+}
+
+.landing-problem-grid,
+.landing-command-grid {
+  display: grid;
+  gap: 1.05rem;
+}
+
+.landing-problem-copy p + p {
+  margin-top: 0.42rem;
+}
+
+.fragmentation-map,
+.bridge-diagram,
+.pro-panel,
+.footer-cta {
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: var(--helm-radius-lg);
+  background: var(--helm-panel-dark);
+  box-shadow: 0 2px 8px rgba(4, 11, 21, 0.18);
+}
+
+:root[data-theme="light"] .fragmentation-map,
+:root[data-theme="light"] .bridge-diagram,
+:root[data-theme="light"] .pro-panel,
+:root[data-theme="light"] .footer-cta {
+  background: var(--helm-panel-light);
+}
+
+.fragmentation-map,
+.bridge-diagram,
+.pro-panel,
+.footer-cta,
+.feature-item {
+  padding: 1rem;
+}
+
+.fragmentation-map-title {
+  margin: 0 0 0.7rem;
+  color: var(--sl-color-white);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.manager-chip-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.manager-chip {
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: 999px;
+  background: rgba(60, 125, 217, 0.06);
+  color: var(--sl-color-white);
+  font-family: var(--sl-font-mono);
+  font-size: 0.78rem;
+  padding: 0.34rem 0.58rem;
+}
+
+:root[data-theme="light"] .manager-chip {
+  color: var(--helm-text-light);
+}
+
+.feature-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.72rem;
+}
+
+.feature-item {
+  border: 1px solid var(--sl-color-hairline);
+  border-left: 3px solid rgba(108, 166, 232, 0.74);
+  border-radius: 12px;
+  background: rgba(20, 30, 47, 0.5);
+  transition:
+    transform var(--helm-transition-base),
+    border-color var(--helm-transition-base),
+    box-shadow var(--helm-transition-base);
+}
+
+:root[data-theme="light"] .feature-item {
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.feature-item:hover {
+  transform: translateY(-2px);
+  border-color: rgba(108, 166, 232, 0.7);
+  box-shadow: var(--sl-shadow-sm);
+}
+
+.feature-item h3 {
+  margin: 0;
+  font-family: var(--helm-font-display);
+  font-size: 1.04rem;
+  color: var(--sl-color-white);
+}
+
+.feature-item p {
+  margin: 0.32rem 0 0;
+  color: var(--sl-color-text);
+}
+
+.feature-item.pro {
+  border-left-color: rgba(200, 156, 61, 0.9);
+  border-color: rgba(200, 156, 61, 0.4);
+}
+
+.pro-inline-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.45rem;
+  border-radius: 999px;
+  font-size: 0.69rem;
+  line-height: 1;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.23rem 0.42rem;
+  background: rgba(200, 156, 61, 0.18);
+  color: #f0d08d;
+}
+
+:root[data-theme="light"] .pro-inline-badge {
+  color: #6a4f1c;
+}
+
+.landing-close-line {
+  margin-top: 0.95rem;
+  color: var(--sl-color-text);
+  font-weight: 550;
+}
+
+.bridge-grid {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.bridge-node {
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: 12px;
+  padding: 0.5rem 0.68rem;
+  background: rgba(60, 125, 217, 0.045);
+  font-size: 0.85rem;
+}
+
+.bridge-node strong {
+  color: var(--sl-color-white);
+}
+
+.bridge-arrow {
+  color: #9dc5f2;
+  font-weight: 700;
+  text-align: center;
+}
+
+.bridge-core {
+  border: 1px solid rgba(60, 125, 217, 0.56);
+  border-radius: 12px;
+  background: rgba(60, 125, 217, 0.11);
+  padding: 0.56rem 0.68rem;
+}
+
+.bridge-shot {
+  margin-top: 0.8rem;
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: var(--helm-radius-md);
+  width: 100%;
+  height: auto;
+}
+
+.pro-panel {
+  border-color: rgba(200, 156, 61, 0.5);
+  border-left-width: 3px;
+  background:
+    linear-gradient(180deg, rgba(200, 156, 61, 0.08), rgba(169, 126, 42, 0.04)),
+    var(--helm-panel-dark);
+}
+
+:root[data-theme="light"] .pro-panel {
+  background:
+    linear-gradient(180deg, rgba(200, 156, 61, 0.1), rgba(169, 126, 42, 0.05)),
+    var(--helm-panel-light);
+}
+
+.pro-list {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.pro-list li + li {
+  margin-top: 0.42rem;
+}
+
+.footer-cta {
+  border-left-width: 3px;
+  border-left-color: rgba(108, 166, 232, 0.85);
+  background:
+    radial-gradient(420px 180px at 82% -20%, rgba(60, 125, 217, 0.14), transparent 65%),
+    var(--helm-panel-dark);
+}
+
+:root[data-theme="light"] .footer-cta {
+  background:
+    radial-gradient(420px 180px at 82% -20%, rgba(60, 125, 217, 0.1), transparent 65%),
+    var(--helm-panel-light);
+}
+
+.footer-cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem 0.8rem;
+  margin-top: 0.8rem;
+}
+
+.release-note {
+  margin-top: 0.8rem;
+  color: var(--sl-color-text);
+  font-size: 0.9rem;
+}
+
+@media (min-width: 50rem) {
+  .landing-problem-grid,
+  .landing-command-grid {
+    grid-template-columns: minmax(0, 1.06fr) minmax(0, 0.94fr);
+    gap: 1.2rem 1.5rem;
+    align-items: start;
+  }
+
+  .feature-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.78rem 0.9rem;
+  }
+
+  .feature-item.pro {
+    grid-column: 1 / -1;
+  }
+
+  .bridge-grid {
+    grid-template-columns: 1fr auto 1fr auto 1fr;
+    align-items: center;
+    gap: 0.65rem;
+  }
+}
+
+@media (min-width: 72rem) {
+  .footer-cta-actions .sl-link-button {
+    margin-block: 0;
+  }
+
+  .landing-section {
+    margin-top: clamp(4rem, 6vw, 6.5rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sl-link-button,
+  .feature-item {
+    transition: none;
+  }
+
+  .sl-link-button:hover,
+  .feature-item:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add website redesign planning docs under docs/website/
- implement a custom Helm brand theme for Astro/Starlight in web/src/styles/helm-theme.css
- redesign landing page structure and copy in web/src/content/docs/index.mdx (Problem, Solution, Command Bridge, Helm Pro, CTA)
- improve hero/header readability and focus states with explicit contrast-safe text colors
- update docs/CURRENT_STATE.md and docs/NEXT_STEPS.md to reflect website workstream changes

## Validation
- npm run build (web)