### PR TITLE
docs: stage security rollout and milestone restructuring for v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-02-21
+
+### Changed
+- Documentation-only release planning update for staged security rollout (no feature implementation changes).
+- Revised milestone sequencing:
+  - new `0.18.x` local security groundwork milestone
+  - prior `0.18.x` stability/hardening milestone moved to `0.19.x`
+  - new `1.4.x` Shared Brain milestone inserted
+  - prior `1.4.x+` milestones shifted forward by one minor version
+- Security architecture clarified as three staged phases:
+  - Stage 1 (`0.18.x`) local internal groundwork
+  - Stage 2 (`1.3.x`) Security Advisory System (Helm Pro, local-first, optional public API queries, local TTL cache)
+  - Stage 3 (`1.4.x`) Shared Brain (fingerprint sharing, known-fix lookup, centralized backend, App Attest request controls)
+- Minimum supported macOS baseline documentation updated to `macOS 11+ (Big Sur)` across README and website installation/FAQ surfaces.
+
 ## [0.16.0] - 2026-02-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
   <br>
   A native macOS menu bar app for unified package manager control.
   <br>
-  <strong>Pre-1.0 &middot; v0.16.0</strong>
+  <strong>Pre-1.0 &middot; v0.16.1</strong>
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/platform-macOS%2012%2B-blue" alt="macOS 12+">
+  <img src="https://img.shields.io/badge/platform-macOS%2011%2B-blue" alt="macOS 11+">
   <img src="https://img.shields.io/badge/swift-5.7%2B-orange" alt="Swift 5.7+">
   <img src="https://img.shields.io/badge/rust-2024%20edition-brown" alt="Rust 2024">
   <img src="https://img.shields.io/github/v/tag/jasoncavinder/Helm?label=version" alt="Version">
@@ -23,7 +23,7 @@
 
 Helm manages software across multiple package managers (Homebrew, npm, pip, Cargo, etc.) and runtime tools (mise, rustup) from a single menu bar interface. It is designed as infrastructure software: deterministic, safety-first, and explicit about authority, orchestration, and error handling.
 
-> **Status:** Active pre-1.0 development at `v0.16.0`. Twenty-eight managers are implemented with authority-ordered refresh, progressive search, pin/safe-mode policy controls, optional/detection-only manager handling, and localization coverage for `en`, `es`, `de`, `fr`, `pt-BR`, and `ja`.
+> **Status:** Active pre-1.0 development at `v0.16.1` (documentation and planning update). Current implemented release baseline remains `v0.16.0`.
 >
 > **Testing:** Please test `v0.16.0` and report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
@@ -61,18 +61,7 @@ Your support helps fund continued development.
 Install the latest beta DMG from GitHub Releases:
 - https://github.com/jasoncavinder/Helm/releases
 
-DMG builds target **Any Mac (Apple Silicon + Intel)** on **macOS 12+** and use standard drag-to-`Applications` installation.
-
-## Support Helm
-
-Helm is an independent project.
-
-If you find it useful, consider supporting development:
-
-- GitHub Sponsors: https://github.com/sponsors/jasoncavinder
-- Patreon: https://patreon.com/yourname
-
-Your support helps fund continued development and long-term sustainability.
+DMG builds target **Any Mac (Apple Silicon + Intel)** on **macOS 11+ (Big Sur)** and use standard drag-to-`Applications` installation.
 
 ## Features
 
@@ -100,7 +89,7 @@ The XPC boundary isolates process execution from the sandboxed app. The Rust cor
 
 ### Prerequisites
 
-- macOS 12+
+- macOS 11+ (Big Sur)
 - Xcode 14+
 - Rust stable toolchain (2024 edition)
 
@@ -138,11 +127,21 @@ Or open `apps/macos-ui/Helm.xcodeproj` in Xcode and run the **Helm** scheme. The
 | 0.14.x | Platform, Detection & Optional Managers — Docker, Xcode, Rosetta, Sparkle | Completed (`v0.14.x` stable, latest patch `v0.14.1`) |
 | 0.15.x | Upgrade Preview & Execution Transparency — bulk preview, scoped execution, failure isolation | Completed (`v0.15.0`) |
 | 0.16.x | Self-Update & Installer Hardening — Sparkle integration, signed verification | Completed (`v0.16.0`) |
