### PR TITLE
feat: redesign website and refresh docs accessibility

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -119,14 +119,32 @@ Validation snapshot for `v0.11.0-beta.1` expansion:
 
 ## Website Status
 
-- Astro + Starlight website now uses a Helm-brand custom theme layer via `web/src/styles/helm-theme.css`
-- Landing page (`web/src/content/docs/index.mdx`) has been redesigned to match brand/copy structure:
+- Astro + Starlight website uses a Helm-brand custom theme layer via `web/src/styles/helm-theme.css` with tokenized color/motion/shape rules aligned to brand docs.
+- Landing page (`web/src/content/docs/index.mdx`) has been redesigned with a calmer dual-audience narrative and command-bridge structure:
   - Hero
   - Problem
   - Solution
-  - Command Bridge
+  - Editions (Helm consumer + Helm Business)
+  - Architecture
   - Helm Pro
   - Footer CTA
+- Website typography/color system now follows explicit Helm website spec:
+  - headings: Neue Haas Grotesk stack
+  - body: Inter
+  - code: SF Mono
+  - light/dark heading color mapping and restrained gold usage for Pro accents
+- Website content/docs pass completed for product clarity and audience fit:
+  - updated overview/roadmap/changelog wording for current `v0.16.0` release-finalization state
+  - expanded consumer vs Helm Business messaging in overview + FAQ
+  - refreshed installation/usage/visual-tour guide copy for current UI/support surfaces
+- Website accessibility verification pass completed:
+  - automated Axe CLI audit executed across key routes (`/`, overview, usage, installation, FAQ, visual-tour, licensing, changelog, roadmap)
+  - fixed homepage hero secondary CTA contrast issue (`color-contrast` on `.actions > .secondary.sl-link-button.not-content`)
+  - post-fix Axe run reports zero violations on audited routes
+  - keyboard focus-visible styling present for links/buttons/navigation
+  - reduced-motion media query support present for animated interactions
+  - heading hierarchy on key pages has no level-skip violations
+  - key text/background contrast pairs meet AA or better (with most body text at AAA)
 - Website redesign planning artifacts added:
   - `docs/website/WEBSITE_REDESIGN_PLAN.md`
   - `docs/website/DESIGN_TOKENS.md`

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -123,7 +123,7 @@ Delivered:
 
 ---
 
-## Website Workstream (2026-02-20)
+## Website Workstream (2026-02-21)
 
 Completed:
 
@@ -133,17 +133,33 @@ Completed:
 - Implemented a custom Helm visual theme for the Astro/Starlight site:
   - `web/src/styles/helm-theme.css`
   - wired through `web/astro.config.mjs`
-- Rebuilt landing page structure and copy hierarchy in `web/src/content/docs/index.mdx` to match:
+- Rebuilt landing page structure and copy hierarchy in `web/src/content/docs/index.mdx` with dual-audience framing:
   - Hero
   - Problem
   - Solution
-  - Command Bridge
+  - Editions (Helm consumer + Helm Business)
+  - Architecture
   - Helm Pro
   - Footer CTA
+- Applied explicit Helm website typography/color specification in `web/src/styles/helm-theme.css`:
+  - Neue Haas Grotesk heading stack, Inter body text, SF Mono code
+  - specified H1/H2/H3/body/small scale and heading color mapping by theme
+  - 8pt spacing rhythm and restrained Pro-only gold accents
+  - calm, structured visual tone (no neon/startup-style hero effects)
+- Completed website content alignment pass across docs pages:
+  - updated release-status wording consistency for `v0.16.0` release finalization
+  - clarified consumer vs Helm Business positioning in overview + FAQ
+  - refreshed installation/usage/visual-tour copy for current UX
+- Completed manual accessibility verification pass for key routes:
+  - automated Axe CLI scan across key website routes reports zero violations after remediation
+  - patched homepage hero secondary CTA contrast to resolve Axe `color-contrast` failure
+  - verified heading hierarchy and image alt coverage on docs content
+  - verified focus-visible and reduced-motion support in theme CSS
 
 Immediate follow-up:
 
 - Perform manual visual QA in both light and dark theme across mobile/tablet/desktop breakpoints before release publishing.
+- Replace visual-tour screenshots after UI styling refresh in `web/src/assets/tour/` and re-run manual QA.
 
 ---
 

--- a/web/src/content/docs/changelog.md
+++ b/web/src/content/docs/changelog.md
@@ -7,6 +7,8 @@ All notable changes to Helm are documented here. The format is based on [Keep a 
 
 For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncavinder/Helm/blob/main/CHANGELOG.md).
 
+> Latest entries below reflect the current release-finalization snapshots.
+
 ---
 
 ## 0.16.1 — 2026-02-21
@@ -23,7 +25,7 @@ For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncav
 
 ---
 
-## 0.16.0 — 2026-02-21
+## 0.16.0 — 2026-02-21 (Release Finalization Snapshot)
 
 ### Added
 - Channel-aware update configuration and direct-channel Sparkle integration scaffolding in the macOS app.

--- a/web/src/content/docs/guides/faq.md
+++ b/web/src/content/docs/guides/faq.md
@@ -26,6 +26,10 @@ Helm currently supports twenty-eight managers across six categories:
 
 Helm is currently in pre-1.0 beta with all features available. Post-1.0 planning includes Helm (Consumer: Free + Pro) and Helm Business (Fleet) as a separate product lifecycle. See the [licensing page](/licensing/) for details.
 
+### Is Helm Business included in the consumer app?
+
+No. Helm Business is planned as a separate fleet product lifecycle, not a hidden mode inside the consumer app.
+
 ### What macOS versions are supported?
 
 Helm requires macOS 11 (Big Sur) or later and runs natively on both Apple Silicon and Intel Macs.

--- a/web/src/content/docs/guides/installation.md
+++ b/web/src/content/docs/guides/installation.md
@@ -3,9 +3,9 @@ title: Installation
 description: Build and run Helm from source.
 ---
 
-Helm is pre-1.0 software and now ships beta binaries in addition to source builds.
+Helm is pre-1.0 software and ships signed test binaries in addition to source builds.
 
