### PR TITLE
merge: pre-resolve main/dev docs conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
 
 ## [Unreleased]
 
+### Added
+- Third-party dependency licensing baseline document:
+  - `docs/legal/THIRD_PARTY_LICENSES.md`
+  - includes runtime/build/toolchain scope split and release obligations.
+
+### Changed
+- Legal notice and licensing strategy docs now explicitly link to third-party dependency obligations:
+  - `docs/legal/NOTICE.md`
+  - `docs/legal/LICENSING_STRATEGY.md`
+- Release process now includes mandatory third-party license compliance gates in:
+  - `docs/RELEASE_CHECKLIST.md`
+- Project state/planning docs now track this compliance baseline:
+  - `docs/CURRENT_STATE.md`
+  - `docs/NEXT_STEPS.md`
+- ADR log adds third-party license compliance baseline decision:
+  - `docs/DECISIONS.md` (Decision 023)
+
 ## [0.16.2] - 2026-02-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ See [`docs/VERSIONING.md`](docs/VERSIONING.md) for the versioning strategy.
 - [Changelog](CHANGELOG.md) — Versioned release notes
 - [Release Checklist](docs/RELEASE_CHECKLIST.md) — Required ship checklist and tag steps
 - [Release Criteria](docs/DEFINITION_OF_DONE.md) — 1.0 definition of done
+- [Third-Party Licenses](docs/legal/THIRD_PARTY_LICENSES.md) — dependency license inventory and release obligations
 - [Enterprise Architecture](docs/enterprise/ENTERPRISE_INTEGRATION_ARCHITECTURE.md) — Integration model for managed enterprise environments
 - [Editions and Entitlements](docs/enterprise/EDITIONS_AND_ENTITLEMENTS.md) — Debug/release build strategy and Free/Pro/Business gating
 - [Business Central Management Spec](docs/enterprise/BUSINESS_CENTRAL_MANAGEMENT_SPEC.md) — Scoped policy, drift, and compliance model

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -25,6 +25,10 @@ Security rollout staging status:
 - Stage 2 (`1.3.x`): Security Advisory System (Pro, planned)
 - Stage 3 (`1.4.x`): Shared Brain infrastructure (planned)
 
+Third-party licensing compliance status:
+- Dependency-license inventory and obligations baseline documented at `docs/legal/THIRD_PARTY_LICENSES.md` (audited 2026-02-21).
+- Release process now includes explicit third-party license checks in `docs/RELEASE_CHECKLIST.md`.
+
 ---
 
 ## Completed Milestones

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -335,6 +335,31 @@ Version restructuring:
 
 ---
 
+## Decision 023 — Third-Party License Compliance Baseline
+
+**Decision:**
+Maintain an explicit dependency-license inventory and release-gate checklist for third-party components.
+
+Implementation baseline:
+
+- canonical inventory doc: `docs/legal/THIRD_PARTY_LICENSES.md`
+- release gating entries: `docs/RELEASE_CHECKLIST.md` (all releases)
+- legal notice cross-reference: `docs/legal/NOTICE.md`
+
+Scope clarifications:
+
+- Runtime app dependencies and build-time dependencies are tracked separately.
+- Sparkle attributions remain required for channels that include Sparkle.
+- Website toolchain dependencies (including `sharp/libvips`) are tracked with distribution-path-specific obligations.
+
+**Rationale:**
+
+- Helm's project license does not supersede third-party license obligations.
+- A documented baseline reduces release risk from dependency changes.
+- Explicit runtime-vs-build separation prevents over- or under-scoping compliance actions.
+
+---
+
 ## Summary
 
 Helm prioritizes:

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -40,6 +40,11 @@ Next release targets:
 - `v0.18.x` — Local security groundwork (internal-only)
 - `v0.19.x` — Stability & Pre-1.0 hardening
 
+License/compliance follow-through:
+- Keep `docs/legal/THIRD_PARTY_LICENSES.md` updated as dependency sets change.
+- Treat third-party notice validation as a required release gate (`docs/RELEASE_CHECKLIST.md`).
+- Add release-automation support for producing a distribution-ready third-party notices artifact in a future docs/automation slice.
+
 ---
 
 ## v0.16.x Kickoff Plan (Completed)

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -2,6 +2,13 @@
 
 This checklist is required before creating a release tag on `main`.
 
+## Third-Party License Compliance (All Releases)
+
+- [ ] Re-audit dependency licenses and update `docs/legal/THIRD_PARTY_LICENSES.md` when versions or dependency sets change.
+- [ ] Confirm release materials retain required third-party attribution/license texts for shipped runtime dependencies.
+- [ ] Confirm Sparkle license + external attributions remain preserved for channels that include Sparkle.
+- [ ] If distributing artifacts that include `sharp/libvips` binaries (outside static-site output), include LGPL notice/corresponding-source obligations for that artifact.
+
 ## v0.16.2 (Sparkle Connectivity + macOS 11 Alignment)
 
 ### Scope and Documentation

