### PR TITLE
ci: trigger Deploy Web after successful release workflow

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -11,6 +11,12 @@ on:
       - main
     paths:
       - 'web/**'
+  workflow_run:
+    workflows:
+      - 'Release macOS DMG'
+    types:
+      - completed
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -23,6 +29,9 @@ concurrency:
 
 jobs:
   build:
+    if: |
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -36,7 +45,12 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.repository.full_name == github.repository)
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- add `workflow_run` trigger for `Release macOS DMG` in `deploy-web.yml`
- add `workflow_dispatch` support for manual deploy fallback
- gate `build` to only run for successful release workflow completions when event is `workflow_run`
- gate `deploy` to:
  - `push` on `main`
  - manual `workflow_dispatch` on `main`
  - successful `workflow_run` from same repository

## Why
Release automation publishes updated `web/public/updates/appcast.xml` to `main`, but bot-authored commits may not trigger existing `push`-path deploy behavior reliably. This makes website feed publication deterministic after successful release builds.
