### PR TITLE
docs: add app design refinement reminder in 0.19.x roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -613,6 +613,9 @@ Goal:
   - ICU syntax validation
 - UI validation for text expansion
 - Localization fallback behavior tested
+- App Design Refinement (planned):
+  - finalize production typography direction across app/website
+  - reminder: purchase Neue Haas Grotesk commercial license before shipping it in product branding
 
 Exit Criteria:
 


### PR DESCRIPTION
## Summary
- add an App Design Refinement note to the 0.19.x milestone in the roadmap
- include a reminder to purchase Neue Haas Grotesk commercial license before shipping it in product branding

## Scope
- documentation-only
- single file change: docs/ROADMAP.md