### PR TITLE
chore: prep v0.17.0-rc.1 release artifacts and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,20 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
 
 ## [Unreleased]
 
+## [0.17.0-rc.1] - 2026-02-21
+
 ### Added
 - Third-party dependency licensing baseline document:
   - `docs/legal/THIRD_PARTY_LICENSES.md`
   - includes runtime/build/toolchain scope split and release obligations.
-- v0.17 diagnostics/logging foundation kickoff:
+- v0.17 diagnostics/logging delivery:
   - SQLite-backed task lifecycle log schema (`task_log_records`)
   - runtime lifecycle log persistence hooks (queued/running/terminal)
   - new FFI/API surface for retrieving persisted task logs (`helm_list_task_logs`)
+- Inspector diagnostics log viewer with level/status filters and load-more pagination.
+- Structured support export payloads with redaction for diagnostics and support workflows.
+- Settings service health diagnostics panel with copyable health snapshot output.
+- Manager inspector detection diagnostics (reason states plus latest detection task status/ID).
 
 ### Changed
 - Legal notice and licensing strategy docs now explicitly link to third-party dependency obligations:
@@ -26,6 +32,10 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
   - `docs/NEXT_STEPS.md`
 - ADR log adds third-party license compliance baseline decision:
   - `docs/DECISIONS.md` (Decision 023)
+- Diagnostics/reporting hardening now captures attributed last-error context (`source`, `action`, `manager`, `task_type`) across fetch/action/settings failure paths and includes that attribution in:
+  - support structured export payloads
+  - support plaintext diagnostics output
+  - service health snapshot diagnostics
 
 ## [0.16.2] - 2026-02-21
 

