### PR TITLE
feat: add v0.17 task log foundation plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
 - Third-party dependency licensing baseline document:
   - `docs/legal/THIRD_PARTY_LICENSES.md`
   - includes runtime/build/toolchain scope split and release obligations.
+- v0.17 diagnostics/logging foundation kickoff:
+  - SQLite-backed task lifecycle log schema (`task_log_records`)
+  - runtime lifecycle log persistence hooks (queued/running/terminal)
+  - new FFI/API surface for retrieving persisted task logs (`helm_list_task_logs`)
 
 ### Changed
 - Legal notice and licensing strategy docs now explicitly link to third-party dependency obligations:

--- a/apps/macos-ui/Helm/Shared/HelmServiceProtocol.swift
+++ b/apps/macos-ui/Helm/Shared/HelmServiceProtocol.swift
@@ -5,6 +5,7 @@ import Foundation
     func listOutdatedPackages(withReply reply: @escaping (String?) -> Void)
     func listTasks(withReply reply: @escaping (String?) -> Void)
     func getTaskOutput(taskId: Int64, withReply reply: @escaping (String?) -> Void)
+    func listTaskLogs(taskId: Int64, limit: Int64, withReply reply: @escaping (String?) -> Void)
     func triggerRefresh(withReply reply: @escaping (Bool) -> Void)
     func searchLocal(query: String, withReply reply: @escaping (String?) -> Void)
     func triggerRemoteSearch(query: String, withReply reply: @escaping (Int64) -> Void)

--- a/apps/macos-ui/HelmService/Sources/HelmService.swift
+++ b/apps/macos-ui/HelmService/Sources/HelmService.swift
@@ -60,6 +60,16 @@ class HelmService: NSObject, HelmServiceProtocol {
         reply(String(cString: cString))
     }
 