--- a/docs/legal/LICENSING_STRATEGY.md
+++ b/docs/legal/LICENSING_STRATEGY.md
@@ -194,7 +194,22 @@ Possible future additions include:
 
 ---
 
-## 12. Summary
+## 12. Third-Party Dependency Obligations
+
+Helm's project license is separate from third-party dependency licenses.
+
+Third-party obligations are tracked in:
+
+- `docs/legal/THIRD_PARTY_LICENSES.md`
+- `docs/legal/NOTICE.md`
+
+Release process expectations are tracked in:
+
+- `docs/RELEASE_CHECKLIST.md` (third-party license compliance gate)
+
+---
+
+## 13. Summary
 
 Helm is currently:
 

--- a/docs/legal/NOTICE.md
+++ b/docs/legal/NOTICE.md
@@ -16,6 +16,10 @@ Helm may include or depend on third-party libraries and components, each of whic
 
 Where applicable, third-party licenses and attributions are included in the source repository or accompanying distribution materials.
 
+For current dependency-license inventory and release obligations, see:
+
+- `docs/legal/THIRD_PARTY_LICENSES.md`
+
 ---
 
 No Trademark License

--- a/docs/legal/THIRD_PARTY_LICENSES.md
+++ b/docs/legal/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,115 @@
+# Third-Party Dependency Licenses and Release Obligations
+
+This document tracks third-party license obligations for Helm distributions.
+
+It is an engineering compliance reference, not legal advice.
+
+---
+
+## Scope
+
+Helm has three dependency surfaces with different obligations:
+
+1. **macOS app runtime artifact** (DMG/app bundle)
+2. **Build-only tooling** (used to produce artifacts, not shipped)
+3. **Website build toolchain** (`web/` dependencies)
+
+The Helm project license (`LICENSE`) does not replace third-party license obligations.
+
+---
+
+## Snapshot (Audited 2026-02-21)
+
+Release context:
+
+- docs baseline: `v0.16.1`
+- app release baseline: `v0.16.0`
+
+### 1) macOS App Runtime Dependencies
+
+#### Rust core/runtime (`helm-ffi` normal dependency graph)
+
+- Third-party crates: **45**
+- License families observed:
+  - `MIT OR Apache-2.0` (24)
+  - `MIT` (15)
+  - `MIT/Apache-2.0` (2)
+  - `Zlib` (1)
+  - `(MIT OR Apache-2.0) AND Unicode-3.0` (1)
+  - `Unlicense OR MIT` (1)
+  - `Apache-2.0 OR MIT` (1)
+
+Implication:
+- Current app runtime crates are permissive licenses.
+- Preserve required copyright/license text in third-party notices.
+
+#### Swift Package Dependency
+
+- `Sparkle` `2.8.1` (`apps/macos-ui/Helm.xcodeproj/project.pbxproj`)
+- Sparkle license is MIT-style and includes an `EXTERNAL LICENSES` section.
+
+Implication:
+- When distributing Developer ID builds that include Sparkle, preserve Sparkle license text and external attributions.
+
+### 2) Build-Only Dependencies (Not App Runtime)
+
+- `cbindgen` `0.29.2` (`core/rust/crates/helm-ffi/Cargo.toml` build-dependency)
+- License: `MPL-2.0`
+
+Implication:
+- Treated as a build tool dependency.
+- Reassess obligations only if build tooling artifacts/code are redistributed beyond standard build use.
+
+### 3) Website Toolchain Dependencies (`web/`)
+
+Direct dependencies:
+
+- `astro` (MIT)
+- `@astrojs/starlight` (MIT)
+- `sharp` (Apache-2.0)
+
+Additional lockfile notes:
+
+- Platform `@img/sharp-libvips-*` packages appear under `LGPL-3.0-or-later`.
+- `web/package-lock.json` marks `zod-to-ts` as `UNKNOWN`; local package license file is MIT.
+
+Implication:
+- Current macOS app release artifacts do not ship `node_modules`.
+- If Helm distributes runtime artifacts that include `sharp/libvips` binaries, LGPL obligations must be handled in that distribution path.
+
+---
+
+## Required Release Actions
+
+### For macOS app releases (DMG)
+
+- Keep this document current for dependency/version/license changes.
+- Keep third-party attributions available from release materials (repository docs or bundled notices).
+- Preserve Sparkle license + external notices for channels that include Sparkle.
+- Flag any new strong-copyleft runtime dependencies for explicit owner review before release.
+
+### For website/infrastructure distributions
+
+- If distributing only generated static site output, keep source-level notices in repository docs.
+- If distributing containers or binaries that include `sharp/libvips` payloads, include LGPL notices and required corresponding-source instructions for that artifact.
+
+---
+
+## Audit Commands
+
+Use these commands to refresh the snapshot:
+
+```bash
+cargo metadata --manifest-path core/rust/Cargo.toml --format-version 1 --locked
+cargo tree --manifest-path core/rust/Cargo.toml -e normal -p helm-ffi
+cargo tree --manifest-path core/rust/Cargo.toml -e build -p helm-ffi
+node -e 'const lock=require("./web/package-lock.json"); console.log(lock.packages["node_modules/astro"].license)'
+node -e 'const lock=require("./web/package-lock.json"); for (const [k,v] of Object.entries(lock.packages)) if(k && /GPL|UNKNOWN|NOASSERTION/i.test(v.license||"UNKNOWN")) console.log(k, v.license)'
+```
+
+---
+
+## Known Follow-Ups
+
+- Automate generation of a release-ready third-party notices artifact.
+- Add explicit packaging step for notices if/when DMG bundling policy requires in-bundle notice files.

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -30,7 +30,7 @@ export default defineConfig({
 					tag: 'meta',
 					attrs: {
 						property: 'og:image',
-						content: 'https://helmapp.dev/og-image.png',
+						content: 'https://helmapp.dev/og-image.png?v=2',
 					},
 				},
 				{
@@ -44,7 +44,7 @@ export default defineConfig({
 					tag: 'meta',
 					attrs: {
 						name: 'twitter:image',
-						content: 'https://helmapp.dev/og-image.png',
+						content: 'https://helmapp.dev/og-image.png?v=2',
 					},
 				},
 			],

--- a/web/public/updates/appcast.xml
+++ b/web/public/updates/appcast.xml
@@ -6,16 +6,16 @@
     <description>Helm direct-channel updates</description>
     <language>en</language>
     <item>
-      <title>Helm 0.16.0</title>
-      <pubDate>Sat, 21 Feb 2026 03:57:25 +0000</pubDate>
-      <sparkle:releaseNotesLink>https://github.com/jasoncavinder/Helm/releases/tag/v0.16.0</sparkle:releaseNotesLink>
+      <title>Helm 0.16.2</title>
+      <pubDate>Sat, 21 Feb 2026 08:51:37 +0000</pubDate>
+      <sparkle:releaseNotesLink>https://github.com/jasoncavinder/Helm/releases/tag/v0.16.2</sparkle:releaseNotesLink>
       <enclosure
-        url="https://github.com/jasoncavinder/Helm/releases/download/v0.16.0/Helm-v0.16.0-macos-universal.dmg"
-        sparkle:version="16000900"
-        sparkle:shortVersionString="0.16.0"
-        sparkle:edSignature="bkHaih7jSM9wnXRdqj6UuNXe71OoftZz9Zlh9Z6vJuZOpZaDVIak2QGae3ayj0c3bAF2nIDYkwcKivXfqONADw=="
-         sparkle:minimumSystemVersion="12.0"
-        length="12182600"
+        url="https://github.com/jasoncavinder/Helm/releases/download/v0.16.2/Helm-v0.16.2-macos-universal.dmg"
+        sparkle:version="16002900"
+        sparkle:shortVersionString="0.16.2"
+        sparkle:edSignature="PFHeJlVn4NHqJV+Zm8WiqqyCfF/5SFV8z9W006eIApvGroqY4cSI5Ozg50vsD0QviZdVgx8qnSnpWn6lTXBoAw=="
+         sparkle:minimumSystemVersion="11.0"
+        length="12107221"
         type="application/octet-stream"/>
     </item>
   </channel>

--- a/web/src/content/docs/licensing.md
+++ b/web/src/content/docs/licensing.md
@@ -19,6 +19,17 @@ Helm is free to use for personal, non-commercial purposes.
 
 See the [LICENSE](https://github.com/jasoncavinder/Helm/blob/main/LICENSE) file for the full legal text.
 
+## Third-Party Dependencies
+
+Helm includes third-party dependencies that are governed by their own licenses.
+
+Dependency license inventory and release obligations are tracked in:
+
+- [Third-Party Licenses](https://github.com/jasoncavinder/Helm/blob/main/docs/legal/THIRD_PARTY_LICENSES.md)
+- [NOTICE](https://github.com/jasoncavinder/Helm/blob/main/docs/legal/NOTICE.md)
+
+Helm's project license does not replace third-party license obligations.
+
 ## Future Strategy (Post-1.0)
 
 We intend to transition to a sustainable commercial model at or after version 1.0. The goal is to support ongoing development while maintaining transparency.


### PR DESCRIPTION
Summary
- merged origin/main into this dev-based branch
- manually reconciled conflict sections in CHANGELOG.md and docs/RELEASE_CHECKLIST.md
- kept both main-side license-compliance updates and dev-side v0.16.2 updates

Why
- pre-resolves the current main<->dev content conflicts so a later dev->main merge can proceed without manual conflict edits in those files.