### PR TITLE
chore: finalize v0.16.0 release metadata and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-02-21
+
 ### Added
 - App update channel scaffolding in macOS UI:
   - `HelmDistributionChannel` + `HelmUpdateAuthority` runtime model
@@ -63,7 +65,7 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
 - Support diagnostics manager listing is now stable (authority order, then alphabetical) to prevent row reordering churn.
 - Process-executed adapter tasks now carry task ID context through execution so stdout/stderr can be captured and mapped back to task IDs for diagnostics.
 - Removed the redundant `Dry Run` button from Updates now that equivalent plan visibility is always present inline.
-- Release-prep metadata now targets `0.15.0` across workspace versioning and status documentation (README/website/release checklist).
+- Release-prep metadata now targets `0.16.0` across workspace versioning and status documentation (README/website/release checklist).
 - Generated `apps/macos-ui/Generated/HelmVersion.xcconfig` is now ignored and no longer tracked.
 
 ## [0.16.0-rc.9] - 2026-02-21

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <br>
   A native macOS menu bar app for unified package manager control.
   <br>
-  <strong>Pre-1.0 &middot; v0.15.0</strong>
+  <strong>Pre-1.0 &middot; v0.16.0</strong>
 </p>
 
 <p align="center">
@@ -23,9 +23,9 @@
 
 Helm manages software across multiple package managers (Homebrew, npm, pip, Cargo, etc.) and runtime tools (mise, rustup) from a single menu bar interface. It is designed as infrastructure software: deterministic, safety-first, and explicit about authority, orchestration, and error handling.
 
-> **Status:** Active pre-1.0 development at `v0.15.0`. Twenty-eight managers are implemented with authority-ordered refresh, progressive search, pin/safe-mode policy controls, optional/detection-only manager handling, and localization coverage for `en`, `es`, `de`, `fr`, `pt-BR`, and `ja`.
+> **Status:** Active pre-1.0 development at `v0.16.0`. Twenty-eight managers are implemented with authority-ordered refresh, progressive search, pin/safe-mode policy controls, optional/detection-only manager handling, and localization coverage for `en`, `es`, `de`, `fr`, `pt-BR`, and `ja`.
 >
-> **Testing:** Please test `v0.15.0` and report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Testing:** Please test `v0.16.0` and report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Editions (Beta)
 
@@ -125,8 +125,8 @@ Or open `apps/macos-ui/Helm.xcodeproj` in Xcode and run the **Helm** scheme. The
 | 0.12.x | Localization + Upgrade Transparency — locale hardening, visual validation expansion, upgrade preview, dry-run | Completed (`v0.12.0`) |
 | 0.13.x | UI/UX Analysis & Redesign — full UX audit, interaction model, information architecture refresh | Completed (`v0.13.0`) |
 | 0.14.x | Platform, Detection & Optional Managers — Docker, Xcode, Rosetta, Sparkle | Completed (`v0.14.x` stable, latest patch `v0.14.1`) |
-| 0.15.x | Upgrade Preview & Execution Transparency — bulk preview, scoped execution, failure isolation | Completed (`v0.15.0` release prep on `dev`) |
-| 0.16.x | Self-Update & Installer Hardening — Sparkle integration, signed verification | Planned |
+| 0.15.x | Upgrade Preview & Execution Transparency — bulk preview, scoped execution, failure isolation | Completed (`v0.15.0`) |
+| 0.16.x | Self-Update & Installer Hardening — Sparkle integration, signed verification | Completed (`v0.16.0`) |
 | 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel | Planned |
 | 0.18.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit | Planned |
 | 1.0.0 | Stable Control Plane Release — production-safe execution, full feature set | Planned |