--- a/core/rust/Cargo.lock
+++ b/core/rust/Cargo.lock
@@ -238,7 +238,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helm-core"
-version = "0.16.2"
+version = "0.17.0-rc.1"
 dependencies = [
  "libc",
  "rusqlite",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "helm-ffi"
-version = "0.16.2"
+version = "0.17.0-rc.1"
 dependencies = [
  "cbindgen",
  "helm-core",

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -3,4 +3,4 @@ members = ["crates/helm-core", "crates/helm-ffi"]
 resolver = "2"
 
 [workspace.package]
-version = "0.16.2"
+version = "0.17.0-rc.1"

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,22 +8,22 @@ It reflects reality, not intention.
 
 ## Version
 
-Current documentation baseline: **0.16.2** (Sparkle connectivity and platform-baseline alignment patch).
+Current documentation baseline: **0.17.0-rc.1** (diagnostics/logging release-candidate prep on `dev`).
 
-Implementation baseline: **0.16.2** (latest shipped patch release target).
+Implementation baseline: **0.17.0-rc.1** (all six v0.17 diagnostics slices merged to `dev`; release prep in progress).
 
 See:
 - CHANGELOG.md
 
 Active milestone:
-- 0.16.2 — Sparkle connectivity hardening + macOS 11 deployment-target alignment
-- 0.17.x — Diagnostics & Logging (next implementation milestone)
-  - in progress: `feat/v0.17-log-foundation` (SQLite-backed task lifecycle logs + retrieval plumbing)
-  - in progress: `feat/v0.17-structured-error-export` (structured JSON diagnostics export with redaction for support workflows)
-  - in progress: `feat/v0.17-service-health-panel` (settings diagnostics panel for service/runtime health + copyable service snapshot)
-  - in progress: `feat/v0.17-task-log-viewer` (inspector diagnostics logs tab with level/status filters + load-more pagination)
-  - in progress: `feat/v0.17-manager-detection-diagnostics` (manager inspector detection reason diagnostics + latest detection task metadata visibility)
-  - in progress: `feat/v0.17-diagnostics-hardening` (attributed last-error capture across fetch/action/settings failures + diagnostics export parity)
+- latest shipped release on `main`: **0.16.2** (Sparkle connectivity hardening + macOS 11 deployment-target alignment)
+- 0.17.x — Diagnostics & Logging (**delivery merged on `dev`**, pending RC tag/release flow)
+  - delivered: `feat/v0.17-log-foundation` (SQLite-backed task lifecycle logs + retrieval plumbing)
+  - delivered: `feat/v0.17-task-log-viewer` (inspector diagnostics logs tab with level/status filters + load-more pagination)
+  - delivered: `feat/v0.17-structured-error-export` (structured JSON diagnostics export with redaction for support workflows)
+  - delivered: `feat/v0.17-service-health-panel` (settings diagnostics panel for service/runtime health + copyable service snapshot)
+  - delivered: `feat/v0.17-manager-detection-diagnostics` (manager inspector detection reason diagnostics + latest detection task metadata visibility)
+  - delivered: `feat/v0.17-diagnostics-hardening` (attributed last-error capture across fetch/action/settings failures + diagnostics export parity)
 
 Security rollout staging status:
 - Stage 0 (`<=0.16.x`): planning/docs only (active in `0.16.1`)
@@ -838,4 +838,4 @@ Helm is a **functional control plane for 28 implemented managers** with:
 
 The core architecture is in place. The Rust core passed a full audit with no critical issues.
 
-0.13.x through 0.15.x stable checkpoints are complete, and 0.16.0 release finalization is in progress. Next delivery focus after `v0.16.0` is 0.17.x diagnostics/logging hardening.
+0.13.x through 0.16.2 stable checkpoints are complete on `main`, and the full 0.17.x diagnostics/logging slice is now merged on `dev` for `v0.17.0-rc.1` release preparation.

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -11,15 +11,22 @@ It is intentionally tactical.
 Helm is in:
 
 ```
-0.16.x
+0.17.x
 ```
 
 Focus:
-- 0.16.2 Sparkle connectivity stabilization and platform-baseline alignment
-- begin 0.17.x diagnostics/logging implementation planning
+- finalize `v0.17.0-rc.1` release-prep artifacts on `dev`
+- complete validation gates and release handoff for RC tagging
 
 Current checkpoint:
-- `v0.16.2` release prep in progress (Sparkle entitlement/feed hardening + macOS 11 deployment-target enforcement)
+- `v0.17.0-rc.1` release prep in progress on `dev` after merged diagnostics/logging slices:
+  - `#93` `feat/v0.17-log-foundation`
+  - `#95` `feat/v0.17-structured-error-export`
+  - `#96` `feat/v0.17-service-health-panel`
+  - `#97` `feat/v0.17-task-log-viewer`
+  - `#98` `feat/v0.17-manager-detection-diagnostics`
+  - `#99` `feat/v0.17-diagnostics-hardening`
+- latest stable release on `main`: `v0.16.2`
 - `v0.15.0` released on `main` (tag `v0.15.0`)
 - `v0.14.0` released (merged to `main`, tagged, manager rollout + docs/version alignment complete)
 - `v0.14.1` released (merged to `main` via `#65`, tagged `v0.14.1`)
@@ -42,13 +49,12 @@ Next release targets:
 
 ## v0.17.x Delivery Tracker (Target: `v0.17.0-rc.1`)
 
-- [ ] `feat/v0.17-log-foundation` — task log event model, SQLite persistence migration, FFI/XPC retrieval surface.
-- [ ] `feat/v0.17-task-log-viewer` — per-task log viewer UI with filters and pagination. (in progress: diagnostics logs tab + filter/pagination wiring underway on this branch)
-- [ ] `feat/v0.17-structured-error-export` — structured support/error export payloads with redaction. (in progress: JSON export schema + clipboard workflow + redaction rules)
-- [ ] `feat/v0.17-service-health-panel` — service/runtime health diagnostics panel. (in progress: settings health card + copyable service snapshot diagnostics)
-- [ ] `feat/v0.17-manager-detection-diagnostics` — per-manager detection diagnostics and reason visibility. (in progress: inspector reason states + latest detection task status/ID surface)
-- [ ] `feat/v0.17-diagnostics-hardening` — silent-failure sweep, attribution consistency, integration/doc exit checks.
-- [ ] `feat/v0.17-diagnostics-hardening` — silent-failure sweep, attribution consistency, integration/doc exit checks. (in progress: attributed error context capture + support snapshot/export enrichment)
+- [x] `feat/v0.17-log-foundation` — task log event model, SQLite persistence migration, FFI/XPC retrieval surface.
+- [x] `feat/v0.17-task-log-viewer` — per-task log viewer UI with filters and pagination.
+- [x] `feat/v0.17-structured-error-export` — structured support/error export payloads with redaction.
+- [x] `feat/v0.17-service-health-panel` — service/runtime health diagnostics panel.
+- [x] `feat/v0.17-manager-detection-diagnostics` — per-manager detection diagnostics and reason visibility.
+- [x] `feat/v0.17-diagnostics-hardening` — silent-failure sweep, attribution consistency, integration/doc exit checks.
 
 RC-1 release gate for `v0.17.x`:
 - Logs are accessible in UI.
@@ -881,4 +887,4 @@ Implement:
 - 0.14 stable release alignment for `v0.14.0` is complete (README/website + version artifacts).
 - Distribution/licensing future-state planning documentation is aligned for 0.14 release notes and roadmap planning (no implementation yet).
 - 0.14.x and 0.15.x release execution are complete on `main` (`v0.14.1` and `v0.15.0`).
-- 0.16.0 release execution is in progress; next delivery slice is 0.17.x diagnostics/logging.
+- 0.16.2 release execution is complete on `main`; 0.17.x diagnostics/logging delivery is complete on `dev` pending `v0.17.0-rc.1` tag/release cut.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -9,6 +9,28 @@ This checklist is required before creating a release tag on `main`.
 - [ ] Confirm Sparkle license + external attributions remain preserved for channels that include Sparkle.
 - [ ] If distributing artifacts that include `sharp/libvips` binaries (outside static-site output), include LGPL notice/corresponding-source obligations for that artifact.
 
+## v0.17.0-rc.1 (Diagnostics & Logging RC)
+
+### Scope and Documentation
+- [x] `CHANGELOG.md` includes `0.17.0-rc.1` release-candidate notes for all diagnostics/logging slices.
+- [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect merged `0.17.x` delivery state and RC prep status.
+- [x] `docs/RELEASE_CHECKLIST.md` includes `v0.17.0-rc.1` release tasks.
+
+### Versioning
+- [x] Workspace version bumped to `0.17.0-rc.1` in `core/rust/Cargo.toml`.
+- [x] Rust lockfile local package versions aligned to `0.17.0-rc.1` in `core/rust/Cargo.lock`.
+
+### Validation
+- [x] Rust tests pass (`cargo test -p helm-core -p helm-ffi --manifest-path core/rust/Cargo.toml`).
+- [x] `HelmTests` pass (`xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' test`).
+- [x] Locale checks pass (`apps/macos-ui/scripts/check_locale_integrity.sh` and `apps/macos-ui/scripts/check_locale_lengths.sh`).
+
+### Branch and Tag
+- [ ] Open release-prep PR into `dev` and complete CI checks.
+- [ ] Merge release-prep PR into `dev`.
+- [ ] Create annotated RC tag from `dev` lineage: `git tag -a v0.17.0-rc.1 -m "Helm v0.17.0-rc.1"`.
+- [ ] Push RC tag: `git push origin v0.17.0-rc.1`.
+
 ## v0.16.2 (Sparkle Connectivity + macOS 11 Alignment)
 
 ### Scope and Documentation


### PR DESCRIPTION
## Summary
- bump Rust workspace/package versions to `0.17.0-rc.1`
- add `0.17.0-rc.1` changelog release-candidate notes for delivered diagnostics/logging slices
- update `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` to reflect full `0.17.x` delivery merged on `dev`
- add and mark completed `v0.17.0-rc.1` release-prep checklist items (docs/versioning/validation)

## Validation
- `cargo test -p helm-core -p helm-ffi --manifest-path core/rust/Cargo.toml`
- `xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' test`
- `apps/macos-ui/scripts/check_locale_integrity.sh`
- `apps/macos-ui/scripts/check_locale_lengths.sh`