-## Download Beta DMG (Recommended)
+## Download DMG (Recommended)
 
 Download the latest beta DMG from GitHub Releases:
 - [Helm Releases](https://github.com/jasoncavinder/Helm/releases)
@@ -15,7 +15,7 @@ When you open the DMG, install like a standard macOS app:
 2. Launch Helm from `Applications`.
 3. If macOS prompts, confirm opening the app and grant requested permissions.
 
-The beta DMG is built for **Any Mac (Apple Silicon + Intel)** with a **macOS 11+ (Big Sur)** minimum target.
+The DMG is built for **Any Mac (Apple Silicon + Intel)** with a **macOS 11+ (Big Sur)** minimum target.
 
 ## Prerequisites
 

--- a/web/src/content/docs/guides/usage.md
+++ b/web/src/content/docs/guides/usage.md
@@ -25,6 +25,8 @@ The Control Center is a standalone window with sidebar navigation across six dom
 5. **Managers** — per-manager health, capabilities, and configuration
 6. **Settings** — cadence, policy, localization, accessibility, and diagnostics
 
+The Settings surface also includes **Support & Feedback** actions for bug reports, feature requests, and diagnostics copy/export.
+
 ## Inspector Sidebar
 
 Selecting any task, package, or manager in the Control Center opens the **inspector sidebar** on the right. It shows contextual detail: version delta, pin state, manager attribution, available actions, task logs, or manager capabilities — depending on what is selected.

--- a/web/src/content/docs/guides/visual-tour.mdx
+++ b/web/src/content/docs/guides/visual-tour.mdx
@@ -8,7 +8,7 @@ import { Aside } from '@astrojs/starlight/components';
 Helm has two main surfaces: a **menu bar popover** for quick triage and a **Control Center window** for deeper management. This tour walks through each.
 
 <Aside type="note">
-Screenshots show Helm v0.13.0 on macOS. The interface may vary slightly between versions.
+Screenshots show Helm `v0.16.0` UI surfaces on macOS. Minor styling may change between builds, and screenshot refreshes are applied as new app captures are published.
 </Aside>
 
 ---

--- a/web/src/content/docs/index.mdx
+++ b/web/src/content/docs/index.mdx
@@ -4,7 +4,7 @@ description: Take the helm. Operational clarity for macOS toolchains.
 template: splash
 hero:
   title: "Take the helm."
-  tagline: "Helm centralizes your toolchain and restores operational clarity across package managers."
+  tagline: "Helm centralizes package and toolchain operations across macOS environments with deterministic, auditable workflows."
   image:
     file: ../../assets/tour/control-center-overview.png
     alt: "Helm Control Center showing manager and package status."
@@ -20,119 +20,140 @@ hero:
 ---
 
 import { LinkButton } from '@astrojs/starlight/components';
-import menuBarPopover from '../../assets/tour/menu-bar-popover-dark.png';
+import statusMenuShot from '../../assets/tour/status-menu.png';
 
 <div class="landing-shell">
+  <nav class="landing-nav" aria-label="Section navigation">
+    <a href="#problem">Problem</a>
+    <a href="#solution">Solution</a>
+    <a href="#audiences">Editions</a>
+    <a href="#architecture">Architecture</a>
+    <a href="#pro">Helm Pro</a>
+  </nav>
+
   <section id="problem" class="landing-section">
     <div class="section-head">
-      <p class="landing-kicker"><span class="section-index">01</span> Problem</p>
-      <h2>Modern development environments are fragmented.</h2>
+      <p class="section-kicker">Problem</p>
+      <h2>Modern macOS environments are operationally fragmented.</h2>
     </div>
-    <div class="landing-problem-grid">
-      <div class="landing-problem-copy">
-        <p>Homebrew. npm. pip. cargo. RubyGems.</p>
-        <p>Each manages its own universe.</p>
-        <p>Your system state becomes opaque.</p>
-        <p>Updates break silently.</p>
-        <p>You lose visibility.</p>
+    <div class="split-grid">
+      <div class="panel body-lg">
+        <p>Homebrew, npm, pip, cargo, and runtime managers all maintain separate state.</p>
+        <p>Developers lose visibility, and platform teams inherit drift, brittle scripts, and inconsistent update behavior.</p>
       </div>
-      <div class="fragmentation-map">
-        <p class="fragmentation-map-title">Typical fragmented manager surface</p>
-        <div class="manager-chip-grid">
-          <div class="manager-chip">Homebrew</div>
-          <div class="manager-chip">npm</div>
-          <div class="manager-chip">pip</div>
-          <div class="manager-chip">cargo</div>
-          <div class="manager-chip">RubyGems</div>
-          <div class="manager-chip">rustup</div>
-        </div>
+      <div class="panel panel-compact">
+        <h3>Common failure pattern</h3>
+        <ul>
+          <li>Toolchain and package updates run out of order</li>
+          <li>No shared, auditable execution view</li>
+          <li>Breakage is discovered only after impact</li>
+        </ul>
       </div>
     </div>
   </section>
 
   <section id="solution" class="landing-section">
     <div class="section-head">
-      <p class="landing-kicker"><span class="section-index">02</span> Solution</p>
-      <h2>Helm restores control.</h2>
+      <p class="section-kicker">Solution</p>
+      <h2>Helm provides one command bridge for package operations.</h2>
     </div>
-    <ul class="feature-list">
-      <li class="feature-item">
-        <h3>Unified visibility across managers</h3>
-        <p>One control plane for package and toolchain state.</p>
-      </li>
-      <li class="feature-item">
-        <h3>Centralized upgrade strategy</h3>
-        <p>Operator-friendly execution order with clear manager context.</p>
-      </li>
-      <li class="feature-item">
-        <h3>Deterministic system state</h3>
-        <p>Deterministic actions and traceable outcomes.</p>
-      </li>
-      <li class="feature-item">
-        <h3>Clear update history</h3>
-        <p>Auditable task records and explicit status.</p>
-      </li>
-      <li class="feature-item pro">
-        <h3>CVE awareness <span class="pro-inline-badge">Pro</span></h3>
-        <p>Security context for risk-aware upgrade decisions.</p>
-      </li>
-    </ul>
-    <p class="landing-close-line">Your system. Clearly understood.</p>
+    <div class="card-grid">
+      <article class="panel capability-card">
+        <h3>Unified visibility</h3>
+        <p>Installed, outdated, and available state across managers in one control surface.</p>
+      </article>
+      <article class="panel capability-card">
+        <h3>Deterministic orchestration</h3>
+        <p>Authority-ordered execution with explicit task lifecycle and cancellation.</p>
+      </article>
+      <article class="panel capability-card">
+        <h3>Operational clarity</h3>
+        <p>Structured logs and manager/task/action attribution for reliable diagnosis.</p>
+      </article>
+      <article class="panel capability-card">
+        <h3>Local-first behavior</h3>
+        <p>Fast local search and progressive enrichment without cloud dependence.</p>
+      </article>
+    </div>
   </section>
 
-  <section id="command-bridge" class="landing-section">
+  <section id="audiences" class="landing-section">
     <div class="section-head">
-      <p class="landing-kicker"><span class="section-index">03</span> Command Bridge</p>
-      <h2>Think of Helm as your command bridge.</h2>
+      <p class="section-kicker">Editions</p>
+      <h2>Built for individual developers and enterprise platform teams.</h2>
     </div>
-    <div class="landing-command-grid">
-      <div>
-        <p>One interface. All managers. Total visibility.</p>
-        <p>Helm gives operators a stable, centralized control surface for routine maintenance.</p>
-      </div>
-      <div class="bridge-diagram">
-        <div class="bridge-grid">
-          <div class="bridge-node"><strong>Inputs</strong><br />brew, npm, pip, cargo, rustup</div>
-          <div class="bridge-arrow">-&gt;</div>
-          <div class="bridge-core"><strong>Helm Core</strong><br />Orchestration + task visibility</div>
-          <div class="bridge-arrow">-&gt;</div>
-          <div class="bridge-node"><strong>Output</strong><br />Clear system state</div>
+    <div class="split-grid">
+      <article class="panel edition-card">
+        <p class="edition-label">Helm (Consumer)</p>
+        <h3>Daily control for developers</h3>
+        <p>Menu bar-native workflows for maintaining package and toolchain state without terminal overhead.</p>
+        <LinkButton href="/guides/usage/" icon="right-arrow" variant="minimal">Usage guide</LinkButton>
+      </article>
+      <article class="panel edition-card">
+        <p class="edition-label">Helm Business</p>
+        <h3>Governance workflows for organizations</h3>
+        <p>Policy-oriented, auditable operations for managed macOS development environments.</p>
+        <LinkButton href="/product-overview/" icon="right-arrow" variant="minimal">Product overview</LinkButton>
+      </article>
+    </div>
+  </section>
+
+  <section id="architecture" class="landing-section">
+    <div class="section-head">
+      <p class="section-kicker">Architecture</p>
+      <h2>Structured around UI, service boundary, and deterministic core.</h2>
+    </div>
+    <div class="split-grid architecture-grid">
+      <div class="panel panel-stack">
+        <div class="lane">
+          <p class="lane-label">UI</p>
+          <p>SwiftUI presentation layer for state and operator intent.</p>
         </div>
-        <img class="bridge-shot" src={menuBarPopover.src} alt="Helm menu bar popover with update status and tasks." loading="lazy" />
+        <div class="lane-arrow">↓</div>
+        <div class="lane">
+          <p class="lane-label">Service</p>
+          <p>XPC boundary for process isolation and execution control.</p>
+        </div>
+        <div class="lane-arrow">↓</div>
+        <div class="lane">
+          <p class="lane-label">Core</p>
+          <p>Rust adapters, orchestration, persistence, and policy enforcement.</p>
+        </div>
+      </div>
+      <div class="panel media-panel">
+        <img src={statusMenuShot.src} alt="Helm status menu with tasks and quick actions." loading="lazy" />
       </div>
     </div>
   </section>
 
-  <section id="helm-pro" class="landing-section">
+  <section id="pro" class="landing-section">
     <div class="section-head">
-      <p class="landing-kicker"><span class="section-index">04</span> Helm Pro</p>
-      <h2>Helm Pro adds advanced system intelligence.</h2>
+      <p class="section-kicker">Helm Pro</p>
+      <h2>Advanced operational intelligence for high-control environments.</h2>
     </div>
-    <div class="pro-panel">
-      <ul class="pro-list">
-        <li>CVE detection</li>
+    <div class="panel pro-panel">
+      <p class="pro-badge">Pro</p>
+      <ul>
+        <li>CVE awareness</li>
         <li>Priority upgrade recommendations</li>
         <li>Audit-ready update history</li>
         <li>Proactive risk insights</li>
       </ul>
-      <p>Professional-grade control for serious builders.</p>
+      <LinkButton href="/licensing/" icon="right-arrow" variant="secondary">Edition and licensing details</LinkButton>
     </div>
   </section>
 
-  <section class="landing-section footer-cta">
-    <div class="section-head">
-      <p class="landing-kicker"><span class="section-index">05</span> Get Helm</p>
+  <section class="landing-section panel cta-panel">
+    <div>
+      <p class="section-kicker">Get Helm</p>
+      <h2>Take the helm.</h2>
+      <p>Download Helm for macOS and run updates with operational clarity.</p>
     </div>
-    <h2>Take the helm.</h2>
-    <p>Download Helm for macOS.</p>
-    <div class="footer-cta-actions">
+    <div class="cta-actions">
       <LinkButton href="https://github.com/jasoncavinder/Helm/releases/latest/download/Helm.dmg" icon="download" variant="primary">Download Helm</LinkButton>
       <LinkButton href="https://github.com/jasoncavinder/Helm" icon="external" variant="secondary">View on GitHub</LinkButton>
-      <LinkButton href="/product-overview/" icon="right-arrow" variant="minimal">Product overview</LinkButton>
-      <LinkButton href="/product-roadmap/" icon="document" variant="minimal">Roadmap</LinkButton>
+      <LinkButton href="/product-roadmap/" icon="document" variant="minimal">Product roadmap</LinkButton>
     </div>
-    <p class="release-note">
-      Helm is currently source-available under a non-commercial license. See the <a href="/licensing/">licensing page</a> for details.
-    </p>
+    <p class="small-note">Helm is currently source-available under a non-commercial license.</p>
   </section>
 </div>

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -8,11 +8,16 @@ Helm is a native macOS menu bar app that gives you a single control plane for al
 
 ## Who is Helm for?
 
-Developers and power users on macOS who manage software through multiple package managers and want a unified, safe way to keep everything up to date.
+Helm serves two operational audiences:
+
+- **Developers and power users on macOS** who want one local control plane for package and toolchain updates.
+- **Platform, IT, and security teams** that need deterministic, auditable workflows for managed development environments.
+
+Helm is planned as two product lifecycles: **Helm (Consumer)** and **Helm Business (Fleet)**.
 
 ## What it does today
 
-Helm v0.16.0 supports twenty-eight managers:
+Helm `v0.16.x` supports twenty-eight managers:
 
 | Category | Managers |
 |---------|----------|
@@ -40,7 +45,7 @@ Key features:
 - **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, and `ja` with locale override in Settings
 - **Upgrade transparency** — dedicated upgrade preview surface with scoped execution and failure-attribution visibility
 
-> **Testing Program:** `v0.16.0` is available for pre-1.0 testing. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.16.0` release finalization is in progress for pre-1.0 testing. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## How it works
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -30,9 +30,9 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 | 0.13.x | UI/UX Analysis & Redesign — full UX audit, interaction model, visual system refresh, accessibility, onboarding walkthrough, inspector sidebar, support & feedback entry points (`v0.13.0` stable released) |
 | 0.14.x | Platform, Detection & Optional Managers — Docker, Xcode, Rosetta, Sparkle, Setapp, Homebrew casks, optional managers (`v0.14.x` stable, latest patch `v0.14.1`) |
 | 0.15.x | Advanced Upgrade Transparency — richer execution-plan visibility, failure isolation, and operator controls (`v0.15.0` released) |
-| 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification (`v0.16.0` released) |
+| 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification (`v0.16.0` release finalization in progress) |
 
-> **Testing:** `v0.16.0` is available. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Testing:** `v0.16.0` is in pre-1.0 release finalization. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Planned
 

--- a/web/src/styles/helm-theme.css
+++ b/web/src/styles/helm-theme.css
@@ -4,72 +4,73 @@
   --helm-blue-700: #2a5da8;
   --helm-blue-500: #3c7dd9;
   --helm-blue-300: #6ca6e8;
-  --helm-gold-700: #a97e2a;
-  --helm-gold-500: #c89c3d;
-  --helm-bg-dark: #0e1624;
-  --helm-panel-dark: #141e2f;
-  --helm-divider-dark: #24324a;
-  --helm-text-dark: #e6edf6;
-  --helm-text-dark-secondary: #9fb0c7;
-  --helm-bg-light: #f5f7fa;
-  --helm-panel-light: #ffffff;
-  --helm-divider-light: #e2e6ec;
-  --helm-text-light: #1c1f26;
-  --helm-text-light-secondary: #4b5563;
-  --helm-critical: #d64545;
 
-  --sl-font:
-    "Inter",
-    "SF Pro Text",
-    "SF Pro Display",
-    "IBM Plex Sans",
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    sans-serif;
-  --helm-font-display:
-    "IBM Plex Sans",
-    "Inter",
-    "SF Pro Display",
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    sans-serif;
-  --sl-font-mono:
-    "SF Mono",
-    "IBM Plex Mono",
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    monospace;
+  --helm-gold-500: #c89c3d;
+  --helm-gold-700: #a97e2a;
+
+  --bg-light: #f5f7fa;
+  --panel-light: #ffffff;
+  --divider-light: #e2e6ec;
+  --text-primary: #1c1f26;
+  --text-secondary: #4b5563;
+
+  --bg-dark: #0e1624;
+  --panel-dark: #141e2f;
+  --divider-dark: #24324a;
+  --text-dark-primary: #e6edf6;
+  --text-dark-secondary: #9fb0c7;
+
+  --space-1: 8px;
+  --space-2: 16px;
+  --space-3: 24px;
+  --space-4: 32px;
+  --space-5: 40px;
+  --space-6: 48px;
+
+  --radius-sm: 12px;
+  --radius-md: 14px;
+  --radius-lg: 16px;
+
+  --shadow-soft: 0 8px 24px rgba(12, 20, 34, 0.1);
+  --shadow-soft-dark: 0 12px 26px rgba(0, 0, 0, 0.26);
+
+  --motion-fast: 180ms ease-out;
+  --motion-base: 220ms ease-out;
+
+  --font-heading: "Neue Haas Grotesk Display Pro", "Neue Haas Grotesk Text Pro", "Neue Haas Grotesk", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-body: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-code: "SF Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  --sl-font: var(--font-body);
+  --sl-font-mono: var(--font-code);
 
   --sl-color-accent-low: #1b3a66;
   --sl-color-accent: #3c7dd9;
   --sl-color-accent-high: #6ca6e8;
-  --sl-color-bg: var(--helm-bg-dark);
-  --sl-color-bg-nav: rgba(14, 22, 36, 0.92);
-  --sl-color-bg-sidebar: #111b2a;
-  --sl-color-bg-inline-code: #1a2740;
+
+  --sl-color-bg: var(--bg-dark);
+  --sl-color-bg-nav: rgba(14, 22, 36, 0.95);
+  --sl-color-bg-sidebar: #111a2a;
+  --sl-color-bg-inline-code: #1d2a3f;
   --sl-color-text: #c4d3e8;
-  --sl-color-text-accent: #d9e8ff;
-  --sl-color-text-invert: #f4f8ff;
-  --sl-color-hairline: var(--helm-divider-dark);
-  --sl-color-hairline-light: #2d3e5d;
-  --sl-color-hairline-shade: #0c1421;
-  --sl-color-white: var(--helm-text-dark);
-  --sl-color-black: var(--helm-bg-dark);
-  --sl-color-blue-low: #16253e;
+  --sl-color-text-accent: #e7f0fc;
+  --sl-color-text-invert: #ffffff;
+  --sl-color-hairline: var(--divider-dark);
+  --sl-color-hairline-light: #2d3d5a;
+  --sl-color-hairline-shade: #0b1320;
+  --sl-color-white: var(--text-dark-primary);
+  --sl-color-black: var(--bg-dark);
+  --sl-color-blue-low: #182845;
   --sl-color-blue: var(--helm-blue-500);
-  --sl-color-blue-high: #9dc5f2;
-  --sl-color-purple-low: #16253e;
+  --sl-color-blue-high: #a8c9f0;
+  --sl-color-purple-low: #182845;
   --sl-color-purple: var(--helm-blue-500);
-  --sl-color-purple-high: #9dc5f2;
-  --sl-color-orange-low: #31260f;
+  --sl-color-purple-high: #a8c9f0;
+  --sl-color-orange-low: #30260f;
   --sl-color-orange: var(--helm-gold-500);
-  --sl-color-orange-high: #e8cc92;
+  --sl-color-orange-high: #e7cd97;
   --sl-color-red-low: #3f1f25;
-  --sl-color-red: var(--helm-critical);
+  --sl-color-red: #d64545;
   --sl-color-red-high: #f0a8b2;
   --sl-color-gray-1: #f3f7fc;
   --sl-color-gray-2: #d3deee;
@@ -78,42 +79,29 @@
   --sl-color-gray-5: #2a3a55;
   --sl-color-gray-6: #162334;
 
-  --sl-shadow-sm: 0 3px 10px rgba(4, 11, 21, 0.22);
-  --sl-shadow-md: 0 8px 24px rgba(4, 10, 20, 0.28);
-  --sl-shadow-lg: 0 18px 36px rgba(2, 7, 15, 0.32);
-
-  --helm-page-gradient-dark:
-    radial-gradient(900px 420px at 80% -10%, rgba(60, 125, 217, 0.16), transparent 65%),
-    linear-gradient(180deg, #0f1828 0%, #0e1624 100%);
-  --helm-page-gradient-light:
-    radial-gradient(900px 420px at 80% -10%, rgba(60, 125, 217, 0.1), transparent 65%),
-    linear-gradient(180deg, #f7f9fc 0%, #f5f7fa 100%);
-
-  --helm-radius-sm: 12px;
-  --helm-radius-md: 14px;
-  --helm-radius-lg: 16px;
-  --helm-section-space: clamp(3.25rem, 5vw, 6rem);
-  --helm-transition-fast: 180ms ease-out;
-  --helm-transition-base: 220ms ease-out;
+  --sl-shadow-sm: var(--shadow-soft-dark);
+  --sl-shadow-md: 0 16px 34px rgba(0, 0, 0, 0.3);
+  --sl-shadow-lg: 0 20px 40px rgba(0, 0, 0, 0.34);
 }
 
 :root[data-theme="light"],
 [data-theme="light"] ::backdrop {
-  --sl-color-accent-low: #d5e4f7;
+  --sl-color-accent-low: #d7e5f8;
   --sl-color-accent: #2a5da8;
   --sl-color-accent-high: #1b3a66;
-  --sl-color-bg: var(--helm-bg-light);
-  --sl-color-bg-nav: rgba(245, 247, 250, 0.98);
+
+  --sl-color-bg: var(--bg-light);
+  --sl-color-bg-nav: rgba(245, 247, 250, 0.96);
   --sl-color-bg-sidebar: #f6f8fb;
   --sl-color-bg-inline-code: #e9eff8;
   --sl-color-text: #3f4a5c;
-  --sl-color-text-accent: var(--helm-blue-700);
+  --sl-color-text-accent: #1c1f26;
   --sl-color-text-invert: #ffffff;
-  --sl-color-hairline: var(--helm-divider-light);
+  --sl-color-hairline: var(--divider-light);
   --sl-color-hairline-light: #d8dee9;
   --sl-color-hairline-shade: #e3e8f0;
-  --sl-color-white: var(--helm-text-light);
-  --sl-color-black: var(--helm-panel-light);
+  --sl-color-white: var(--text-primary);
+  --sl-color-black: var(--panel-light);
   --sl-color-blue-low: #e6effb;
   --sl-color-blue: #2a5da8;
   --sl-color-blue-high: #1b3a66;
@@ -124,7 +112,7 @@
   --sl-color-orange: var(--helm-gold-500);
   --sl-color-orange-high: #6b511b;
   --sl-color-red-low: #fbecef;
-  --sl-color-red: var(--helm-critical);
+  --sl-color-red: #d64545;
   --sl-color-red-high: #801925;
   --sl-color-gray-1: #1c1f26;
   --sl-color-gray-2: #2f3742;
@@ -134,58 +122,48 @@
   --sl-color-gray-6: #e9edf5;
   --sl-color-gray-7: #ffffff;
 
-  --sl-shadow-sm: 0 2px 8px rgba(16, 28, 48, 0.08);
-  --sl-shadow-md: 0 8px 22px rgba(16, 28, 48, 0.11);
-  --sl-shadow-lg: 0 16px 30px rgba(16, 28, 48, 0.13);
+  --sl-shadow-sm: var(--shadow-soft);
+  --sl-shadow-md: 0 14px 30px rgba(16, 28, 48, 0.14);
+  --sl-shadow-lg: 0 18px 36px rgba(16, 28, 48, 0.18);
 }
 
 html,
 body {
-  background: var(--helm-page-gradient-dark);
+  background: var(--sl-color-bg);
 }
 
-:root[data-theme="light"] body {
-  background: var(--helm-page-gradient-light);
+body {
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--sl-color-text);
+}
+
+code,
+pre,
+kbd,
+samp {
+  font-family: var(--font-code);
 }
 
 .header {
-  background-color: #111c2d;
+  background-color: var(--sl-color-bg-nav);
   backdrop-filter: blur(6px);
   border-bottom-color: var(--sl-color-hairline);
-}
-
-:root[data-theme="light"] .header {
-  background-color: #f5f7fa;
 }
 
 .site-title {
   color: var(--sl-color-text-accent);
 }
 
-.header :is(a, button, label, select) {
-  color: var(--sl-color-white);
-}
-
-:root[data-theme="light"] .header :is(a, button, label, select) {
-  color: var(--helm-text-light);
-}
-
+.header :is(a, button, label, select),
 button[data-open-modal] {
   color: var(--sl-color-white);
 }
 
-@media (min-width: 50rem) {
-  button[data-open-modal] {
-    background-color: rgba(20, 30, 47, 0.9);
-    border-color: var(--sl-color-hairline);
-    color: #d9e8ff;
-  }
-
-  :root[data-theme="light"] button[data-open-modal] {
-    background-color: #ffffff;
-    border-color: var(--sl-color-hairline);
-    color: #2f3742;
-  }
+:root[data-theme="light"] .header :is(a, button, label, select),
+:root[data-theme="light"] button[data-open-modal] {
+  color: var(--text-primary);
 }
 
 .header :is(a, button, select):focus-visible,
@@ -197,14 +175,14 @@ button[data-open-modal] {
 }
 
 .sl-link-button {
-  border-radius: var(--helm-radius-md);
+  border-radius: var(--radius-md);
   font-weight: 600;
   transition:
-    transform var(--helm-transition-base),
-    background-color var(--helm-transition-base),
-    border-color var(--helm-transition-base),
-    color var(--helm-transition-base),
-    box-shadow var(--helm-transition-base);
+    background-color var(--motion-base),
+    border-color var(--motion-base),
+    color var(--motion-base),
+    transform var(--motion-fast),
+    box-shadow var(--motion-base);
 }
 
 .sl-link-button.primary {
@@ -216,29 +194,37 @@ button[data-open-modal] {
 .sl-link-button.primary:hover {
   background: var(--helm-blue-500);
   border-color: var(--helm-blue-500);
-  color: #ffffff;
   transform: translateY(-1px);
-  box-shadow: var(--sl-shadow-sm);
 }
 
 .sl-link-button.secondary {
-  background: transparent;
   border-color: var(--helm-blue-500);
   color: var(--helm-blue-300);
 }
 
 .sl-link-button.secondary:hover {
   background: rgba(60, 125, 217, 0.08);
-  border-color: var(--helm-blue-300);
-  color: #e4f1ff;
 }
 
 :root[data-theme="light"] .sl-link-button.secondary {
   color: var(--helm-blue-700);
 }
 
-:root[data-theme="light"] .sl-link-button.secondary:hover {
-  color: var(--helm-blue-900);
+[data-has-hero] .hero .actions > .secondary.sl-link-button.not-content {
+  color: #d9e8ff !important;
+  border-color: var(--helm-blue-300);
+  background: rgba(60, 125, 217, 0.12);
+}
+
+[data-has-hero] .hero .actions > .secondary.sl-link-button.not-content:hover {
+  color: #ffffff;
+  background: rgba(60, 125, 217, 0.2);
+}
+
+:root[data-theme="light"] [data-has-hero] .hero .actions > .secondary.sl-link-button.not-content {
+  color: var(--helm-blue-900) !important;
+  border-color: var(--helm-blue-700);
+  background: rgba(42, 93, 168, 0.08);
 }
 
 .sl-link-button.minimal {
@@ -250,417 +236,307 @@ button[data-open-modal] {
 }
 
 [data-has-hero] .sl-container {
-  max-width: min(74rem, 100%);
+  max-width: min(76rem, 100%);
 }
 
 [data-has-hero] .hero {
-  position: relative;
-  gap: 1.5rem;
   border: 1px solid var(--sl-color-hairline);
-  border-radius: calc(var(--helm-radius-lg) + 2px);
-  padding: clamp(1.1rem, 2.1vw, 1.9rem);
-  background: linear-gradient(180deg, rgba(20, 30, 47, 0.92), rgba(16, 25, 39, 0.92));
+  border-radius: var(--radius-lg);
+  padding: var(--space-3);
+  background: var(--panel-dark);
+  box-shadow: var(--sl-shadow-sm);
+  gap: var(--space-3);
 }
 
 :root[data-theme="light"] [data-has-hero] .hero {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(247, 249, 252, 0.96));
-}
-
-[data-has-hero] .hero::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background:
-    linear-gradient(to right, rgba(159, 176, 199, 0.05) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(159, 176, 199, 0.05) 1px, transparent 1px);
-  background-size: 42px 42px;
-  opacity: 0.2;
-}
-
-:root[data-theme="light"] [data-has-hero] .hero::after {
-  background:
-    linear-gradient(to right, rgba(42, 93, 168, 0.05) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(42, 93, 168, 0.05) 1px, transparent 1px);
-  opacity: 0.35;
-}
-
-[data-has-hero] .hero > * {
-  position: relative;
-  z-index: 1;
-}
-
-[data-has-hero] .hero .copy {
-  background: rgba(10, 18, 30, 0.55);
-  border: 1px solid rgba(159, 176, 199, 0.18);
-  border-radius: 14px;
-  padding: 0.75rem 0.9rem;
-}
-
-:root[data-theme="light"] [data-has-hero] .hero .copy {
-  background: rgba(255, 255, 255, 0.9);
-  border-color: rgba(42, 93, 168, 0.16);
-}
-
-[data-has-hero] .hero > img,
-[data-has-hero] .hero > .hero-html {
-  border: 1px solid var(--sl-color-hairline);
-  border-radius: var(--helm-radius-lg);
-  background: rgba(10, 18, 30, 0.7);
-  box-shadow: var(--sl-shadow-md);
-}
-
-:root[data-theme="light"] [data-has-hero] .hero > img,
-:root[data-theme="light"] [data-has-hero] .hero > .hero-html {
-  background: #ffffff;
+  background: var(--panel-light);
 }
 
 [data-has-hero] .hero h1 {
-  font-family: var(--helm-font-display);
-  font-size: clamp(2.2rem, 5vw, 3.5rem);
+  font-family: var(--font-heading);
+  font-size: clamp(3rem, 5vw, 3.5rem);
+  line-height: 1.05;
+  letter-spacing: -0.01em;
   font-weight: 700;
-  letter-spacing: -0.02em;
-  color: #f4f8ff;
-  text-shadow: 0 1px 2px rgba(2, 8, 18, 0.45);
-}
-
-[data-has-hero] .hero .tagline {
-  font-size: clamp(1.06rem, 1.35vw, 1.24rem);
-  color: #d5e2f6;
-  max-width: 44ch;
-  text-shadow: 0 1px 1px rgba(2, 8, 18, 0.35);
+  text-transform: none;
+  color: #ffffff;
 }
 
 :root[data-theme="light"] [data-has-hero] .hero h1 {
-  color: #1c1f26;
-  text-shadow: none;
+  color: var(--helm-blue-900);
+}
+
+[data-has-hero] .hero .tagline {
+  font-family: var(--font-body);
+  font-size: 18px;
+  line-height: 1.6;
+  color: var(--text-dark-secondary);
+  max-width: 50ch;
 }
 
 :root[data-theme="light"] [data-has-hero] .hero .tagline {
-  color: #3f4a5c;
-  text-shadow: none;
+  color: var(--text-secondary);
+}
+
+.sl-markdown-content h1,
+.sl-markdown-content h2,
+.sl-markdown-content h3,
+.landing-shell h1,
+.landing-shell h2,
+.landing-shell h3 {
+  font-family: var(--font-heading);
+  text-transform: none;
+}
+
+.sl-markdown-content h2,
+.landing-shell h2 {
+  font-size: clamp(2rem, 3.4vw, 2.25rem);
+  line-height: 1.2;
+  font-weight: 600;
+  letter-spacing: 0;
+  color: var(--helm-blue-300);
+}
+
+:root[data-theme="light"] .sl-markdown-content h2,
+:root[data-theme="light"] .landing-shell h2 {
+  color: var(--helm-blue-700);
+}
+
+.sl-markdown-content h3,
+.landing-shell h3 {
+  font-size: clamp(1.375rem, 2vw, 1.5rem);
+  line-height: 1.35;
+  font-weight: 500;
+  color: var(--sl-color-white);
+}
+
+:root[data-theme="light"] .sl-markdown-content h3,
+:root[data-theme="light"] .landing-shell h3 {
+  color: var(--text-primary);
+}
+
+.sl-markdown-content p,
+.landing-shell p,
+.landing-shell li {
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.landing-shell .body-lg p,
+.landing-shell .body-lg {
+  font-size: 18px;
+  line-height: 1.6;
+}
+
+.small-note {
+  font-size: 14px;
+  color: var(--sl-color-text);
 }
 
 .landing-shell {
-  margin-top: 1rem;
-  max-width: 71rem;
+  margin-top: var(--space-3);
+  max-width: 72rem;
   margin-inline: auto;
 }
 
+.landing-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  margin-bottom: var(--space-3);
+  padding: var(--space-1);
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: var(--radius-md);
+  background: var(--panel-dark);
+}
+
+:root[data-theme="light"] .landing-nav {
+  background: var(--panel-light);
+}
+
+.landing-nav a {
+  text-decoration: none;
+  color: var(--sl-color-text);
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 14px;
+  line-height: 1.2;
+}
+
+.landing-nav a:hover {
+  color: var(--sl-color-white);
+  border-color: rgba(60, 125, 217, 0.34);
+  background: rgba(60, 125, 217, 0.08);
+}
+
 .landing-section {
-  margin-top: var(--helm-section-space);
-  position: relative;
+  margin-top: var(--space-5);
 }
 
 .section-head {
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-3);
 }
 
-.landing-kicker {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.55rem;
-  margin: 0 0 0.5rem;
-  color: var(--helm-blue-300);
-  font-size: 0.78rem;
-  font-weight: 600;
-  letter-spacing: 0.07em;
+.section-kicker {
+  margin: 0 0 var(--space-2);
+  font-size: 14px;
+  line-height: 1.2;
+  letter-spacing: 0.06em;
+  color: var(--sl-color-text);
   text-transform: uppercase;
 }
 
-:root[data-theme="light"] .landing-kicker {
-  color: var(--helm-blue-700);
-}
-
-.section-index {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 2ch;
-  padding: 0.12rem 0.35rem;
-  border: 1px solid rgba(108, 166, 232, 0.42);
-  border-radius: 999px;
-  font-family: var(--sl-font-mono);
-  font-size: 0.68rem;
-  color: #b8d5f8;
-}
-
-:root[data-theme="light"] .section-index {
-  color: var(--helm-blue-700);
-  border-color: rgba(42, 93, 168, 0.28);
-}
-
-.sl-markdown-content h2 {
-  font-family: var(--helm-font-display);
-  font-size: clamp(1.65rem, 2.2vw, 2.28rem);
-  line-height: 1.22;
-  letter-spacing: -0.012em;
-  max-width: 22ch;
-}
-
-.landing-problem-grid,
-.landing-command-grid {
-  display: grid;
-  gap: 1.05rem;
-}
-
-.landing-problem-copy p + p {
-  margin-top: 0.42rem;
-}
-
-.fragmentation-map,
-.bridge-diagram,
-.pro-panel,
-.footer-cta {
+.panel {
   border: 1px solid var(--sl-color-hairline);
-  border-radius: var(--helm-radius-lg);
-  background: var(--helm-panel-dark);
-  box-shadow: 0 2px 8px rgba(4, 11, 21, 0.18);
-}
-
-:root[data-theme="light"] .fragmentation-map,
-:root[data-theme="light"] .bridge-diagram,
-:root[data-theme="light"] .pro-panel,
-:root[data-theme="light"] .footer-cta {
-  background: var(--helm-panel-light);
-}
-
-.fragmentation-map,
-.bridge-diagram,
-.pro-panel,
-.footer-cta,
-.feature-item {
-  padding: 1rem;
-}
-
-.fragmentation-map-title {
-  margin: 0 0 0.7rem;
-  color: var(--sl-color-white);
-  font-size: 0.95rem;
-  font-weight: 600;
-}
-
-.manager-chip-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.5rem;
-}
-
-.manager-chip {
-  border: 1px solid var(--sl-color-hairline);
-  border-radius: 999px;
-  background: rgba(60, 125, 217, 0.06);
-  color: var(--sl-color-white);
-  font-family: var(--sl-font-mono);
-  font-size: 0.78rem;
-  padding: 0.34rem 0.58rem;
-}
-
-:root[data-theme="light"] .manager-chip {
-  color: var(--helm-text-light);
-}
-
-.feature-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.72rem;
-}
-
-.feature-item {
-  border: 1px solid var(--sl-color-hairline);
-  border-left: 3px solid rgba(108, 166, 232, 0.74);
-  border-radius: 12px;
-  background: rgba(20, 30, 47, 0.5);
-  transition:
-    transform var(--helm-transition-base),
-    border-color var(--helm-transition-base),
-    box-shadow var(--helm-transition-base);
-}
-
-:root[data-theme="light"] .feature-item {
-  background: rgba(255, 255, 255, 0.92);
-}
-
-.feature-item:hover {
-  transform: translateY(-2px);
-  border-color: rgba(108, 166, 232, 0.7);
+  border-radius: var(--radius-lg);
+  background: var(--panel-dark);
   box-shadow: var(--sl-shadow-sm);
+  padding: var(--space-3);
 }
 
-.feature-item h3 {
-  margin: 0;
-  font-family: var(--helm-font-display);
-  font-size: 1.04rem;
-  color: var(--sl-color-white);
+:root[data-theme="light"] .panel {
+  background: var(--panel-light);
 }
 
-.feature-item p {
-  margin: 0.32rem 0 0;
-  color: var(--sl-color-text);
+.panel-compact {
+  padding: var(--space-2);
 }
 
-.feature-item.pro {
-  border-left-color: rgba(200, 156, 61, 0.9);
-  border-color: rgba(200, 156, 61, 0.4);
-}
-
-.pro-inline-badge {
-  display: inline-flex;
-  align-items: center;
-  margin-left: 0.45rem;
-  border-radius: 999px;
-  font-size: 0.69rem;
-  line-height: 1;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  padding: 0.23rem 0.42rem;
-  background: rgba(200, 156, 61, 0.18);
-  color: #f0d08d;
-}
-
-:root[data-theme="light"] .pro-inline-badge {
-  color: #6a4f1c;
-}
-
-.landing-close-line {
-  margin-top: 0.95rem;
-  color: var(--sl-color-text);
-  font-weight: 550;
-}
-
-.bridge-grid {
+.split-grid,
+.card-grid {
   display: grid;
-  gap: 0.6rem;
+  gap: var(--space-3);
 }
 
-.bridge-node {
-  border: 1px solid var(--sl-color-hairline);
-  border-radius: 12px;
-  padding: 0.5rem 0.68rem;
-  background: rgba(60, 125, 217, 0.045);
-  font-size: 0.85rem;
+.card-grid {
+  grid-template-columns: 1fr;
 }
 
-.bridge-node strong {
-  color: var(--sl-color-white);
+.capability-card {
+  transition:
+    border-color var(--motion-base),
+    transform var(--motion-fast),
+    box-shadow var(--motion-base);
 }
 
-.bridge-arrow {
-  color: #9dc5f2;
-  font-weight: 700;
-  text-align: center;
+.capability-card:hover {
+  border-color: rgba(60, 125, 217, 0.5);
+  transform: translateY(-1px);
 }
 
-.bridge-core {
-  border: 1px solid rgba(60, 125, 217, 0.56);
-  border-radius: 12px;
-  background: rgba(60, 125, 217, 0.11);
-  padding: 0.56rem 0.68rem;
+.edition-label {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.2;
+  color: var(--sl-color-text);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
 
-.bridge-shot {
-  margin-top: 0.8rem;
-  border: 1px solid var(--sl-color-hairline);
-  border-radius: var(--helm-radius-md);
+.edition-card h3 {
+  margin-top: var(--space-2);
+}
+
+.architecture-grid .media-panel img {
   width: 100%;
   height: auto;
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: var(--radius-md);
+}
+
+.panel-stack {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.lane {
+  border: 1px solid var(--sl-color-hairline);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2);
+  background: rgba(60, 125, 217, 0.04);
+}
+
+.lane-label {
+  margin: 0;
+  font-family: var(--font-code);
+  font-size: 14px;
+  line-height: 1.2;
+  color: var(--sl-color-white);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+:root[data-theme="light"] .lane-label {
+  color: var(--helm-blue-700);
+}
+
+.lane-arrow {
+  text-align: center;
+  color: var(--helm-blue-300);
+  font-size: 18px;
+  line-height: 1;
 }
 
 .pro-panel {
-  border-color: rgba(200, 156, 61, 0.5);
-  border-left-width: 3px;
-  background:
-    linear-gradient(180deg, rgba(200, 156, 61, 0.08), rgba(169, 126, 42, 0.04)),
-    var(--helm-panel-dark);
+  border-top: 2px solid var(--helm-gold-500);
 }
 
-:root[data-theme="light"] .pro-panel {
-  background:
-    linear-gradient(180deg, rgba(200, 156, 61, 0.1), rgba(169, 126, 42, 0.05)),
-    var(--helm-panel-light);
+.pro-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 14px;
+  line-height: 1;
+  font-weight: 600;
+  color: #1c1f26;
+  background: var(--helm-gold-500);
+  border-radius: 999px;
+  padding: 6px 10px;
+  margin: 0 0 var(--space-2);
 }
 
-.pro-list {
-  margin: 0;
-  padding-left: 1.1rem;
+.pro-panel ul {
+  margin: 0 0 var(--space-3);
+  padding-left: 18px;
 }
 
-.pro-list li + li {
-  margin-top: 0.42rem;
+.cta-panel {
+  margin-top: var(--space-5);
 }
 
-.footer-cta {
-  border-left-width: 3px;
-  border-left-color: rgba(108, 166, 232, 0.85);
-  background:
-    radial-gradient(420px 180px at 82% -20%, rgba(60, 125, 217, 0.14), transparent 65%),
-    var(--helm-panel-dark);
-}
-
-:root[data-theme="light"] .footer-cta {
-  background:
-    radial-gradient(420px 180px at 82% -20%, rgba(60, 125, 217, 0.1), transparent 65%),
-    var(--helm-panel-light);
-}
-
-.footer-cta-actions {
+.cta-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65rem 0.8rem;
-  margin-top: 0.8rem;
-}
-
-.release-note {
-  margin-top: 0.8rem;
-  color: var(--sl-color-text);
-  font-size: 0.9rem;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
 }
 
 @media (min-width: 50rem) {
-  .landing-problem-grid,
-  .landing-command-grid {
-    grid-template-columns: minmax(0, 1.06fr) minmax(0, 0.94fr);
-    gap: 1.2rem 1.5rem;
-    align-items: start;
+  [data-has-hero] .hero {
+    padding: var(--space-4);
   }
 
-  .feature-list {
+  .split-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.78rem 0.9rem;
   }
 
-  .feature-item.pro {
-    grid-column: 1 / -1;
-  }
-
-  .bridge-grid {
-    grid-template-columns: 1fr auto 1fr auto 1fr;
-    align-items: center;
-    gap: 0.65rem;
-  }
-}
-
-@media (min-width: 72rem) {
-  .footer-cta-actions .sl-link-button {
-    margin-block: 0;
+  .card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .landing-section {
-    margin-top: clamp(4rem, 6vw, 6.5rem);
+    margin-top: var(--space-6);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .sl-link-button,
-  .feature-item {
+  .capability-card {
     transition: none;
   }
 
-  .sl-link-button:hover,
-  .feature-item:hover {
+  .capability-card:hover,
+  .sl-link-button.primary:hover {
     transform: none;
   }
 }


### PR DESCRIPTION
## Summary
- redesign the website landing experience with a cleaner dual-audience structure (consumer + Helm Business) and updated command-bridge framing
- apply the Helm website typography/color spec (Neue Haas Grotesk heading stack with requested fallbacks, Inter body, SF Mono code, 8pt rhythm, restrained Pro gold accents)
- refresh website docs content for current product/release messaging across overview, roadmap, changelog, installation, usage, FAQ, and visual tour
- resolve homepage hero secondary CTA contrast issue and preserve focus-visible + reduced-motion behavior
- sync project status docs (`docs/CURRENT_STATE.md`, `docs/NEXT_STEPS.md`) with website/content/accessibility updates

## Validation
- `npm run build --prefix web`
- Axe CLI audit run across:
  - `/`
  - `/product-overview/`
  - `/guides/usage/`
  - `/guides/installation/`
  - `/guides/faq/`
  - `/guides/visual-tour/`
  - `/licensing/`
  - `/changelog/`
  - `/product-roadmap/`
- post-fix result: 0 Axe violations on the audited routes

## Notes
- visual-tour screenshots are ready for replacement via `web/src/assets/tour/` when new captures are available.
