### PR TITLE
feat: harden diagnostics error attribution paths

### DIFF
--- a/apps/macos-ui/Helm/Core/HelmCore+Fetching.swift
+++ b/apps/macos-ui/Helm/Core/HelmCore+Fetching.swift
@@ -8,7 +8,12 @@ extension HelmCore {
 
     func fetchPackages() {
         guard let svc = service() else { return }
-        withTimeout(30, operation: { completion in
+        withTimeout(
+            30,
+            source: "core.fetching",
+            action: "listInstalledPackages",
+            taskType: "refresh",
+            operation: { completion in
             svc.listInstalledPackages { completion($0) }
         }) { [weak self] jsonString in
             guard let jsonString = jsonString, let data = jsonString.data(using: String.Encoding.utf8) else { return }
@@ -32,14 +37,23 @@ extension HelmCore {
                 }
             } catch {
                 logger.error("fetchPackages: decode failed (\(data.count) bytes): \(error)")
-                DispatchQueue.main.async { self?.lastError = L10n.Common.error.localized }
+                self?.recordLastError(
+                    source: "core.fetching",
+                    action: "listInstalledPackages.decode",
+                    taskType: "refresh"
+                )
             }
         }
     }
 
     func fetchOutdatedPackages() {
         guard let svc = service() else { return }
-        withTimeout(30, operation: { completion in
+        withTimeout(
+            30,
+            source: "core.fetching",
+            action: "listOutdatedPackages",
+            taskType: "refresh",
+            operation: { completion in
             svc.listOutdatedPackages { completion($0) }
         }) { [weak self] jsonString in
             guard let jsonString = jsonString, let data = jsonString.data(using: String.Encoding.utf8) else { return }
@@ -71,7 +85,11 @@ extension HelmCore {
                 }
             } catch {
                 logger.error("fetchOutdatedPackages: decode failed (\(data.count) bytes): \(error)")
-                DispatchQueue.main.async { self?.lastError = L10n.Common.error.localized }
+                self?.recordLastError(
+                    source: "core.fetching",
+                    action: "listOutdatedPackages.decode",
+                    taskType: "refresh"
+                )
             }
         }
     }
@@ -79,7 +97,12 @@ extension HelmCore {
     // swiftlint:disable:next function_body_length
     func fetchTasks() {
         guard let svc = service() else { return }
-        withTimeout(30, operation: { completion in
+        withTimeout(
+            30,
+            source: "core.fetching",
+            action: "listTasks",
+            taskType: "refresh",
+            operation: { completion in
             svc.listTasks { completion($0) }
         }) { [weak self] jsonString in
             guard let jsonString = jsonString, let data = jsonString.data(using: String.Encoding.utf8) else { return }
@@ -220,7 +243,11 @@ extension HelmCore {
                 }
             } catch {
                 logger.error("fetchTasks: decode failed (\(data.count) bytes): \(error)")
-                DispatchQueue.main.async { self?.lastError = L10n.Common.error.localized }
+                self?.recordLastError(
+                    source: "core.fetching",
+                    action: "listTasks.decode",
+                    taskType: "refresh"
+                )
             }
         }
     }
@@ -273,8 +300,12 @@ extension HelmCore {
                 logger.error("fetchSearchResults: decode failed (\(data.count) bytes): \(error)")
                 DispatchQueue.main.async {
                     self?.searchResults = []
-                    self?.lastError = L10n.Common.error.localized
                 }
+                self?.recordLastError(
+                    source: "core.fetching",
+                    action: "searchLocal.decode",
+                    taskType: "search"
+                )
             }
         }
     }
@@ -337,6 +368,11 @@ extension HelmCore {
                 }
             } catch {
                 logger.error("refreshCachedAvailablePackages: decode failed (\(data.count) bytes): \(error)")
+                self?.recordLastError(
+                    source: "core.fetching",
+                    action: "refreshCachedAvailablePackages.decode",
+                    taskType: "search"
+                )
             }
         }
     }
