### PR TITLE
feat: add structured support export with redaction

### DIFF
--- a/apps/macos-ui/Helm/Core/HelmCore+Settings.swift
+++ b/apps/macos-ui/Helm/Core/HelmCore+Settings.swift
@@ -587,6 +587,146 @@ struct HelmSupport {
     static let koFiURL = URL(string: "https://ko-fi.com/jasoncavinder")!
     static let payPalURL = URL(string: "https://paypal.me/jasoncavinder")!
     static let venmoURL = URL(string: "https://www.venmo.com/u/JasonCavinder")!
+
+    private struct SupportExportPayload: Codable {
+        let schemaVersion: String
+        let generatedAt: String
+        let app: SupportExportAppContext
+        let system: SupportExportSystemContext
+        let managers: [SupportExportManagerContext]
+        let tasks: [SupportExportTaskContext]
+        let failures: [SupportExportFailureContext]
+        let redaction: SupportExportRedactionContext
+    }
+
+    private struct SupportExportAppContext: Codable {
+        let version: String
+        let locale: String
+        let distributionChannel: String
+        let safeModeEnabled: Bool
+        let managerCount: Int
+        let outdatedCount: Int
+        let runningTaskCount: Int
+    }
+
+    private struct SupportExportSystemContext: Codable {
+        let macOSVersion: String
+        let architecture: String
+    }
+
+    private struct SupportExportManagerContext: Codable {
+        let id: String
+        let displayName: String
+        let enabled: Bool
+        let detected: Bool
+        let version: String?
+        let executablePath: String?
+        let authority: String
+    }
+
+    private struct SupportExportTaskContext: Codable {
+        let id: String
+        let status: String
+        let managerId: String?
+        let taskType: String?
+        let description: String
+        let labelKey: String?
+        let labelArgs: [String: String]?
+    }
+
+    private struct SupportExportFailureContext: Codable {
+        let taskId: String
+        let managerId: String?
+        let taskType: String?
+        let status: String
+        let description: String
+        let suggestedCommand: String?
+    }
+
+    private struct SupportExportRedactionContext: Codable {
+        let appliedRules: [String]
+        let replacementCount: Int
+    }
+
+    private struct SupportRedactor {
+        private(set) var appliedRules: Set<String> = []
+        private(set) var replacementCount: Int = 0
+        private let homeDirectory = NSHomeDirectory()
+
+        mutating func redactString(_ raw: String) -> String {
+            var value = raw
+            value = applyLiteral(
+                rule: "home_directory",
+                value: value,
+                target: homeDirectory,
+                replacement: "~"
+            )
+            value = applyRegex(
+                rule: "user_path",
+                value: value,
+                pattern: #"/Users/[^/\s]+"#,
+                replacement: "/Users/[redacted-user]"
+            )
+            value = applyRegex(
+                rule: "email",
+                value: value,
+                pattern: #"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b"#,
+                replacement: "[redacted-email]"
+            )
+            value = applyRegex(
+                rule: "github_token",
+                value: value,
+                pattern: #"\b(gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})\b"#,
+                replacement: "[redacted-token]"
+            )
+            return value
+        }
+
+        mutating func redactOptionalString(_ raw: String?) -> String? {
+            guard let raw else { return nil }
+            return redactString(raw)
+        }
+
+        mutating func redactDictionary(_ raw: [String: String]?) -> [String: String]? {
+            guard let raw else { return nil }
+            var redacted: [String: String] = [:]
+            for (key, value) in raw {
+                redacted[key] = redactString(value)
+            }
+            return redacted
+        }
+
+        private mutating func applyLiteral(
+            rule: String,
+            value: String,
+            target: String,
+            replacement: String
+        ) -> String {
+            guard !target.isEmpty else { return value }
+            let count = value.components(separatedBy: target).count - 1
+            guard count > 0 else { return value }
+            appliedRules.insert(rule)
+            replacementCount += count
+            return value.replacingOccurrences(of: target, with: replacement)
+        }
+
+        private mutating func applyRegex(
+            rule: String,
+            value: String,
+            pattern: String,
+            replacement: String
+        ) -> String {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else {
+                return value
+            }
+            let range = NSRange(value.startIndex..<value.endIndex, in: value)
+            let matches = regex.numberOfMatches(in: value, range: range)
+            guard matches > 0 else { return value }
+            appliedRules.insert(rule)
+            replacementCount += matches
+            return regex.stringByReplacingMatches(in: value, range: range, withTemplate: replacement)
+        }
+    }
     
     struct FeedbackBody {
         let type: String
@@ -612,6 +752,122 @@ struct HelmSupport {
             \(diagnostics)
             """
         }
+    }
+
+    private static func machineArchitecture() -> String {
+        var sysInfo = utsname()
+        uname(&sysInfo)
+        return withUnsafeBytes(of: &sysInfo.machine) { buf in
+            guard let baseAddress = buf.baseAddress else { return "" }
+            return String(cString: baseAddress.assumingMemoryBound(to: CChar.self))
+        }
+    }
+
+    private static func buildStructuredDiagnosticsPayload() -> SupportExportPayload {
+        let core = HelmCore.shared
+        var redactor = SupportRedactor()
+
+        let sortedManagers = core.managerStatuses.map { id, status in
+            let manager = ManagerInfo.find(byId: id)
+            let authorityRank: Int
+            switch manager?.authority {
+            case .authoritative:
+                authorityRank = 0
+            case .standard, .none:
+                authorityRank = 1
+            case .guarded:
+                authorityRank = 2
+            }
+            return (
+                id: id,
+                status: status,
+                authorityRank: authorityRank,
+                sortName: manager?.displayName ?? id,
+                authorityName: manager?.authority.key.localized ?? "standard"
+            )
+        }.sorted { lhs, rhs in
+            if lhs.authorityRank != rhs.authorityRank {
+                return lhs.authorityRank < rhs.authorityRank
+            }
+            return lhs.sortName.localizedCaseInsensitiveCompare(rhs.sortName) == .orderedAscending
+        }
+
+        let managerSnapshots = sortedManagers.map { entry in
+            SupportExportManagerContext(
+                id: entry.id,
+                displayName: localizedManagerDisplayName(entry.id),
+                enabled: entry.status.enabled,
+                detected: entry.status.detected,
+                version: redactor.redactOptionalString(entry.status.version),
+                executablePath: redactor.redactOptionalString(entry.status.executablePath),
+                authority: entry.authorityName
+            )
+        }
+
+        let taskSnapshots = core.activeTasks.map { task in
+            SupportExportTaskContext(
+                id: task.id,
+                status: task.status,
+                managerId: task.managerId,
+                taskType: task.taskType,
+                description: redactor.redactString(task.description),
+                labelKey: task.labelKey,
+                labelArgs: redactor.redactDictionary(task.labelArgs)
+            )
+        }
+
+        let failureSnapshots = core.activeTasks
+            .filter { $0.status.lowercased() == "failed" }
+            .map { task in
+                SupportExportFailureContext(
+                    taskId: task.id,
+                    managerId: task.managerId,
+                    taskType: task.taskType,
+                    status: task.status,
+                    description: redactor.redactString(task.description),
+                    suggestedCommand: redactor.redactOptionalString(core.diagnosticCommandHint(for: task))
+                )
+            }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        return SupportExportPayload(
+            schemaVersion: "1.0.0",
+            generatedAt: formatter.string(from: Date()),
+            app: SupportExportAppContext(
+                version: helmVersion,
+                locale: Locale.current.identifier,
+                distributionChannel: AppUpdateConfiguration.from().channel.rawValue,
+                safeModeEnabled: core.safeModeEnabled,
+                managerCount: core.visibleManagers.count,
+                outdatedCount: core.outdatedPackages.count,
+                runningTaskCount: core.runningTaskCount
+            ),
+            system: SupportExportSystemContext(
+                macOSVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+                architecture: machineArchitecture()
+            ),
+            managers: managerSnapshots,
+            tasks: taskSnapshots,
+            failures: failureSnapshots,
+            redaction: SupportExportRedactionContext(
+                appliedRules: redactor.appliedRules.sorted(),
+                replacementCount: redactor.replacementCount
+            )
+        )
+    }
+
+    static func generateStructuredDiagnostics() -> String {
+        let payload = buildStructuredDiagnosticsPayload()
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+
+        guard let data = try? encoder.encode(payload),
+              let json = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return json
     }
 
     static func generateDiagnostics() -> String {
@@ -684,6 +940,18 @@ struct HelmSupport {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(diagnostics, forType: .string)
+    }
+
+    static func copyStructuredDiagnosticsToClipboard() {
+        let diagnostics = generateStructuredDiagnostics()
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(diagnostics, forType: .string)
+    }
+
+    static func redactForStructuredExport(_ raw: String) -> String {
+        var redactor = SupportRedactor()
+        return redactor.redactString(raw)
     }
 
     static func generateTaskDiagnostics(task: TaskItem, suggestedCommand: String?) -> String {
@@ -771,7 +1039,7 @@ struct HelmSupport {
 
     static func reportBug(includeDiagnostics: Bool = false) {
         if includeDiagnostics {
-            copyDiagnosticsToClipboard()
+            copyStructuredDiagnosticsToClipboard()
         }
         var components = URLComponents(url: gitHubBugReportURL, resolvingAgainstBaseURL: true)
         var queryItems = components?.queryItems ?? []
@@ -784,7 +1052,7 @@ struct HelmSupport {
 
     static func requestFeature(includeDiagnostics: Bool = false) {
         if includeDiagnostics {
-            copyDiagnosticsToClipboard()
+            copyStructuredDiagnosticsToClipboard()
         }
         var components = URLComponents(url: gitHubFeatureRequestURL, resolvingAgainstBaseURL: true)
         var queryItems = components?.queryItems ?? []

--- a/apps/macos-ui/Helm/Core/L10n+App.swift
+++ b/apps/macos-ui/Helm/Core/L10n+App.swift
@@ -237,6 +237,7 @@ extension L10n {
                 static let requestFeature = "app.settings.support_feedback.request_feature"
                 static let sendFeedback = "app.settings.support_feedback.send_feedback"
                 static let copyDiagnostics = "app.settings.support_feedback.copy_diagnostics"
+                static let copyStructuredExport = "app.settings.support_feedback.copy_structured_export"
                 static let includeDiagnostics = "app.settings.support_feedback.include_diagnostics"
                 static let copiedConfirmation = "app.settings.support_feedback.copied_confirmation"
                 static let diagnosticsCopiedHint = "app.settings.support_feedback.diagnostics_copied_hint"

--- a/apps/macos-ui/Helm/Resources/locales/de/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/de/app.json
@@ -284,6 +284,7 @@
   "app.settings.support_feedback.request_feature": "Funktion vorschlagen",
   "app.settings.support_feedback.send_feedback": "Feedback senden",
   "app.settings.support_feedback.copy_diagnostics": "Diagnose kopieren",
+  "app.settings.support_feedback.copy_structured_export": "Strukturierten Export kopieren (JSON)",
   "app.settings.support_feedback.include_diagnostics": "Diagnose einschließen",
   "app.settings.support_feedback.copied_confirmation": "Kopiert!",
   "app.settings.support_feedback.diagnostics_copied_hint": "Diagnose in die Zwischenablage kopiert",

--- a/apps/macos-ui/Helm/Resources/locales/en/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/en/app.json
@@ -284,6 +284,7 @@
   "app.settings.support_feedback.request_feature": "Request a Feature",
   "app.settings.support_feedback.send_feedback": "Send Feedback",
   "app.settings.support_feedback.copy_diagnostics": "Copy Diagnostics",
+  "app.settings.support_feedback.copy_structured_export": "Copy Structured Export (JSON)",
   "app.settings.support_feedback.include_diagnostics": "Include Diagnostics",
   "app.settings.support_feedback.copied_confirmation": "Copied!",
   "app.settings.support_feedback.diagnostics_copied_hint": "Diagnostics copied to clipboard",

--- a/apps/macos-ui/Helm/Resources/locales/es/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/es/app.json
@@ -284,6 +284,7 @@
   "app.settings.support_feedback.request_feature": "Solicitar función",
   "app.settings.support_feedback.send_feedback": "Enviar comentarios",
   "app.settings.support_feedback.copy_diagnostics": "Copiar diagnósticos",
+  "app.settings.support_feedback.copy_structured_export": "Copiar exportación estructurada (JSON)",
   "app.settings.support_feedback.include_diagnostics": "Incluir diagnósticos",
   "app.settings.support_feedback.copied_confirmation": "¡Copiado!",
   "app.settings.support_feedback.diagnostics_copied_hint": "Diagnósticos copiados al portapapeles",

--- a/apps/macos-ui/Helm/Resources/locales/fr/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/fr/app.json
@@ -284,6 +284,7 @@
   "app.settings.support_feedback.request_feature": "Suggérer une fonction",
   "app.settings.support_feedback.send_feedback": "Envoyer un retour",
   "app.settings.support_feedback.copy_diagnostics": "Copier les diagnostics",
+  "app.settings.support_feedback.copy_structured_export": "Copier l'export structuré (JSON)",
   "app.settings.support_feedback.include_diagnostics": "Inclure les diagnostics",
   "app.settings.support_feedback.copied_confirmation": "Copié !",
   "app.settings.support_feedback.diagnostics_copied_hint": "Diagnostics copiés dans le presse-papiers",

--- a/apps/macos-ui/Helm/Resources/locales/ja/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/ja/app.json
@@ -284,6 +284,7 @@
   "app.settings.support_feedback.request_feature": "機能をリクエスト",
   "app.settings.support_feedback.send_feedback": "フィードバックを送信",
   "app.settings.support_feedback.copy_diagnostics": "診断情報をコピー",
+  "app.settings.support_feedback.copy_structured_export": "構造化エクスポートをコピー (JSON)",
   "app.settings.support_feedback.include_diagnostics": "診断情報を含める",
   "app.settings.support_feedback.copied_confirmation": "コピーしました",
   "app.settings.support_feedback.diagnostics_copied_hint": "診断情報をクリップボードにコピーしました",

--- a/apps/macos-ui/Helm/Resources/locales/pt-BR/app.json
+++ b/apps/macos-ui/Helm/Resources/locales/pt-BR/app.json
@@ -284,6 +284,7 @@
   "app.settings.support_feedback.request_feature": "Solicitar recurso",
   "app.settings.support_feedback.send_feedback": "Enviar feedback",
   "app.settings.support_feedback.copy_diagnostics": "Copiar diagnósticos",
+  "app.settings.support_feedback.copy_structured_export": "Copiar exportação estruturada (JSON)",
   "app.settings.support_feedback.include_diagnostics": "Incluir diagnósticos",
   "app.settings.support_feedback.copied_confirmation": "Copiado!",
   "app.settings.support_feedback.diagnostics_copied_hint": "Diagnósticos copiados para a área de transferência",

--- a/apps/macos-ui/Helm/Views/SettingsPopoverView.swift
+++ b/apps/macos-ui/Helm/Views/SettingsPopoverView.swift
@@ -263,6 +263,16 @@ struct SettingsSectionView: View {
                                     )
                                 }
                             )
+
+                            SettingsActionButton(
+                                title: L10n.App.Settings.SupportFeedback.copyStructuredExport.localized,
+                                badges: [],
+                                isProminent: false,
+                                useSystemStyle: true
+                            ) {
+                                HelmSupport.copyStructuredDiagnosticsToClipboard()
+                                showCopiedBriefly()
+                            }
                         }
                         .frame(maxWidth: .infinity, alignment: .top)
                     }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -19,6 +19,7 @@ Active milestone:
 - 0.16.2 — Sparkle connectivity hardening + macOS 11 deployment-target alignment
 - 0.17.x — Diagnostics & Logging (next implementation milestone)
   - in progress: `feat/v0.17-log-foundation` (SQLite-backed task lifecycle logs + retrieval plumbing)
+  - in progress: `feat/v0.17-structured-error-export` (structured JSON diagnostics export with redaction for support workflows)
 
 Security rollout staging status:
 - Stage 0 (`<=0.16.x`): planning/docs only (active in `0.16.1`)

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -44,7 +44,7 @@ Next release targets:
 
 - [ ] `feat/v0.17-log-foundation` — task log event model, SQLite persistence migration, FFI/XPC retrieval surface.
 - [ ] `feat/v0.17-task-log-viewer` — per-task log viewer UI with filters and pagination.
-- [ ] `feat/v0.17-structured-error-export` — structured support/error export payloads with redaction.
+- [ ] `feat/v0.17-structured-error-export` — structured support/error export payloads with redaction. (in progress: JSON export schema + clipboard workflow + redaction rules)
 - [ ] `feat/v0.17-service-health-panel` — service/runtime health diagnostics panel.
 - [ ] `feat/v0.17-manager-detection-diagnostics` — per-manager detection diagnostics and reason visibility.
 - [ ] `feat/v0.17-diagnostics-hardening` — silent-failure sweep, attribution consistency, integration/doc exit checks.
@@ -53,7 +53,6 @@ RC-1 release gate for `v0.17.x`:
 - Logs are accessible in UI.
 - No silent failures in task execution/reporting paths.
 - Support data export works and is operator-usable.
-
 License/compliance follow-through:
 - Keep `docs/legal/THIRD_PARTY_LICENSES.md` updated as dependency sets change.
 - Treat third-party notice validation as a required release gate (`docs/RELEASE_CHECKLIST.md`).

--- a/locales/de/app.json
+++ b/locales/de/app.json
@@ -284,6 +284,7 @@
   "app.settings.support_feedback.request_feature": "Funktion vorschlagen",
   "app.settings.support_feedback.send_feedback": "Feedback senden",
   "app.settings.support_feedback.copy_diagnostics": "Diagnose kopieren",
+  "app.settings.support_feedback.copy_structured_export": "Strukturierten Export kopieren (JSON)",
   "app.settings.support_feedback.include_diagnostics": "Diagnose einschließen",
   "app.settings.support_feedback.copied_confirmation": "Kopiert!",
   "app.settings.support_feedback.diagnostics_copied_hint": "Diagnose in die Zwischenablage kopiert",

--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -284,6 +284,7 @@
   "app.settings.support_feedback.request_feature": "Request a Feature",
   "app.settings.support_feedback.send_feedback": "Send Feedback",
   "app.settings.support_feedback.copy_diagnostics": "Copy Diagnostics",
+  "app.settings.support_feedback.copy_structured_export": "Copy Structured Export (JSON)",
   "app.settings.support_feedback.include_diagnostics": "Include Diagnostics",
   "app.settings.support_feedback.copied_confirmation": "Copied!",
   "app.settings.support_feedback.diagnostics_copied_hint": "Diagnostics copied to clipboard",

--- a/locales/es/app.json
+++ b/locales/es/app.json
@@ -284,6 +284,7 @@
   "app.settings.support_feedback.request_feature": "Solicitar función",
   "app.settings.support_feedback.send_feedback": "Enviar comentarios",
   "app.settings.support_feedback.copy_diagnostics": "Copiar diagnósticos",
+  "app.settings.support_feedback.copy_structured_export": "Copiar exportación estructurada (JSON)",
   "app.settings.support_feedback.include_diagnostics": "Incluir diagnósticos",
   "app.settings.support_feedback.copied_confirmation": "¡Copiado!",
   "app.settings.support_feedback.diagnostics_copied_hint": "Diagnósticos copiados al portapapeles",

--- a/locales/fr/app.json
+++ b/locales/fr/app.json
@@ -284,6 +284,7 @@
   "app.settings.support_feedback.request_feature": "Suggérer une fonction",
   "app.settings.support_feedback.send_feedback": "Envoyer un retour",
   "app.settings.support_feedback.copy_diagnostics": "Copier les diagnostics",
+  "app.settings.support_feedback.copy_structured_export": "Copier l'export structuré (JSON)",
   "app.settings.support_feedback.include_diagnostics": "Inclure les diagnostics",
   "app.settings.support_feedback.copied_confirmation": "Copié !",
   "app.settings.support_feedback.diagnostics_copied_hint": "Diagnostics copiés dans le presse-papiers",

--- a/locales/ja/app.json
+++ b/locales/ja/app.json
@@ -284,6 +284,7 @@
   "app.settings.support_feedback.request_feature": "機能をリクエスト",
   "app.settings.support_feedback.send_feedback": "フィードバックを送信",
   "app.settings.support_feedback.copy_diagnostics": "診断情報をコピー",
+  "app.settings.support_feedback.copy_structured_export": "構造化エクスポートをコピー (JSON)",
   "app.settings.support_feedback.include_diagnostics": "診断情報を含める",
   "app.settings.support_feedback.copied_confirmation": "コピーしました",
   "app.settings.support_feedback.diagnostics_copied_hint": "診断情報をクリップボードにコピーしました",

--- a/locales/pt-BR/app.json
+++ b/locales/pt-BR/app.json
@@ -284,6 +284,7 @@
   "app.settings.support_feedback.request_feature": "Solicitar recurso",
   "app.settings.support_feedback.send_feedback": "Enviar feedback",
   "app.settings.support_feedback.copy_diagnostics": "Copiar diagnósticos",
+  "app.settings.support_feedback.copy_structured_export": "Copiar exportação estruturada (JSON)",
   "app.settings.support_feedback.include_diagnostics": "Incluir diagnósticos",
   "app.settings.support_feedback.copied_confirmation": "Copiado!",
   "app.settings.support_feedback.diagnostics_copied_hint": "Diagnósticos copiados para a área de transferência",


### PR DESCRIPTION
## Summary
- add a structured JSON support export payload in HelmSupport with explicit schema/app/system/manager/task/failure sections
- add redaction rules for home directory paths, user paths, email addresses, and GitHub-style tokens before export
- wire report bug / request feature include-diagnostics flow to copy the structured export payload
- add a new Settings action (Copy Structured Export (JSON)) and localization key across all supported locales
- update docs/CURRENT_STATE.md and docs/NEXT_STEPS.md with v0.17 in-progress tracking

## Validation
- for f in apps/macos-ui/Helm/Resources/locales/{en,es,de,fr,pt-BR,ja}/app.json locales/{en,es,de,fr,pt-BR,ja}/app.json; do jq empty "$f"; done
- apps/macos-ui/scripts/check_locale_integrity.sh
- xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' build
- xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' test -only-testing:HelmTests/AppUpdateConfigurationTests -only-testing:HelmTests/UpgradePreviewPlannerTests
