### PR TITLE
fix: repair release workflow YAML

### DIFF
--- a/.github/workflows/release-macos-dmg.yml
+++ b/.github/workflows/release-macos-dmg.yml
@@ -18,10 +18,6 @@ concurrency:
   group: release-dmg-${{ github.event.release.tag_name || github.event.inputs.tag }}
   cancel-in-progress: true
 
-concurrency:
-  group: release-dmg-${{ github.event.release.tag_name || github.event.inputs.tag }}
-  cancel-in-progress: true
-
 jobs:
   build-and-upload-dmg:
     runs-on: macos-14


### PR DESCRIPTION
## Summary
- fix invalid YAML in `.github/workflows/release-macos-dmg.yml` by removing duplicated top-level `concurrency` key
- unblock release workflow parsing so release events/workflow dispatch can execute

## Why
Recent main pushes were producing immediate workflow-file failures (`This run likely failed because of a workflow file issue`), which blocks `v0.16.0` DMG/appcast automation.

## Validation
- `gh workflow view release-macos-dmg.yml --yaml` now renders a single `concurrency` block