+    func listTaskLogs(taskId: Int64, limit: Int64, withReply reply: @escaping (String?) -> Void) {
+        guard let cString = helm_list_task_logs(taskId, limit) else {
+            logger.warning("helm_list_task_logs(\(taskId), \(limit)) returned nil")
+            reply(nil)
+            return
+        }
+        defer { helm_free_string(cString) }
+        reply(String(cString: cString))
+    }
+
     func triggerRefresh(withReply reply: @escaping (Bool) -> Void) {
         let result = helm_trigger_refresh()
         logger.info("helm_trigger_refresh result: \(result)")

--- a/core/rust/crates/helm-core/src/models/mod.rs
+++ b/core/rust/crates/helm-core/src/models/mod.rs
@@ -5,6 +5,7 @@ pub mod package;
 pub mod pin;
 pub mod search;
 pub mod task;
+pub mod task_log;
 
 pub use error::{CoreError, CoreErrorKind};
 pub use keg_policy::{HomebrewKegPolicy, PackageKegPolicy};
@@ -16,3 +17,4 @@ pub use package::{InstalledPackage, OutdatedPackage, PackageCandidate, PackageRe
 pub use pin::{PinKind, PinRecord};
 pub use search::{CachedSearchResult, SearchQuery};
 pub use task::{TaskId, TaskRecord, TaskStatus, TaskType};
+pub use task_log::{NewTaskLogRecord, TaskLogLevel, TaskLogRecord};

--- a/core/rust/crates/helm-core/src/models/task_log.rs
+++ b/core/rust/crates/helm-core/src/models/task_log.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+use std::time::SystemTime;
+
+use crate::models::{ManagerId, TaskId, TaskStatus, TaskType};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskLogLevel {
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct TaskLogRecord {
+    pub id: u64,
+    pub task_id: TaskId,
+    pub manager: ManagerId,
+    pub task_type: TaskType,
+    pub status: Option<TaskStatus>,
+    pub level: TaskLogLevel,
+    pub message: String,
+    pub created_at: SystemTime,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NewTaskLogRecord {
+    pub task_id: TaskId,
+    pub manager: ManagerId,
+    pub task_type: TaskType,
+    pub status: Option<TaskStatus>,
+    pub level: TaskLogLevel,
+    pub message: String,
+    pub created_at: SystemTime,
+}

--- a/core/rust/crates/helm-core/src/orchestration/adapter_runtime.rs
+++ b/core/rust/crates/helm-core/src/orchestration/adapter_runtime.rs
@@ -9,8 +9,8 @@ use crate::adapters::{
     ManagerAdapter,
 };
 use crate::models::{
-    Capability, CoreError, CoreErrorKind, ManagerAction, ManagerId, TaskId, TaskRecord, TaskStatus,
-    TaskType,
+    Capability, CoreError, CoreErrorKind, ManagerAction, ManagerId, NewTaskLogRecord, TaskId,
+    TaskLogLevel, TaskRecord, TaskStatus, TaskType,
 };
 use crate::orchestration::{
     AdapterExecutionRuntime, AdapterTaskSnapshot, AdapterTaskTerminalState, CancellationMode,
@@ -369,6 +369,34 @@ impl AdapterRuntime {
                 return Err(error);
             }
 
+            if let Err(error) = persist_append_task_log(
+                task_store.clone(),
+                NewTaskLogRecord {
+                    task_id,
+                    manager,
+                    task_type,
+                    status: Some(TaskStatus::Queued),
+                    level: TaskLogLevel::Info,
+                    message: "task queued".to_string(),
+                    created_at: SystemTime::now(),
+                },
+                manager,
+                task_type,
+                action,
+            )
+            .await
+            {
+                tracing::warn!(
+                    manager = ?manager,
+                    task_id = task_id.0,
+                    task_type = ?task_type,
+                    action = ?action,
+                    kind = ?error.kind,
+                    message = %error.message,
+                    "failed to persist queued task log"
+                );
+            }
+
             spawn_terminal_persistence_watcher(PersistenceWatcherContext {
                 execution: self.execution.clone(),
                 task_store: task_store.clone(),
@@ -448,6 +476,23 @@ fn spawn_terminal_persistence_watcher(ctx: PersistenceWatcherContext) {
                     let _ = persist_update_task(
                         task_store.clone(),
                         running_record,
+                        manager,
+                        task_type,
+                        action,
+                    )
+                    .await;
+
+                    let _ = persist_append_task_log(
+                        task_store.clone(),
+                        NewTaskLogRecord {
+                            task_id,
+                            manager,
+                            task_type,
+                            status: Some(TaskStatus::Running),
+                            level: TaskLogLevel::Info,
+                            message: "task started".to_string(),
+                            created_at: SystemTime::now(),
+                        },
                         manager,
                         task_type,
                         action,
@@ -545,7 +590,7 @@ fn spawn_terminal_persistence_watcher(ctx: PersistenceWatcherContext) {
         };
 
         if let Err(error) = persist_update_task(
-            task_store,
+            task_store.clone(),
             updated,
             snapshot.runtime.manager,
             snapshot.runtime.task_type,
@@ -561,6 +606,39 @@ fn spawn_terminal_persistence_watcher(ctx: PersistenceWatcherContext) {
                 kind = ?error.kind,
                 message = %error.message,
                 "failed to persist terminal task status"
+            );
+        }
+
+        let terminal_status = snapshot.runtime.status;
+        let terminal_error_message = snapshot.runtime.error_message.clone();
+        let terminal_level = task_log_level_for_status(terminal_status);
+        let terminal_message = task_log_message_for_status(terminal_status, terminal_error_message);
+
+        if let Err(error) = persist_append_task_log(
+            task_store.clone(),
+            NewTaskLogRecord {
+                task_id: snapshot.runtime.id,
+                manager: snapshot.runtime.manager,
+                task_type: snapshot.runtime.task_type,
+                status: Some(terminal_status),
+                level: terminal_level,
+                message: terminal_message,
+                created_at: SystemTime::now(),
+            },
+            snapshot.runtime.manager,
+            snapshot.runtime.task_type,
+            action,
+        )
+        .await
+        {
+            tracing::warn!(
+                manager = ?manager,
+                task_id = task_id.0,
+                task_type = ?task_type,
+                action = ?action,
+                kind = ?error.kind,
+                message = %error.message,
+                "failed to persist terminal task log"
             );
         }
     });
@@ -689,6 +767,64 @@ async fn persist_update_task(
         TaskStoreOperation::Update,
     )
     .await
+}
+
+async fn persist_append_task_log(
+    task_store: Arc<dyn TaskStore>,
+    entry: NewTaskLogRecord,
+    manager: ManagerId,
+    task_type: TaskType,
+    action: ManagerAction,
+) -> OrchestrationResult<()> {
+    let mut remaining_attempts = TASK_PERSIST_RETRY_ATTEMPTS;
+    loop {
+        let store = task_store.clone();
+        let log_entry = entry.clone();
+        let op_result = tokio::task::spawn_blocking(move || store.append_task_log(&log_entry))
+            .await
+            .map_err(|join_error| CoreError {
+                manager: Some(manager),
+                task: Some(task_type),
+                action: Some(action),
+                kind: CoreErrorKind::Internal,
+                message: format!("task log persistence join failure: {join_error}"),
+            })?;
+
+        match op_result {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                let attributed = attribute_error(error, manager, task_type, action);
+                remaining_attempts = remaining_attempts.saturating_sub(1);
+                if remaining_attempts == 0 || attributed.kind != CoreErrorKind::StorageFailure {
+                    return Err(attributed);
+                }
+
+                tokio::time::sleep(Duration::from_millis(TASK_PERSIST_RETRY_DELAY_MS)).await;
+            }
+        }
+    }
+}
+
+fn task_log_level_for_status(status: TaskStatus) -> TaskLogLevel {
+    match status {
+        TaskStatus::Queued | TaskStatus::Running | TaskStatus::Completed => TaskLogLevel::Info,
+        TaskStatus::Cancelled => TaskLogLevel::Warn,
+        TaskStatus::Failed => TaskLogLevel::Error,
+    }
+}
+
+fn task_log_message_for_status(status: TaskStatus, error_message: Option<String>) -> String {
+    match status {
+        TaskStatus::Queued => "task queued".to_string(),
+        TaskStatus::Running => "task started".to_string(),
+        TaskStatus::Completed => "task completed".to_string(),
+        TaskStatus::Cancelled => error_message
+            .map(|message| format!("task cancelled: {message}"))
+            .unwrap_or_else(|| "task cancelled".to_string()),
+        TaskStatus::Failed => error_message
+            .map(|message| format!("task failed: {message}"))
+            .unwrap_or_else(|| "task failed".to_string()),
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/core/rust/crates/helm-core/src/persistence/mod.rs
+++ b/core/rust/crates/helm-core/src/persistence/mod.rs
@@ -2,7 +2,7 @@ pub mod detection_store;
 
 use crate::models::{
     CachedSearchResult, CoreError, InstalledPackage, ManagerId, OutdatedPackage, PackageRef,
-    PinRecord, TaskRecord,
+    PinRecord, TaskId, TaskLogRecord, TaskRecord,
 };
 
 pub use detection_store::DetectionStore;
@@ -64,4 +64,20 @@ pub trait TaskStore: Send + Sync {
 
     /// Delete all task records.
     fn delete_all_tasks(&self) -> PersistenceResult<()>;
+
+    fn append_task_log(&self, _entry: &crate::models::NewTaskLogRecord) -> PersistenceResult<()> {
+        Ok(())
+    }
+
+    fn list_task_logs(
+        &self,
+        _task_id: TaskId,
+        _limit: usize,
+    ) -> PersistenceResult<Vec<TaskLogRecord>> {
+        Ok(Vec::new())
+    }
+
+    fn prune_task_logs(&self, _max_age_secs: i64) -> PersistenceResult<usize> {
+        Ok(0)
+    }
 }

--- a/core/rust/crates/helm-core/src/sqlite/migrations.rs
+++ b/core/rust/crates/helm-core/src/sqlite/migrations.rs
@@ -146,12 +146,41 @@ DROP TABLE IF EXISTS package_keg_policies;
 "#,
 };
 
-const MIGRATIONS: [SqliteMigration; 5] = [
+const MIGRATION_0006: SqliteMigration = SqliteMigration {
+    version: 6,
+    name: "add_task_log_records",
+    up_sql: r#"
+CREATE TABLE IF NOT EXISTS task_log_records (
+    log_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id INTEGER NOT NULL,
+    manager_id TEXT NOT NULL,
+    task_type TEXT NOT NULL,
+    status TEXT,
+    level TEXT NOT NULL,
+    message TEXT NOT NULL,
+    created_at_unix INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_log_records_task_time
+    ON task_log_records (task_id, created_at_unix DESC, log_id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_task_log_records_created_at
+    ON task_log_records (created_at_unix);
+"#,
+    down_sql: r#"
+DROP INDEX IF EXISTS idx_task_log_records_created_at;
+DROP INDEX IF EXISTS idx_task_log_records_task_time;
+DROP TABLE IF EXISTS task_log_records;
+"#,
+};
+
+const MIGRATIONS: [SqliteMigration; 6] = [
     MIGRATION_0001,
     MIGRATION_0002,
     MIGRATION_0003,
     MIGRATION_0004,
     MIGRATION_0005,
+    MIGRATION_0006,
 ];
 
 pub fn migrations() -> &'static [SqliteMigration] {

--- a/core/rust/crates/helm-ffi/include/helm.h
+++ b/core/rust/crates/helm-ffi/include/helm.h
@@ -28,6 +28,13 @@ char *helm_list_tasks(void);
  */
 char *helm_get_task_output(int64_t task_id);
 
+/**
+ * Return persisted lifecycle task logs for a task ID as JSON.
+ *
+ * Returns `null` only on invalid input or serialization/allocation failure.
+ */
+char *helm_list_task_logs(int64_t task_id, int64_t limit);
+
 bool helm_trigger_refresh(void);
 
 /**

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -18,6 +18,7 @@ See:
 Active milestone:
 - 0.16.2 — Sparkle connectivity hardening + macOS 11 deployment-target alignment
 - 0.17.x — Diagnostics & Logging (next implementation milestone)
+  - in progress: `feat/v0.17-log-foundation` (SQLite-backed task lifecycle logs + retrieval plumbing)
 
 Security rollout staging status:
 - Stage 0 (`<=0.16.x`): planning/docs only (active in `0.16.1`)

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -40,6 +40,20 @@ Next release targets:
 - `v0.18.x` — Local security groundwork (internal-only)
 - `v0.19.x` — Stability & Pre-1.0 hardening
 
+## v0.17.x Delivery Tracker (Target: `v0.17.0-rc.1`)
+
+- [ ] `feat/v0.17-log-foundation` — task log event model, SQLite persistence migration, FFI/XPC retrieval surface.
+- [ ] `feat/v0.17-task-log-viewer` — per-task log viewer UI with filters and pagination.
+- [ ] `feat/v0.17-structured-error-export` — structured support/error export payloads with redaction.
+- [ ] `feat/v0.17-service-health-panel` — service/runtime health diagnostics panel.
+- [ ] `feat/v0.17-manager-detection-diagnostics` — per-manager detection diagnostics and reason visibility.
+- [ ] `feat/v0.17-diagnostics-hardening` — silent-failure sweep, attribution consistency, integration/doc exit checks.
+
+RC-1 release gate for `v0.17.x`:
+- Logs are accessible in UI.
+- No silent failures in task execution/reporting paths.
+- Support data export works and is operator-usable.
+
 License/compliance follow-through:
 - Keep `docs/legal/THIRD_PARTY_LICENSES.md` updated as dependency sets change.
 - Treat third-party notice validation as a required release gate (`docs/RELEASE_CHECKLIST.md`).


### PR DESCRIPTION
Summary
- add task lifecycle log domain model in core
- add sqlite migration 0006 for task_log_records
- persist queued/running/terminal lifecycle logs from orchestration runtime
- add FFI endpoint helm_list_task_logs(task_id, limit) and expose via XPC service protocol
- add sqlite/runtime tests for task-log persistence
- add v0.17.x tracked delivery checklist in docs/NEXT_STEPS.md

Validation
- cargo test -p helm-core --manifest-path core/rust/Cargo.toml --test sqlite_store_skeleton --test orchestration_sqlite_task_persistence
- cargo test -p helm-ffi --manifest-path core/rust/Cargo.toml
- xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination platform=macOS build