+| 0.16.1 | Documentation, Milestone Restructure & Security Staging Clarification | Completed (documentation-only) |
 | 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel | Planned |
-| 0.18.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit | Planned |
+| 0.18.x | Local Security Groundwork — local vulnerability abstractions and cache plumbing (no public feature surface) | Planned |
+| 0.19.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit | Planned |
 | 1.0.0 | Stable Control Plane Release — production-safe execution, full feature set | Planned |
 
 See [`docs/ROADMAP.md`](docs/ROADMAP.md) for the full roadmap through 1.x.
+
+## Security Rollout (Planned)
+
+- **Phase 1 (`0.18.x`)**: Local-only security groundwork. Internal abstractions and data-handling preparation only. No Pro gate and no centralized backend.
+- **Phase 2 (`1.3.x`, Helm Pro)**: **Security Advisory System**. Local-first CVE/advisory evaluation, optional public API queries (OSV/GitHub Advisory DB/NVD-style sources), local TTL cache, and actionable recommendations.
+- **Phase 3 (`1.4.x`)**: **Shared Brain**. Fingerprint sharing, known-fix lookup, centralized Postgres-backed services, and App Attest-based request authentication.
+
+Security Advisory System and Shared Brain are separate systems. Shared Brain is additive and depends on additional infrastructure not required for Phase 2.
 
 ## Repository Layout
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,6 +21,11 @@ Primary goals:
 - Complete transparency of operations
 - Extensibility via adapters
 
+Minimum platform baseline:
+
+- macOS 11+ (Big Sur)
+- Rationale: aligns with modern platform security primitives required for planned App Attest-based install authentication in the Shared Brain stage (`1.4.x`)
+
 Helm is not a shell wrapper. It is a **structured execution engine**.
 
 ---
@@ -361,6 +366,8 @@ Failures:
 
 ## 6. Security Model
 
+### 6.1 Core Execution Security
+
 Helm enforces:
 
 - No shell injection vectors
@@ -368,6 +375,39 @@ Helm enforces:
 - XPC boundary validation
 - Code signing checks
 - Guardrails for privileged operations
+
+### 6.2 Staged Security Rollout
+
+Security capabilities are staged and intentionally separated:
+
+Stage 0 (`<=0.16.x`):
+- Documentation and planning only
+- No implemented security advisory logic
+
+Stage 1 (`0.18.x`):
+- Internal local-only groundwork for vulnerability data handling
+- No public feature exposure
+- No Pro gating
+- No centralized backend
+
+Stage 2 (`1.3.x`) - Security Advisory System (Helm Pro):
+- Local-first CVE/advisory scanning and recommendation engine
+- Optional queries to public advisory APIs (for example OSV / GitHub Advisory Database)
+- Local SQLite cache with TTL-based refresh
+- No Helm-operated central database required
+- No fingerprint sharing
+- No App Attest
+
+Stage 3 (`1.4.x`) - Shared Brain:
+- Centralized fingerprint and known-fix lookup services
+- Managed Postgres backend with edge/serverless API entry points
+- Anonymous per-install auth via Apple App Attest
+- Signed requests, nonce/replay protection, per-install rate limiting, and abuse controls
+
+### 6.3 System Boundary
+
+- The Security Advisory System (`1.3.x`) is independent of Shared Brain and remains functional without Helm-hosted services.
+- Shared Brain (`1.4.x`) is additive infrastructure that can enrich advisory outcomes but is not a prerequisite for local advisory evaluation.
 
 ---
 

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,14 +8,22 @@ It reflects reality, not intention.
 
 ## Version
 
-Current version: **0.16.0** (release finalization in progress on `chore/v0.16.0-release-final`; latest stable release on `main` is `v0.15.0` until `v0.16.0` merge/tag completion)
+Current documentation baseline: **0.16.1** (documentation-only milestone restructuring and staged security planning update).
+
+Implementation baseline remains: **0.16.0** (latest shipped feature release).
 
 See:
 - CHANGELOG.md
 
 Active milestone:
-- 0.16.0 — Self-Update & Installer Hardening (release finalization)
-- 0.15.0 — Released on `main` (tag `v0.15.0`)
+- 0.16.1 — Documentation, roadmap, and architecture clarification (no security feature implementation)
+- 0.17.x — Diagnostics & Logging (next implementation milestone)
+
+Security rollout staging status:
+- Stage 0 (`<=0.16.x`): planning/docs only (active in `0.16.1`)
+- Stage 1 (`0.18.x`): local security groundwork (planned)
+- Stage 2 (`1.3.x`): Security Advisory System (Pro, planned)
+- Stage 3 (`1.4.x`): Shared Brain infrastructure (planned)
 
 ---
 
@@ -488,7 +496,10 @@ Based on the full codebase audit conducted on 2026-02-17 and subsequent beta.3 r
 - "Control Center" item added to right-click status menu (opens dashboard overview)
 
 ### Documentation
-- Security Advisory System incorporated into ROADMAP.md as milestone 1.3.x
+- Security rollout clarified and re-staged in ROADMAP.md:
+  - `0.18.x` reserved for local groundwork
+  - prior `0.18.x` hardening shifted to `0.19.x`
+  - `1.4.x` now reserved for Shared Brain infrastructure
 - CHANGELOG.md, CURRENT_STATE.md, NEXT_STEPS.md updated
 
 ---

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -310,6 +310,31 @@ Policy guardrails:
 
 ---
 
+## Decision 022 — Security Rollout Staging and Platform Baseline
+
+**Decision:**
+Adopt a staged security rollout with explicit milestone separation and set platform baseline to macOS 11+ (Big Sur).
+
+Staging:
+
+- `<=0.16.x`: documentation/planning only (no security advisory implementation)
+- `0.18.x`: local-only internal groundwork
+- `1.3.x`: Security Advisory System (Helm Pro, local-first, optional public advisory API queries)
+- `1.4.x`: Shared Brain (centralized fingerprint/fix services with App Attest-backed request controls)
+
+Version restructuring:
+
+- Existing `0.18.x` hardening scope is moved to `0.19.x`
+- Existing `1.4.x+` milestones are shifted forward by one minor version
+
+**Rationale:**
+
+- Keeps local advisory capabilities independent from centralized infrastructure
+- Reduces coupling and delivery risk by separating local security value from backend-heavy features
+- Aligns future Shared Brain auth requirements with modern platform primitives available from macOS 11+
+
+---
+
 ## Summary
 
 Helm prioritizes:

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -15,10 +15,12 @@ Helm is in:
 ```
 
 Focus:
-- 0.16.x self-update and installer hardening
+- 0.16.1 documentation-only milestone restructuring and staged security planning
+- no security feature implementation in 0.16.x
 
 Current checkpoint:
-- `v0.16.0` release finalization in progress on `chore/v0.16.0-release-final` (final version/docs alignment, release PR flow, merge/tag execution)
+- `v0.16.1` documentation/planning milestone alignment in progress (roadmap, architecture, ADR updates)
+- `v0.16.0` remains the latest implemented feature baseline
 - `v0.15.0` released on `main` (tag `v0.15.0`)
 - `v0.14.0` released (merged to `main`, tagged, manager rollout + docs/version alignment complete)
 - `v0.14.1` released (merged to `main` via `#65`, tagged `v0.14.1`)
@@ -35,8 +37,9 @@ Current checkpoint:
 - `v0.14.0` distribution/licensing architecture planning docs aligned (future-state, no implementation changes)
 
 Next release targets:
-- `v0.16.0` — final release execution (merge/tag/publish)
 - `v0.17.x` — Diagnostics & Logging
+- `v0.18.x` — Local security groundwork (internal-only)
+- `v0.19.x` — Stability & Pre-1.0 hardening
 
 ---
 
@@ -496,7 +499,10 @@ Delivered:
 
 Delivered:
 