@@ -345,7 +381,12 @@ extension HelmCore {
 
     func fetchManagerStatus() {
         guard let svc = service() else { return }
-        withTimeout(30, operation: { completion in
+        withTimeout(
+            30,
+            source: "core.fetching",
+            action: "listManagerStatus",
+            taskType: "refresh",
+            operation: { completion in
             svc.listManagerStatus { completion($0) }
         }) { [weak self] jsonString in
             guard let jsonString = jsonString, let data = jsonString.data(using: .utf8) else { return }
@@ -364,20 +405,38 @@ extension HelmCore {
                 }
             } catch {
                 logger.error("fetchManagerStatus: decode failed (\(data.count) bytes): \(error)")
-                DispatchQueue.main.async { self?.lastError = L10n.Common.error.localized }
+                self?.recordLastError(
+                    source: "core.fetching",
+                    action: "listManagerStatus.decode",
+                    taskType: "refresh"
+                )
             }
         }
     }
 
     func fetchTaskOutput(taskId: String, completion: @escaping (CoreTaskOutputRecord?) -> Void) {
-        guard let numericTaskId = Int64(taskId), let svc = service() else {
+        guard let numericTaskId = Int64(taskId) else {
+            completion(nil)
+            return
+        }
+        guard let svc = service() else {
+            recordLastError(
+                source: "core.fetching",
+                action: "getTaskOutput.service_unavailable",
+                taskType: "diagnostics"
+            )
             completion(nil)
             return
         }
 
-        withTimeout(30, operation: { callback in
+        withTimeout(
+            30,
+            source: "core.fetching",
+            action: "getTaskOutput",
+            taskType: "diagnostics",
+            operation: { callback in
             svc.getTaskOutput(taskId: numericTaskId) { callback($0) }
-        }) { jsonString in
+        }) { [weak self] jsonString in
             guard let jsonString = jsonString,
                   let data = jsonString.data(using: .utf8) else {
                 completion(nil)
@@ -391,13 +450,27 @@ extension HelmCore {
                 completion(output)
             } catch {
                 logger.error("fetchTaskOutput: decode failed (\(data.count) bytes): \(error)")
+                self?.recordLastError(
+                    source: "core.fetching",
+                    action: "getTaskOutput.decode",
+                    taskType: "diagnostics"
+                )
                 completion(nil)
             }
         }
     }
 
     func fetchTaskLogs(taskId: String, limit: Int, completion: @escaping ([CoreTaskLogRecord]?) -> Void) {
-        guard let numericTaskId = Int64(taskId), let svc = service() else {
+        guard let numericTaskId = Int64(taskId) else {
+            completion(nil)
+            return
+        }
+        guard let svc = service() else {
+            recordLastError(
+                source: "core.fetching",
+                action: "listTaskLogs.service_unavailable",
+                taskType: "diagnostics"
+            )
             completion(nil)
             return
         }
@@ -408,9 +481,14 @@ extension HelmCore {
             return
         }
 
-        withTimeout(30, operation: { callback in
+        withTimeout(
+            30,
+            source: "core.fetching",
+            action: "listTaskLogs",
+            taskType: "diagnostics",
+            operation: { callback in
             svc.listTaskLogs(taskId: numericTaskId, limit: Int64(clampedLimit)) { callback($0) }
-        }) { jsonString in
+        }) { [weak self] jsonString in
             guard let jsonString = jsonString,
                   let data = jsonString.data(using: .utf8) else {
                 completion(nil)
@@ -424,6 +502,11 @@ extension HelmCore {
                 completion(logs)
             } catch {
                 logger.error("fetchTaskLogs: decode failed (\(data.count) bytes): \(error)")
+                self?.recordLastError(
+                    source: "core.fetching",
+                    action: "listTaskLogs.decode",
+                    taskType: "diagnostics"
+                )
                 completion(nil)
             }
         }

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -23,6 +23,7 @@ Active milestone:
   - in progress: `feat/v0.17-service-health-panel` (settings diagnostics panel for service/runtime health + copyable service snapshot)
   - in progress: `feat/v0.17-task-log-viewer` (inspector diagnostics logs tab with level/status filters + load-more pagination)
   - in progress: `feat/v0.17-manager-detection-diagnostics` (manager inspector detection reason diagnostics + latest detection task metadata visibility)
+  - in progress: `feat/v0.17-diagnostics-hardening` (attributed last-error capture across fetch/action/settings failures + diagnostics export parity)
 
 Security rollout staging status:
 - Stage 0 (`<=0.16.x`): planning/docs only (active in `0.16.1`)

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -48,6 +48,7 @@ Next release targets:
 - [ ] `feat/v0.17-service-health-panel` — service/runtime health diagnostics panel. (in progress: settings health card + copyable service snapshot diagnostics)
 - [ ] `feat/v0.17-manager-detection-diagnostics` — per-manager detection diagnostics and reason visibility. (in progress: inspector reason states + latest detection task status/ID surface)
 - [ ] `feat/v0.17-diagnostics-hardening` — silent-failure sweep, attribution consistency, integration/doc exit checks.
+- [ ] `feat/v0.17-diagnostics-hardening` — silent-failure sweep, attribution consistency, integration/doc exit checks. (in progress: attributed error context capture + support snapshot/export enrichment)
 
 RC-1 release gate for `v0.17.x`:
 - Logs are accessible in UI.


### PR DESCRIPTION
## Summary
- add CoreErrorAttribution and lastErrorAttribution in HelmCore for manager/task/action/source context
- extend timeout wrappers and failure paths (fetching/actions/settings) to record attributed last-error context instead of logging-only failures
- enrich diagnostics outputs with last-error attribution in service snapshot, plain diagnostics text, and structured support export payload
- update v0.17 tracker docs to mark diagnostics-hardening as in progress

## Validation
- xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' build -quiet
- apps/macos-ui/scripts/check_locale_integrity.sh