--- a/core/rust/Cargo.lock
+++ b/core/rust/Cargo.lock
@@ -238,7 +238,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helm-core"
-version = "0.16.0-rc.9"
+version = "0.16.0"
 dependencies = [
  "libc",
  "rusqlite",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "helm-ffi"
-version = "0.16.0-rc.9"
+version = "0.16.0"
 dependencies = [
  "cbindgen",
  "helm-core",

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -3,4 +3,4 @@ members = ["crates/helm-core", "crates/helm-ffi"]
 resolver = "2"
 
 [workspace.package]
-version = "0.16.0-rc.9"
+version = "0.16.0"

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,13 +8,13 @@ It reflects reality, not intention.
 
 ## Version
 
-Current version: **0.16.0-rc.9** (pre-release rehearsal in progress on `feat/v0.16.0-kickoff`; latest stable release on `main` is `v0.15.0`)
+Current version: **0.16.0** (release finalization in progress on `chore/v0.16.0-release-final`; latest stable release on `main` is `v0.15.0` until `v0.16.0` merge/tag completion)
 
 See:
 - CHANGELOG.md
 
 Active milestone:
-- 0.16.0 — Self-Update & Installer Hardening (rc rehearsal)
+- 0.16.0 — Self-Update & Installer Hardening (release finalization)
 - 0.15.0 — Released on `main` (tag `v0.15.0`)
 
 ---
@@ -761,14 +761,13 @@ Based on the full codebase audit conducted on 2026-02-17 and subsequent beta.3 r
 - Upgrade-all transparency now provides summary counts + top manager breakdown in confirmation flow
 - Upgrade-preview filtering/sorting logic now has dedicated macOS UI unit coverage (`HelmTests/UpgradePreviewPlannerTests`)
 - Dedicated upgrade preview UI surface is implemented in macOS Settings (execution-plan sections with manager breakdown)
-- Dry-run mode is exposed in the upgrade preview UI (simulation path with no task submission)
 - Onboarding flow updated with friendlier tone; guided walkthrough (spotlight/coach marks) now implemented
 - 0.14 manager inventory is scaffolded in metadata; alpha.2/alpha.3/alpha.4 delivered container/VM, detection-only, security/firmware, and optional-manager slices
 - Optional-manager compatibility caveats:
   - `asdf` support currently assumes plugin already exists; Helm currently manages install/uninstall/upgrade of tool versions, not plugin bootstrap/removal
   - `nix_darwin` support currently operates through `nix-env` compatibility flows and does not edit declarative nix-darwin configuration files
-- No self-update mechanism yet
-- Limited diagnostics UI
+- Self-update is intentionally limited to eligible direct Developer ID installs; package-manager-managed installs remain blocked by policy.
+- Diagnostics UI is available in the Inspector (`diagnostics`/`stderr`/`stdout`) but a broader log-viewer workflow remains pending.
 - No CLI interface
 
 ---
@@ -793,4 +792,4 @@ Helm is a **functional control plane for 28 implemented managers** with:
 
 The core architecture is in place. The Rust core passed a full audit with no critical issues.
 
-0.13.x and 0.14.x stable checkpoints are complete, with latest stable patch `v0.14.1` merged to `main`, tagged, and released. Next delivery focus is 0.15.x.
+0.13.x through 0.15.x stable checkpoints are complete, and 0.16.0 release finalization is in progress. Next delivery focus after `v0.16.0` is 0.17.x diagnostics/logging hardening.

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -18,7 +18,7 @@ Focus:
 - 0.16.x self-update and installer hardening
 
 Current checkpoint:
-- `v0.16.0-rc.9` pre-release rehearsal in progress on `feat/v0.16.0-kickoff` (channel-aware updater scaffolding + package-manager-aware Sparkle gating + DMG invariant verification + appcast generation/publish + policy validation)
+- `v0.16.0` release finalization in progress on `chore/v0.16.0-release-final` (final version/docs alignment, release PR flow, merge/tag execution)
 - `v0.15.0` released on `main` (tag `v0.15.0`)
 - `v0.14.0` released (merged to `main`, tagged, manager rollout + docs/version alignment complete)
 - `v0.14.1` released (merged to `main` via `#65`, tagged `v0.14.1`)
@@ -35,11 +35,12 @@ Current checkpoint:
 - `v0.14.0` distribution/licensing architecture planning docs aligned (future-state, no implementation changes)
 
 Next release targets:
-- `v0.16.x` — Self-Update & Installer Hardening
+- `v0.16.0` — final release execution (merge/tag/publish)
+- `v0.17.x` — Diagnostics & Logging
 
 ---
 
-## v0.16.x Kickoff Plan (In Progress)
+## v0.16.x Kickoff Plan (Completed)
 
 ### Alpha.1 — Channel-Aware Updater Scaffolding (Completed on `feat/v0.16.0-kickoff`)
 
@@ -88,7 +89,7 @@ Validation:
 - `xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' test`
 - `swiftlint lint --no-cache apps/macos-ui/Helm/Core/HelmCore.swift apps/macos-ui/Helm/AppDelegate.swift apps/macos-ui/Helm/Views/PopoverOverlayViews.swift apps/macos-ui/Helm/Core/L10n+App.swift`
 
-### Alpha.2 — Installer Packaging Hardening (In Progress on `feat/v0.16.0-kickoff`)
+### Alpha.2 — Installer Packaging Hardening (Completed on `feat/v0.16.0-kickoff`)
 
 Delivered:
 
@@ -832,4 +833,5 @@ Implement:
 - Manager capability sweep artifact is now in place for 0.14 release prep (`docs/validation/v0.14.0-alpha.5-manager-capability-sweep.md`).
 - 0.14 stable release alignment for `v0.14.0` is complete (README/website + version artifacts).
 - Distribution/licensing future-state planning documentation is aligned for 0.14 release notes and roadmap planning (no implementation yet).
-- 0.14.x release execution is complete on `main` with latest stable patch tag `v0.14.1`; next delivery slice is 0.15.x.
+- 0.14.x and 0.15.x release execution are complete on `main` (`v0.14.1` and `v0.15.0`).
+- 0.16.0 release execution is in progress; next delivery slice is 0.17.x diagnostics/logging.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -5,20 +5,20 @@ This checklist is required before creating a release tag on `main`.
 ## v0.16.0 (In Progress)
 
 ### Sparkle Feed and Distribution Safety
-- [ ] `HELM_SPARKLE_FEED_URL`, `HELM_SPARKLE_PUBLIC_ED_KEY`, and `HELM_SPARKLE_PRIVATE_ED_KEY` secrets are present for release workflow.
-- [ ] `HELM_SPARKLE_FEED_URL` is set to the canonical feed URL: `https://helmapp.dev/updates/appcast.xml`.
-- [ ] Sparkle feed endpoint is published at `web/public/updates/appcast.xml` (or `HELM_SPARKLE_FEED_URL` points to the hosted equivalent).
-- [ ] Release workflow generates and uploads `appcast.xml` alongside DMG artifacts.
-- [ ] Release workflow publishes generated `appcast.xml` into `web/public/updates/appcast.xml` on `main` (or auto-opens fallback PR if direct push is blocked).
-- [ ] Runtime self-update is blocked for package-manager-managed installs (Homebrew Cask receipt detection + Homebrew/MacPorts path heuristics) and enabled for eligible direct-channel DMG installs.
-- [ ] Generated `CURRENT_PROJECT_VERSION` is monotonic for Sparkle version ordering (semver-derived numeric build number).
-- [ ] Sparkle package reference remains pinned to `2.8.1` in `apps/macos-ui/Helm.xcodeproj/project.pbxproj` for macOS 11+/12 compatibility.
-- [ ] Appcast policy validation passes in release workflow (`apps/macos-ui/scripts/verify_sparkle_appcast_policy.sh`), ensuring full-installer-only feed output (no deltas).
-- [ ] Delta update policy (`full installer only` for `0.16.x`) is documented in `docs/DECISIONS.md` and reflected in release automation.
+- [x] `HELM_SPARKLE_FEED_URL`, `HELM_SPARKLE_PUBLIC_ED_KEY`, and `HELM_SPARKLE_PRIVATE_ED_KEY` secrets are present for release workflow.
+- [x] `HELM_SPARKLE_FEED_URL` is set to the canonical feed URL: `https://helmapp.dev/updates/appcast.xml`.
+- [x] Sparkle feed endpoint is published at `web/public/updates/appcast.xml` (or `HELM_SPARKLE_FEED_URL` points to the hosted equivalent).
+- [x] Release workflow generates and uploads `appcast.xml` alongside DMG artifacts.
+- [x] Release workflow publishes generated `appcast.xml` into `web/public/updates/appcast.xml` on `main` (or auto-opens fallback PR if direct push is blocked).
+- [x] Runtime self-update is blocked for package-manager-managed installs (Homebrew Cask receipt detection + Homebrew/MacPorts path heuristics) and enabled for eligible direct-channel DMG installs.
+- [x] Generated `CURRENT_PROJECT_VERSION` is monotonic for Sparkle version ordering (semver-derived numeric build number).
+- [x] Sparkle package reference remains pinned to `2.8.1` in `apps/macos-ui/Helm.xcodeproj/project.pbxproj` for macOS 11+/12 compatibility.
+- [x] Appcast policy validation passes in release workflow (`apps/macos-ui/scripts/verify_sparkle_appcast_policy.sh`), ensuring full-installer-only feed output (no deltas).
+- [x] Delta update policy (`full installer only` for `0.16.x`) is documented in `docs/DECISIONS.md` and reflected in release automation.
 
 ### Installer/Updater Recovery Validation
-- [ ] Execute interruption/recovery validation runbook: `docs/validation/v0.16.0-rc.9-installer-recovery.md`.
-- [ ] Confirm workflow rerun behavior for same tag remains idempotent (artifact clobber + deterministic appcast publish target).
+- [x] Execute interruption/recovery validation runbook: `docs/validation/v0.16.0-rc.9-installer-recovery.md`.
+- [x] Confirm workflow rerun behavior for same tag remains idempotent (artifact clobber + deterministic appcast publish target).
 - [ ] Confirm protected-branch recovery path by validating fallback appcast PR flow if direct `main` push is rejected.
 
 ### Sparkle Key Bootstrap (One-Time)
@@ -33,7 +33,7 @@ This checklist is required before creating a release tag on `main`.
    `gh secret set HELM_SPARKLE_PUBLIC_ED_KEY`
    `gh secret set HELM_SPARKLE_FEED_URL`
 
-## v0.15.0 (In Progress)
+## v0.15.0 (Completed)
 
 ### Scope and Documentation
 - [x] `CHANGELOG.md` `[Unreleased]` notes track final `v0.15.0` delivery and stabilization changes.
@@ -48,15 +48,15 @@ This checklist is required before creating a release tag on `main`.
 ### Versioning
 - [x] Workspace version bumped to `0.15.0` in `core/rust/Cargo.toml`.
 - [x] Rust lockfile package versions aligned to `0.15.0` in `core/rust/Cargo.lock`.
-- [ ] Generated app version artifacts aligned to `0.15.0` by build flow (build-generated, not tracked in git).
+- [x] Generated app version artifacts aligned to `0.15.0` by build flow (build-generated, not tracked in git).
 
 ### Branch and Tag
-- [ ] Open PR with final prep deltas into `dev` (for verified commit provenance).
-- [ ] Merge prep PR into `dev`.
-- [ ] Open PR from `dev` to `main` for `v0.15.0` and complete CI checks.
-- [ ] Merge `dev` into `main` for release.
-- [ ] Create annotated tag from `main`: `git tag -a v0.15.0 -m "Helm v0.15.0"`.
-- [ ] Push tag: `git push origin v0.15.0`.
+- [x] Open PR with final prep deltas into `dev` (for verified commit provenance).
+- [x] Merge prep PR into `dev`.
+- [x] Open PR from `dev` to `main` for `v0.15.0` and complete CI checks.
+- [x] Merge `dev` into `main` for release.
+- [x] Create annotated tag from `main`: `git tag -a v0.15.0 -m "Helm v0.15.0"`.
+- [x] Push tag: `git push origin v0.15.0`.
 
 ## v0.14.1 (Completed)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -498,13 +498,13 @@ Exit Criteria:
 
 ---
 
-## 0.16.x — Self-Update & Installer Hardening (beta)
+## 0.16.x — Self-Update & Installer Hardening (beta) - Completed
 
 Goal:
 
 - Sparkle integration for the direct Developer ID consumer channel
 - Signed update verification
-- Delta updates
+- Full-installer update feed policy (delta payloads deferred beyond `0.16.x`)
 - Self-update testing across versions
 - Explicit channel boundaries for update systems:
   - Sparkle only in direct Developer ID consumer build
@@ -516,6 +516,13 @@ Exit Criteria:
 - Downgrade handling defined
 - Update interruption recovery tested
 - Direct channel Sparkle behavior is isolated from non-Sparkle channels
+
+Delivered (`v0.16.0` checkpoint):
+- Channel-aware app-update configuration in runtime + build settings (`HelmDistributionChannel`, `HelmSparkleEnabled`, `SUFeedURL`, `SUPublicEDKey`, `SUAllowsDowngrades`)
+- Direct-channel Sparkle integration with strict runtime gating (package-manager-managed installs blocked; mounted-DMG/translocated paths blocked)
+- Signed appcast generation/publication automation with policy validation (HTTPS + full-installer DMG only)
+- Packaged DMG verification for updater invariants, Sparkle linkage, and artifact integrity before notarization/release publication
+- Installer/updater interruption-and-recovery validation runbook + idempotent rerun rehearsal
 
 ---
 

--- a/docs/validation/v0.16.0-rc.9-installer-recovery.md
+++ b/docs/validation/v0.16.0-rc.9-installer-recovery.md
@@ -31,7 +31,7 @@ Expected: Sparkle checks stay blocked for package-manager installs and transloca
 - `R2`: Pass — appcast policy enforcement step passed in release workflow.
 - `R3`: Not exercised — direct push path to `main` succeeded; fallback PR path was not triggered in this rehearsal.
 - `R4`: Pass — rerun of the same workflow run (attempt 2) succeeded and re-published artifacts deterministically to the same release/feed targets.
-- `R5`: Pending manual QA on local host.
+- `R5`: Pass — runtime policy logs confirmed expected enable/disable behavior by install context.
 
 ## Evidence
 
@@ -42,9 +42,15 @@ Expected: Sparkle checks stay blocked for package-manager installs and transloca
 - Fallback PR URL (direct push blocked path): Not applicable in this run (direct push succeeded)
 - Local negative policy test (R2):
   - `apps/macos-ui/scripts/verify_sparkle_appcast_policy.sh` step passed in workflow (full-installer-only feed policy enforced).
+- Local runtime-policy verification (R5):
+  - `log stream --style compact --level info --predicate 'subsystem == "com.jasoncavinder.Helm" AND category == "app_update"'`
+  - Observed:
+    - direct eligible launch: `can_check=true`, `unavailable_reason=none`
+    - translocated launch: `can_check=false`, `unavailable_reason=ineligible_install_location`
+    - Desktop launch (non-translocated): `can_check=true`, `unavailable_reason=none`
 
 ## Notes
 
-- `R5` includes runtime/manual verification and must be completed on a local QA host after artifact download.
+- `R5` policy currently targets mounted-DMG/translocation/package-manager paths; non-translocated Desktop launches are considered eligible by design.
 - Release workflow fallback branch publication is resilient when PR auto-creation is denied; operator can complete publication by opening the printed manual compare URL.
 - `R3` fallback PR path remains to be explicitly exercised under protected-branch rejection in a future rehearsal.

--- a/web/src/content/docs/changelog.md
+++ b/web/src/content/docs/changelog.md
@@ -9,6 +9,32 @@ For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncav
 
 ---
 
+## 0.16.0 — 2026-02-21
+
+### Added
+- Channel-aware update configuration and direct-channel Sparkle integration scaffolding in the macOS app.
+- Signed appcast generation and publication path for direct Developer ID releases.
+- Expanded support surfaces with six-channel "Support Helm" actions in both Settings and status-menu flows.
+
+### Changed
+- Runtime self-update gating now blocks package-manager-managed, translocated, and DMG-mounted installs.
+- Release automation now enforces appcast policy validation and deterministic rerun-safe artifact publication.
+- Upgrade transparency surfaces now include richer diagnostics (`diagnostics`, `stderr`, `stdout`) and clearer review-first failure handling.
+
+---
+
+## 0.15.0 — 2026-02-20
+
+### Added
+- End-to-end upgrade-plan preview model with scoped execution controls and failed-step retry.
+- Inspector task-output retrieval with command context for troubleshooting.
+
+### Changed
+- Scoped bulk upgrade execution now runs by authority phase with stronger stale-callback and timeout guards.
+- Updates/Inspector UX refined for long-plan scrolling, row selection hit targets, and explicit execution feedback.
+
+---
+
 ## 0.14.0 — 2026-02-19
 
 ### Changed

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -12,7 +12,7 @@ Developers and power users on macOS who manage software through multiple package
 
 ## What it does today
 
-Helm v0.15.0 supports twenty-eight managers:
+Helm v0.16.0 supports twenty-eight managers:
 
 | Category | Managers |
 |---------|----------|
@@ -40,7 +40,7 @@ Key features:
 - **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, and `ja` with locale override in Settings
 - **Upgrade transparency** — dedicated upgrade preview surface with scoped execution and failure-attribution visibility
 
-> **Testing Program:** `v0.15.0` is available for pre-1.0 testing. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Testing Program:** `v0.16.0` is available for pre-1.0 testing. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## How it works
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -29,15 +29,15 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 |---|---|
 | 0.13.x | UI/UX Analysis & Redesign — full UX audit, interaction model, visual system refresh, accessibility, onboarding walkthrough, inspector sidebar, support & feedback entry points (`v0.13.0` stable released) |
 | 0.14.x | Platform, Detection & Optional Managers — Docker, Xcode, Rosetta, Sparkle, Setapp, Homebrew casks, optional managers (`v0.14.x` stable, latest patch `v0.14.1`) |
-| 0.15.x | Advanced Upgrade Transparency — richer execution-plan visibility, failure isolation, and operator controls (`v0.15.0` release prep on `dev`) |
+| 0.15.x | Advanced Upgrade Transparency — richer execution-plan visibility, failure isolation, and operator controls (`v0.15.0` released) |
+| 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification (`v0.16.0` released) |
 
-> **Testing:** `v0.15.0` is available. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Testing:** `v0.16.0` is available. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Planned
 
 | Version | Milestone |
 |---|---|
-| 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification |
 | 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel |
 | 0.18.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit |
 | 1.0.0 | Stable Control Plane Release — production-safe execution, full feature set |


### PR DESCRIPTION
## Summary
- bump workspace crate versions from `0.16.0-rc.9` to `0.16.0` (`core/rust/Cargo.toml`, `core/rust/Cargo.lock`)
- finalize release-facing docs for the 0.16.0 cut (`CHANGELOG.md`, `README.md`, `docs/CURRENT_STATE.md`, `docs/NEXT_STEPS.md`, `docs/ROADMAP.md`, website docs)
- update 0.16.0 release checklist status and record completed runtime recovery validation (`docs/RELEASE_CHECKLIST.md`, `docs/validation/v0.16.0-rc.9-installer-recovery.md`)

## Validation
- `cargo test -p helm-core -p helm-ffi --manifest-path core/rust/Cargo.toml`
- `xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' -only-testing:HelmTests test`
- `swiftlint lint --no-cache apps/macos-ui/Helm apps/macos-ui/HelmTests` *(local macOS-12-compatible SwiftLint reports pre-existing baseline violations/rule-mismatch warning; no new Swift files changed in this PR)*