-- Security Advisory System milestone added to ROADMAP.md (1.3.x)
+- Security roadmap restructured with staged boundaries:
+  - `0.18.x` local groundwork, `0.19.x` hardening
+  - `1.3.x` Security Advisory System (Pro)
+  - `1.4.x` Shared Brain
 - CHANGELOG.md, CURRENT_STATE.md, NEXT_STEPS.md, ROADMAP.md updated for rc.1
 
 ---

--- a/docs/PROJECT_BRIEF.md
+++ b/docs/PROJECT_BRIEF.md
@@ -157,6 +157,8 @@ System integrity and tooling:
 ## **Platform & UX Choices**
 
 - Menu bar macOS utility (`LSUIElement`, no Dock icon).
+- Minimum platform baseline: **macOS 11+ (Big Sur)**.
+  - Rationale: aligns with planned modern security primitives for future App Attest usage in post-1.0 Shared Brain features.
 - SwiftUI frontend for native look & feel.
 - Floating panel UI from the menu bar icon.
 - Background execution for long-running tasks.
@@ -383,7 +385,7 @@ This scope is planned for 1.x and is not a 1.0 release gate.
 5. `0.9.x` internationalization foundation (completed): centralized locale loading, key-based UI string accessors, locale preference persistence.
 6. `0.10.x` core language manager delivery (completed): npm/pipx/pip/cargo/cargo-binstall end-to-end plus hardening baseline.
 7. `0.11.x-0.12.x` language + localization expansion (completed): extended language adapters (pnpm/yarn/poetry/rubygems/bundler), non-English locale hardening, upgrade preview, dry-run.
-8. `0.13.x-0.18.x` UX/platform, reliability & hardening (in progress — 0.13.x at rc.1): UI/UX analysis and redesign, platform managers (docker/xcode), self-update, diagnostics, stress testing.
+8. `0.13.x-0.19.x` UX/platform, reliability & hardening (in progress): UI/UX analysis and redesign, platform managers (docker/xcode), self-update, diagnostics, security groundwork staging (`0.18.x`), and stress/hardening (`0.19.x`).
 9. `1.0.0` stabilization: release criteria closure, documentation lock, and production readiness sign-off.
 
 ---

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -2,6 +2,20 @@
 
 This checklist is required before creating a release tag on `main`.
 
+## v0.16.1 (Documentation-Only)
+
+### Scope and Documentation
+- [x] `README.md` updated for `macOS 11+ (Big Sur)` minimum and staged security rollout summary.
+- [x] `docs/ROADMAP.md` and website roadmap updated for milestone restructuring (`0.18.x` groundwork, `0.19.x` hardening, `1.4.x` Shared Brain insertion, `1.4.x+` forward shift).
+- [x] `docs/ARCHITECTURE.md` includes staged security model and explicit Security Advisory vs Shared Brain separation.
+- [x] `docs/DECISIONS.md` includes ADR for platform baseline + milestone restructure + system separation.
+- [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect `v0.16.1` docs/planning state and revised milestone sequence.
+- [x] `CHANGELOG.md` and website changelog include `0.16.1` documentation-only release notes.
+
+### Validation
+- [x] Documentation consistency sweep confirms no pre-`1.4.x` placement of Shared Brain infrastructure.
+- [x] Documentation consistency sweep confirms no centralized-backend dependency claims for `1.3.x` Security Advisory System.
+
 ## v0.16.0 (In Progress)
 
 ### Sparkle Feed and Distribution Safety

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -543,7 +543,56 @@ Exit Criteria:
 
 ---
 
-## 0.18.x — Stability & Pre-1.0 Hardening (rc)
+## Security Staging (Planned)
+
+Stage 0 (`<=0.16.x`):
+- Documentation and planning only
+- No security advisory logic implemented
+
+Stage 1 (`0.18.x`):
+- Internal local-only groundwork for vulnerability data handling
+- No public feature exposure
+- No Pro gating
+- No centralized backend
+
+Stage 2 (`1.3.x`) — Security Advisory System (Pro):
+- Local-first CVE/advisory scanning and recommendations
+- Optional public vulnerability API queries
+- Local cache with TTL-based refresh
+- No Helm-operated central database
+- No fingerprint sharing
+- No App Attest
+
+Stage 3 (`1.4.x`) — Shared Brain:
+- Centralized fingerprint database and known-fix lookup
+- Managed Postgres backend and edge/serverless API
+- Anonymous per-install auth with Apple App Attest
+- Request signing, nonce and replay protection, rate limiting, and abuse controls
+
+---
+
+## 0.18.x — Local Security Groundwork (rc)
+
+Goal:
+
+- Local vulnerability data model abstractions in core
+- Manager-agnostic normalization contract for advisory records
+- Local cache schema groundwork (TTL-ready metadata)
+- Task/orchestration hooks for future advisory refresh/evaluation tasks
+- No UI exposure and no user-facing advisory feature gate yet
+- No Pro entitlement gating in this phase
+- No centralized Helm backend in this phase
+
+Exit Criteria:
+
+- Core contracts for local advisory data handling are documented and testable
+- Advisory groundwork paths preserve deterministic task execution
+- No user-facing Security Advisory UI shipped in this milestone
+- No backend dependency introduced
+
+---
+
+## 0.19.x — Stability & Pre-1.0 Hardening (rc)
 
 Goal:
 
@@ -630,14 +679,17 @@ Exit Criteria:
 
 Goal:
 
-- CVE vulnerability awareness for installed packages
-- Local-first advisory evaluation (advisory only, no enforcement)
-- Data sources: OSV.dev, NVD, manager-specific feeds
-- Matching engine: package name + version range → severity + recommendations
-- SQLite-backed advisory cache with periodic refresh
+- Local-first CVE vulnerability awareness for installed packages
+- Advisory-only recommendations (no enforcement)
+- Optional public advisory API queries (OSV.dev, GitHub Advisory Database, NVD, manager-specific feeds)
+- Matching engine: package name + version range -> severity + recommendations
+- SQLite-backed advisory cache with TTL-based refresh
 - UI: vulnerability status, severity badges, and recommended actions per package
 - Offline-capable with cached advisory data
 - Non-blocking: advisory checks never delay operations
+- No Helm-operated central database required
+- No fingerprint sharing in this milestone
+- No App Attest in this milestone
 
 Exit Criteria:
 
@@ -647,10 +699,32 @@ Exit Criteria:
 - Advisory refresh works offline using cached data
 - Advisory evaluation does not block or delay any manager operations
 - Pro edition entitlement gate verified (feature unavailable in Free edition)
+- Implementation works without any Helm-operated backend dependency
 
 ---
 
-## 1.4.x — Business Policy and Drift Management
+## 1.4.x — Shared Brain
+
+Goal:
+
+- Fingerprint sharing for anonymous package/environment signals
+- Known-fix lookup and recommendation enrichment
+- Managed Postgres-backed central data store
+- Edge/serverless API layer for advisory enrichment queries
+- Anonymous per-install authentication via Apple App Attest
+- Request signing, nonce handling, and replay protection
+- Rate limiting per attested install and abuse-detection controls
+
+Exit Criteria:
+
+- Shared Brain API contract is documented and versioned
+- App Attest-based request validation flow is testable end-to-end
+- Security controls (nonce/replay/rate-limit/abuse) are enforced and observable
+- Shared Brain enrichments are additive and do not block local advisory behavior
+
+---
+
+## 1.5.x — Business Policy and Drift Management
 
 Goal:
 
@@ -670,7 +744,7 @@ Exit Criteria:
 
 ---
 
-## 1.5.x — Enterprise Rollout, Approvals, and Audit
+## 1.6.x — Enterprise Rollout, Approvals, and Audit
 
 Goal:
 
@@ -687,7 +761,7 @@ Exit Criteria:
 
 ---
 
-## 1.6.x — Mac App Store Distribution Channel
+## 1.7.x — Mac App Store Distribution Channel
 
 Goal:
 
@@ -703,7 +777,7 @@ Exit Criteria:
 
 ---
 
-## 1.7.x — Setapp Distribution Channel
+## 1.8.x — Setapp Distribution Channel
 
 Goal:
 
@@ -719,7 +793,7 @@ Exit Criteria:
 
 ---
 
-## 1.8.x — Helm Business Fleet Product
+## 1.9.x — Helm Business Fleet Product
 
 Goal:
 
@@ -735,7 +809,7 @@ Exit Criteria:
 
 ---
 
-## 1.9.x — PKG + MDM Deployment and Offline Licensing
+## 1.10.x — PKG + MDM Deployment and Offline Licensing
 
 Goal:
 

--- a/docs/enterprise/BUSINESS_CENTRAL_MANAGEMENT_SPEC.md
+++ b/docs/enterprise/BUSINESS_CENTRAL_MANAGEMENT_SPEC.md
@@ -174,7 +174,7 @@ Helm is authoritative for package-manager policy execution.
 Business central management features are delivered across three post-1.0 milestones (see `docs/ROADMAP.md`):
 
 1. **1.2.x** (Editions and Entitlement Foundations): entitlement scaffolding + managed bootstrap + policy snapshot store
-2. **1.4.x** (Business Policy and Drift Management): scoped policy evaluation + drift detection + compliance reporting
-3. **1.5.x** (Enterprise Rollout, Approvals, and Audit): rollout rings + approvals + audit export integrations
+2. **1.5.x** (Business Policy and Drift Management): scoped policy evaluation + drift detection + compliance reporting
+3. **1.6.x** (Enterprise Rollout, Approvals, and Audit): rollout rings + approvals + audit export integrations
 
-Note: Milestones 1.1.x (Globalization Expansion) and 1.3.x (Security Advisory System, Pro tier) are interleaved between these but are not part of the business central management scope.
+Note: Milestones 1.1.x (Globalization Expansion), 1.3.x (Security Advisory System, Pro tier), and 1.4.x (Shared Brain infrastructure) are interleaved between these but are not part of the business central management scope.

--- a/web/src/content/docs/changelog.md
+++ b/web/src/content/docs/changelog.md
@@ -9,6 +9,20 @@ For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncav
 
 ---
 
+## 0.16.1 — 2026-02-21
+
+### Changed
+- Documentation-only rollout restructuring (no security feature implementation shipped).
+- Added staged security model:
+  - Stage 1 (`0.18.x`) local internal groundwork
+  - Stage 2 (`1.3.x`) Security Advisory System (Pro, local-first, optional public advisory APIs, local TTL cache)
+  - Stage 3 (`1.4.x`) Shared Brain (fingerprint sharing, known-fix lookup, centralized backend, App Attest controls)
+- Moved previous `0.18.x` hardening scope to `0.19.x`.
+- Shifted previous `1.4.x+` roadmap milestones forward by one minor version.
+- Updated documented minimum platform to `macOS 11+ (Big Sur)` in README/website installation references.
+
+---
+
 ## 0.16.0 — 2026-02-21
 
 ### Added

--- a/web/src/content/docs/guides/faq.md
+++ b/web/src/content/docs/guides/faq.md
@@ -28,7 +28,7 @@ Helm is currently in pre-1.0 beta with all features available. Post-1.0 planning
 
 ### What macOS versions are supported?
 
-Helm requires macOS 12 (Monterey) or later and runs natively on both Apple Silicon and Intel Macs.
+Helm requires macOS 11 (Big Sur) or later and runs natively on both Apple Silicon and Intel Macs.
 
 ### Does Helm require administrator privileges?
 
@@ -93,7 +93,7 @@ This only needs to be done once. After that, the app opens normally.
 
 ### How do I build from source?
 
-See the [Installation guide](/guides/installation/) for prerequisites and build steps. You'll need macOS 12+, Xcode 14+, and a Rust stable toolchain.
+See the [Installation guide](/guides/installation/) for prerequisites and build steps. You'll need macOS 11+ (Big Sur), Xcode 14+, and a Rust stable toolchain.
 
 ---
 

--- a/web/src/content/docs/guides/installation.md
+++ b/web/src/content/docs/guides/installation.md
@@ -15,11 +15,11 @@ When you open the DMG, install like a standard macOS app:
 2. Launch Helm from `Applications`.
 3. If macOS prompts, confirm opening the app and grant requested permissions.
 
-The beta DMG is built for **Any Mac (Apple Silicon + Intel)** with a **macOS 12+** deployment target.
+The beta DMG is built for **Any Mac (Apple Silicon + Intel)** with a **macOS 11+ (Big Sur)** minimum target.
 
 ## Prerequisites
 
-- macOS 12 (Monterey) or later
+- macOS 11 (Big Sur) or later
 - Xcode 14+
 - Rust stable toolchain (2024 edition)
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -39,7 +39,8 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 | Version | Milestone |
 |---|---|
 | 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel |
-| 0.18.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit |
+| 0.18.x | Local Security Groundwork — local vulnerability abstractions and cache plumbing (internal only) |
+| 0.19.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit |
 | 1.0.0 | Stable Control Plane Release — production-safe execution, full feature set |
 
 ## Post-1.0
@@ -48,13 +49,14 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 |---|---|
 | 1.1.x | Globalization Expansion — additional locales (zh-Hans, ko, it, nl), website localization |
 | 1.2.x | Editions and Entitlement Foundations — channel-aware build matrix and entitlement boundaries for consumer and fleet products |
-| 1.3.x | Security Advisory System (Pro) — CVE awareness, local-first advisory evaluation |
-| 1.4.x | Business Policy and Drift Management — scoped policy, baseline enforcement, compliance reporting |
-| 1.5.x | Enterprise Rollout, Approvals, and Audit — ring-based rollout, approval workflows, audit export |
-| 1.6.x | Mac App Store Distribution Channel — consumer MAS lifecycle and App Store authority alignment |
-| 1.7.x | Setapp Distribution Channel — consumer Setapp lifecycle and channel authority alignment |
-| 1.8.x | Helm Business Fleet Product — separate business binary and lifecycle from consumer releases |
-| 1.9.x | PKG + MDM Deployment and Offline Licensing — fleet deployment workflow and offline org licensing model |
+| 1.3.x | Security Advisory System (Pro) — local-first CVE scanning, optional public advisory API queries, local TTL cache |
+| 1.4.x | Shared Brain — fingerprint sharing, known-fix lookup, centralized Postgres services, App Attest auth |
+| 1.5.x | Business Policy and Drift Management — scoped policy, baseline enforcement, compliance reporting |
+| 1.6.x | Enterprise Rollout, Approvals, and Audit — ring-based rollout, approval workflows, audit export |
+| 1.7.x | Mac App Store Distribution Channel — consumer MAS lifecycle and App Store authority alignment |
+| 1.8.x | Setapp Distribution Channel — consumer Setapp lifecycle and channel authority alignment |
+| 1.9.x | Helm Business Fleet Product — separate business binary and lifecycle from consumer releases |
+| 1.10.x | PKG + MDM Deployment and Offline Licensing — fleet deployment workflow and offline org licensing model |
 
 ## Details
 


### PR DESCRIPTION
## Summary
- align docs to a documentation-only v0.16.1 milestone with no security feature implementation
- introduce staged security rollout boundaries across README/architecture/roadmap (Stage 1 local groundwork, Stage 2 Security Advisory System, Stage 3 Shared Brain)
- restructure milestone versions (0.18.x groundwork, 0.19.x hardening, 1.4.x Shared Brain insertion, and 1.4.x+ forward shift)
- set documented minimum platform baseline to macOS 11+ (Big Sur)
- update ADR/changelog/release checklist and website roadmap/changelog/install docs for consistency

## Scope
- documentation and planning only
- no Swift/Rust feature implementation
- no backend infrastructure changes

## Validation
- global doc consistency grep for milestone/version/platform references
- verified no pre-1.4.x placement of Shared Brain infrastructure
- verified no 1.3.x dependency on Helm-operated centralized backend