### PR TITLE
fix: prepare v0.17.0-rc.2 updater hotfix release

### DIFF
--- a/.github/workflows/release-macos-dmg.yml
+++ b/.github/workflows/release-macos-dmg.yml
@@ -414,6 +414,7 @@ jobs:
           APPCAST_PATH="$PWD/build/release-assets/appcast.xml"
           DOWNLOAD_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG_NAME}/Helm-${TAG_NAME}-macos-universal.dmg"
           RELEASE_NOTES_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG_NAME}"
+          DISPLAY_VERSION="${TAG_NAME#v}"
 
           apps/macos-ui/scripts/generate_sparkle_appcast.sh \
             --app-path "$APP_PATH" \
@@ -421,6 +422,7 @@ jobs:
             --output-path "$APPCAST_PATH" \
             --download-url "$DOWNLOAD_URL" \
             --appcast-url "$HELM_SPARKLE_FEED_URL" \
+            --display-version "$DISPLAY_VERSION" \
             --release-notes-url "$RELEASE_NOTES_URL"
 
       - name: Enforce Sparkle appcast policy (full installer only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
 
 ## [Unreleased]
 
+## [0.17.0-rc.2] - 2026-02-21
+
+### Changed
+- Sparkle appcast generation now supports an explicit display-version override so prerelease tags are preserved in appcast metadata (`sparkle:shortVersionString` / title) instead of collapsing to stripped marketing versions.
+- Release workflow now passes display version derived from tag name when generating Sparkle appcasts (for example, `v0.17.0-rc.2` -> `0.17.0-rc.2`).
+- Release DMG verification now enforces Sparkle installer-launcher and sandbox entitlement requirements used by sandboxed updater flows.
+
+### Fixed
+- Enabled Sparkle installer launcher service in app metadata (`SUEnableInstallerLauncherService`) for direct-channel updater installs.
+- Added required Sparkle sandbox entitlement exceptions for installer/status mach services (`-spki`, `-spks`) and shared preference access in both debug and release app entitlements.
+- Addressed Sparkle installer-launch failures seen in `v0.17.0-rc.1` (`Failed to make auth right set`, `Failed copying system domain rights: -60005`, `Failed to submit installer job`), which surfaced as “An error occurred while launching the installer.”
+
 ## [0.17.0-rc.1] - 2026-02-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <br>
   A native macOS menu bar app for unified package manager control.
   <br>
-  <strong>Pre-1.0 &middot; v0.17.0-rc.1</strong>
+  <strong>Pre-1.0 &middot; v0.17.0-rc.2</strong>
 </p>
 
 <p align="center">
@@ -23,9 +23,9 @@
 
 Helm manages software across multiple package managers (Homebrew, npm, pip, Cargo, etc.) and runtime tools (mise, rustup) from a single menu bar interface. It is designed as infrastructure software: deterministic, safety-first, and explicit about authority, orchestration, and error handling.
 
-> **Status:** Active pre-1.0 development at `v0.17.0-rc.1` (Diagnostics & Logging RC on `dev`; latest stable on `main` is `v0.16.2`).
+> **Status:** Active pre-1.0 development at `v0.17.0-rc.2` (Diagnostics & Logging RC on `dev`; latest stable on `main` is `v0.16.2`).
 >
-> **Testing:** Please test `v0.17.0-rc.1` and report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Testing:** Please test `v0.17.0-rc.2` and report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Editions (Beta)
 

--- a/apps/macos-ui/Helm/Helm.entitlements
+++ b/apps/macos-ui/Helm/Helm.entitlements
@@ -6,5 +6,14 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
+	</array>
+	<key>com.apple.security.temporary-exception.shared-preference.read-write</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	</array>
 </dict>
 </plist>

--- a/apps/macos-ui/Helm/HelmRelease.entitlements
+++ b/apps/macos-ui/Helm/HelmRelease.entitlements
@@ -6,5 +6,14 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
+	</array>
+	<key>com.apple.security.temporary-exception.shared-preference.read-write</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	</array>
 </dict>
 </plist>

--- a/apps/macos-ui/Helm/Info.plist
+++ b/apps/macos-ui/Helm/Info.plist
@@ -8,6 +8,8 @@
 	<string>$(HELM_SPARKLE_ENABLED)</string>
 	<key>LSUIElement</key>
 	<true/>
+	<key>SUEnableInstallerLauncherService</key>
+	<true/>
 	<key>SUAllowsDowngrades</key>
 	<string>$(HELM_SPARKLE_ALLOW_DOWNGRADES)</string>
 	<key>SUFeedURL</key>

--- a/apps/macos-ui/scripts/generate_sparkle_appcast.sh
+++ b/apps/macos-ui/scripts/generate_sparkle_appcast.sh
@@ -9,6 +9,7 @@ Usage: generate_sparkle_appcast.sh \
   --output-path <appcast.xml> \
   --download-url <https://.../Helm.dmg> \
   --appcast-url <https://.../appcast.xml> \
+  [--display-version <X.Y.Z[-prerelease]>] \
   [--release-notes-url <https://...>] \
   [--sparkle-bin-dir <Sparkle bin directory>] \
   [--sparkle-package-path <Sparkle checkout path, legacy fallback>]
@@ -24,6 +25,7 @@ OUTPUT_PATH=""
 DOWNLOAD_URL=""
 APPCAST_URL=""
 RELEASE_NOTES_URL=""
+DISPLAY_VERSION=""
 SPARKLE_PACKAGE_PATH=""
 SPARKLE_BIN_DIR=""
 
@@ -51,6 +53,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --release-notes-url)
       RELEASE_NOTES_URL="$2"
+      shift 2
+      ;;
+    --display-version)
+      DISPLAY_VERSION="$2"
       shift 2
       ;;
     --sparkle-bin-dir)
@@ -153,6 +159,7 @@ fi
 SHORT_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$INFO_PLIST")
 BUNDLE_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$INFO_PLIST")
 MIN_SYSTEM_VERSION=$(/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" "$INFO_PLIST" 2>/dev/null || true)
+APPCAST_DISPLAY_VERSION="${DISPLAY_VERSION:-$SHORT_VERSION}"
 
 if [[ -z "$RELEASE_NOTES_URL" ]]; then
   RELEASE_NOTES_URL="$APPCAST_URL"
@@ -194,13 +201,13 @@ cat > "$OUTPUT_PATH" <<XML
     <description>Helm direct-channel updates</description>
     <language>en</language>
     <item>
-      <title>Helm $SHORT_VERSION</title>
+      <title>Helm $APPCAST_DISPLAY_VERSION</title>
       <pubDate>$PUB_DATE</pubDate>
       <sparkle:releaseNotesLink>$RELEASE_NOTES_URL</sparkle:releaseNotesLink>
       <enclosure
         url="$DOWNLOAD_URL"
         sparkle:version="$BUNDLE_VERSION"
-        sparkle:shortVersionString="$SHORT_VERSION"
+        sparkle:shortVersionString="$APPCAST_DISPLAY_VERSION"
         sparkle:edSignature="$SIGNATURE"
         $MIN_SYSTEM_VERSION_ATTR
         length="$LENGTH"

--- a/apps/macos-ui/scripts/verify_release_dmg.sh
+++ b/apps/macos-ui/scripts/verify_release_dmg.sh
@@ -51,6 +51,7 @@ plist_value() {
 }
 
 ATTACH_PLIST="$(mktemp "${TMPDIR:-/tmp}/helm-dmg-attach.XXXXXX.plist")"
+HELM_ENTITLEMENTS_PLIST="$(mktemp "${TMPDIR:-/tmp}/helm-entitlements.XXXXXX.plist")"
 DEVICE=""
 MOUNT_PATH=""
 
@@ -58,7 +59,7 @@ cleanup() {
   if [[ -n "$DEVICE" ]]; then
     hdiutil detach "$DEVICE" >/dev/null 2>&1 || hdiutil detach -force "$DEVICE" >/dev/null 2>&1 || true
   fi
-  rm -f "$ATTACH_PLIST"
+  rm -f "$ATTACH_PLIST" "$HELM_ENTITLEMENTS_PLIST"
 }
 trap cleanup EXIT
 
@@ -123,9 +124,11 @@ fi
 
 CHANNEL="$(plist_value "HelmDistributionChannel" "$APP_INFO_PLIST")"
 SPARKLE_ENABLED="$(plist_value "HelmSparkleEnabled" "$APP_INFO_PLIST")"
+SPARKLE_INSTALLER_LAUNCHER_SERVICE_ENABLED="$(plist_value "SUEnableInstallerLauncherService" "$APP_INFO_PLIST")"
 SPARKLE_ALLOWS_DOWNGRADES="$(plist_value "SUAllowsDowngrades" "$APP_INFO_PLIST")"
 SPARKLE_FEED_URL="$(plist_value "SUFeedURL" "$APP_INFO_PLIST")"
 SPARKLE_PUBLIC_ED_KEY="$(plist_value "SUPublicEDKey" "$APP_INFO_PLIST")"
+BUNDLE_IDENTIFIER="$(plist_value "CFBundleIdentifier" "$APP_INFO_PLIST")"
 
 if [[ "$CHANNEL" != "developer_id" ]]; then
   echo "error: HelmDistributionChannel must be developer_id in release DMG, found: $CHANNEL" >&2
@@ -134,6 +137,11 @@ fi
 
 if ! is_truthy "$SPARKLE_ENABLED"; then
   echo "error: HelmSparkleEnabled must be true in release DMG, found: $SPARKLE_ENABLED" >&2
+  exit 1
+fi
+
+if ! is_truthy "$SPARKLE_INSTALLER_LAUNCHER_SERVICE_ENABLED"; then
+  echo "error: SUEnableInstallerLauncherService must be true in release DMG, found: $SPARKLE_INSTALLER_LAUNCHER_SERVICE_ENABLED" >&2
   exit 1
 fi
 
@@ -164,6 +172,33 @@ fi
 
 if ! otool -L "$HELM_BIN" | grep -q "Sparkle.framework"; then
   echo "error: Helm binary in DMG is not linked against Sparkle.framework" >&2
+  exit 1
+fi
+
+if [[ -z "$BUNDLE_IDENTIFIER" ]]; then
+  echo "error: CFBundleIdentifier missing from release DMG app Info.plist" >&2
+  exit 1
+fi
+
+if ! codesign -d --entitlements :- "$HELM_BIN" > "$HELM_ENTITLEMENTS_PLIST" 2>/dev/null; then
+  echo "error: failed to extract Helm entitlements for release DMG verification" >&2
+  exit 1
+fi
+
+EXPECTED_SPKS="${BUNDLE_IDENTIFIER}-spks"
+EXPECTED_SPKI="${BUNDLE_IDENTIFIER}-spki"
+if ! /usr/libexec/PlistBuddy -c "Print :com.apple.security.temporary-exception.mach-lookup.global-name" "$HELM_ENTITLEMENTS_PLIST" 2>/dev/null | grep -q "$EXPECTED_SPKS"; then
+  echo "error: missing Sparkle status mach-lookup entitlement ($EXPECTED_SPKS) in Helm binary" >&2
+  exit 1
+fi
+
+if ! /usr/libexec/PlistBuddy -c "Print :com.apple.security.temporary-exception.mach-lookup.global-name" "$HELM_ENTITLEMENTS_PLIST" 2>/dev/null | grep -q "$EXPECTED_SPKI"; then
+  echo "error: missing Sparkle installer mach-lookup entitlement ($EXPECTED_SPKI) in Helm binary" >&2
+  exit 1
+fi
+
+if ! /usr/libexec/PlistBuddy -c "Print :com.apple.security.temporary-exception.shared-preference.read-write" "$HELM_ENTITLEMENTS_PLIST" 2>/dev/null | grep -q "$BUNDLE_IDENTIFIER"; then
+  echo "error: missing Sparkle shared-preference entitlement ($BUNDLE_IDENTIFIER) in Helm binary" >&2
   exit 1
 fi
 

--- a/core/rust/Cargo.lock
+++ b/core/rust/Cargo.lock
@@ -238,7 +238,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helm-core"
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.2"
 dependencies = [
  "libc",
  "rusqlite",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "helm-ffi"
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.2"
 dependencies = [
  "cbindgen",
  "helm-core",

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -3,4 +3,4 @@ members = ["crates/helm-core", "crates/helm-ffi"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.2"

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,22 +8,23 @@ It reflects reality, not intention.
 
 ## Version
 
-Current documentation baseline: **0.17.0-rc.1** (diagnostics/logging release-candidate prep on `dev`).
+Current documentation baseline: **0.17.0-rc.2** (diagnostics/logging RC hardening on `dev`).
 
-Implementation baseline: **0.17.0-rc.1** (all six v0.17 diagnostics slices merged to `dev`; release prep in progress).
+Implementation baseline: **0.17.0-rc.2** (all six v0.17 diagnostics slices merged; updater/install RC hardening applied on `dev`).
 
 See:
 - CHANGELOG.md
 
 Active milestone:
 - latest shipped release on `main`: **0.16.2** (Sparkle connectivity hardening + macOS 11 deployment-target alignment)
-- 0.17.x — Diagnostics & Logging (**delivery merged on `dev`**, pending RC tag/release flow)
+- 0.17.x — Diagnostics & Logging (**delivery merged on `dev`**, `v0.17.0-rc.1` released, `v0.17.0-rc.2` hotfix RC prep in progress)
   - delivered: `feat/v0.17-log-foundation` (SQLite-backed task lifecycle logs + retrieval plumbing)
   - delivered: `feat/v0.17-task-log-viewer` (inspector diagnostics logs tab with level/status filters + load-more pagination)
   - delivered: `feat/v0.17-structured-error-export` (structured JSON diagnostics export with redaction for support workflows)
   - delivered: `feat/v0.17-service-health-panel` (settings diagnostics panel for service/runtime health + copyable service snapshot)
   - delivered: `feat/v0.17-manager-detection-diagnostics` (manager inspector detection reason diagnostics + latest detection task metadata visibility)
   - delivered: `feat/v0.17-diagnostics-hardening` (attributed last-error capture across fetch/action/settings failures + diagnostics export parity)
+  - delivered: `v0.17.0-rc.2` updater hardening (Sparkle sandbox installer entitlements + launcher service metadata + prerelease appcast short-version preservation)
   - release-prep validation status: green (`cargo test`, macOS `xcodebuild` suite, locale integrity + locale length audits)
 
 Security rollout staging status:
@@ -866,4 +867,4 @@ Helm is a **functional control plane for 28 implemented managers** with:
 
 The core architecture is in place. The Rust core passed a full audit with no critical issues.
 
-0.13.x through 0.16.2 stable checkpoints are complete on `main`, and the full 0.17.x diagnostics/logging slice is now merged on `dev` for `v0.17.0-rc.1` release preparation.
+0.13.x through 0.16.2 stable checkpoints are complete on `main`; `v0.17.0-rc.1` has been released, and updater/install hardening for `v0.17.0-rc.2` is staged on `dev`.

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -15,19 +15,20 @@ Helm is in:
 ```
 
 Focus:
-- finalize `v0.17.0-rc.1` release-prep artifacts on `dev`
-- complete release handoff tasks (release-prep PR, merge, RC tag creation/push)
+- finalize `v0.17.0-rc.2` updater hardening release-prep artifacts on `dev`
+- complete `rc.2` release handoff tasks (release-prep PR, merge, RC tag creation/push)
 
 Current checkpoint:
-- `v0.17.0-rc.1` release prep in progress on `dev` after merged diagnostics/logging slices:
+- `v0.17.0-rc.2` release prep in progress on `dev` after merged diagnostics/logging slices and updater hotfix follow-through:
   - `#93` `feat/v0.17-log-foundation`
   - `#95` `feat/v0.17-structured-error-export`
   - `#96` `feat/v0.17-service-health-panel`
   - `#97` `feat/v0.17-task-log-viewer`
   - `#98` `feat/v0.17-manager-detection-diagnostics`
   - `#99` `feat/v0.17-diagnostics-hardening`
+  - updater/install hardening for Sparkle sandboxed flows and prerelease appcast short-version labeling
 - latest stable release on `main`: `v0.16.2`
-- validation gates currently green for RC prep (`cargo test`, macOS `xcodebuild` tests, locale integrity/length audits)
+- validation gates currently green for RC prep (`cargo test`, macOS `xcodebuild` tests, locale integrity/length audits, release workflow smoke from `v0.17.0-rc.1`)
 - `v0.15.0` released on `main` (tag `v0.15.0`)
 - `v0.14.0` released (merged to `main`, tagged, manager rollout + docs/version alignment complete)
 - `v0.14.1` released (merged to `main` via `#65`, tagged `v0.14.1`)
@@ -48,7 +49,7 @@ Next release targets:
 - `v0.18.x` — Local security groundwork (internal-only)
 - `v0.19.x` — Stability & Pre-1.0 hardening
 
-## v0.17.x Delivery Tracker (Target: `v0.17.0-rc.1`)
+## v0.17.x Delivery Tracker (Target: `v0.17.0-rc.2`)
 
 - [x] `feat/v0.17-log-foundation` — task log event model, SQLite persistence migration, FFI/XPC retrieval surface.
 - [x] `feat/v0.17-task-log-viewer` — per-task log viewer UI with filters and pagination.
@@ -57,11 +58,14 @@ Next release targets:
 - [x] `feat/v0.17-manager-detection-diagnostics` — per-manager detection diagnostics and reason visibility.
 - [x] `feat/v0.17-diagnostics-hardening` — silent-failure sweep, attribution consistency, integration/doc exit checks.
 - [x] `v0.17.0-rc.1` localization follow-through — manager display-name key coverage expanded across all implemented manager IDs with brand-preserving labels; Hungarian (`hu`) locale added with onboarding + service/error translation bootstrap and CI parity checks.
+- [x] `v0.17.0-rc.2` updater/install hardening — Sparkle sandbox installer entitlements + installer launcher service metadata added; prerelease appcast short-version labeling now preserves RC identifiers.
 
-RC-1 release gate for `v0.17.x`:
+RC-2 release gate for `v0.17.x`:
 - Logs are accessible in UI.
 - No silent failures in task execution/reporting paths.
 - Support data export works and is operator-usable.
+- Sparkle updater can launch installer successfully for eligible direct-channel installs.
+- Appcast `sparkle:shortVersionString` preserves prerelease labels for RC builds.
 License/compliance follow-through:
 - Keep `docs/legal/THIRD_PARTY_LICENSES.md` updated as dependency sets change.
 - Treat third-party notice validation as a required release gate (`docs/RELEASE_CHECKLIST.md`).
@@ -889,4 +893,4 @@ Implement:
 - 0.14 stable release alignment for `v0.14.0` is complete (README/website + version artifacts).
 - Distribution/licensing future-state planning documentation is aligned for 0.14 release notes and roadmap planning (no implementation yet).
 - 0.14.x and 0.15.x release execution are complete on `main` (`v0.14.1` and `v0.15.0`).
-- 0.16.2 release execution is complete on `main`; 0.17.x diagnostics/logging delivery is complete on `dev` pending `v0.17.0-rc.1` tag/release cut.
+- 0.16.2 release execution is complete on `main`; 0.17.x diagnostics/logging delivery is complete with `v0.17.0-rc.1` released and `v0.17.0-rc.2` updater hardening in release prep on `dev`.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -31,10 +31,39 @@ This checklist is required before creating a release tag on `main`.
 - [x] Locale checks pass (`apps/macos-ui/scripts/check_locale_integrity.sh` and `apps/macos-ui/scripts/check_locale_lengths.sh`).
 
 ### Branch and Tag
+- [x] Open release-prep PR into `dev` and complete CI checks.
+- [x] Merge release-prep PR into `dev`.
+- [x] Create annotated RC tag from `dev` lineage: `git tag -a v0.17.0-rc.1 -m "Helm v0.17.0-rc.1"`.
+- [x] Push RC tag: `git push origin v0.17.0-rc.1`.
+
+## v0.17.0-rc.2 (Updater Install/Version Label Hotfix RC)
+
+### Scope and Documentation
+- [x] `CHANGELOG.md` includes `0.17.0-rc.2` release-candidate notes for updater install + appcast version-label fixes.
+- [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect `rc.2` updater hardening status.
+- [x] Website changelog includes `0.17.0-rc.2` notes.
+
+### Versioning
+- [x] Workspace version bumped to `0.17.0-rc.2` in `core/rust/Cargo.toml`.
+- [x] Rust lockfile local package versions aligned to `0.17.0-rc.2` in `core/rust/Cargo.lock`.
+
+### Updater/Sparkle Hardening
+- [x] App entitlements include Sparkle installer/status mach-lookup exceptions and shared-preference exception in both debug/release profiles.
+- [x] App metadata enables Sparkle installer launcher service (`SUEnableInstallerLauncherService=true`).
+- [x] Appcast generation supports explicit prerelease display version and writes that value into `sparkle:shortVersionString`.
+- [x] Release workflow passes tag-derived display version into appcast generation.
+- [x] Release DMG verification enforces Sparkle installer launcher + entitlement requirements.
+
+### Validation
+- [x] Rust tests pass (`cargo test -p helm-core -p helm-ffi --manifest-path core/rust/Cargo.toml`).
+- [x] `HelmTests` pass (`xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' test`).
+- [x] Locale checks pass (`apps/macos-ui/scripts/check_locale_integrity.sh` and `apps/macos-ui/scripts/check_locale_lengths.sh`).
+
+### Branch and Tag
 - [ ] Open release-prep PR into `dev` and complete CI checks.
 - [ ] Merge release-prep PR into `dev`.
-- [ ] Create annotated RC tag from `dev` lineage: `git tag -a v0.17.0-rc.1 -m "Helm v0.17.0-rc.1"`.
-- [ ] Push RC tag: `git push origin v0.17.0-rc.1`.
+- [ ] Create annotated RC tag from `dev` lineage: `git tag -a v0.17.0-rc.2 -m "Helm v0.17.0-rc.2"`.
+- [ ] Push RC tag: `git push origin v0.17.0-rc.2`.
 
 ## v0.16.2 (Sparkle Connectivity + macOS 11 Alignment)
 

--- a/docs/legal/THIRD_PARTY_LICENSES.md
+++ b/docs/legal/THIRD_PARTY_LICENSES.md
@@ -22,8 +22,8 @@ The Helm project license (`LICENSE`) does not replace third-party license obliga
 
 Release context:
 
-- docs baseline: `v0.17.0-rc.1`
-- app release baseline: `v0.17.0-rc.1` (RC branch on `dev`)
+- docs baseline: `v0.17.0-rc.2`
+- app release baseline: `v0.17.0-rc.2` (RC branch on `dev`)
 
 ### 1) macOS App Runtime Dependencies
 

--- a/web/src/content/docs/changelog.md
+++ b/web/src/content/docs/changelog.md
@@ -11,6 +11,20 @@ For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncav
 
 ---
 
+## 0.17.0-rc.2 — 2026-02-21
+
+### Changed
+- Sparkle appcast generation now preserves prerelease display versions (for example, `0.17.0-rc.2`) in `sparkle:shortVersionString` and appcast item titles.
+- Release automation now passes tag-derived display versions into appcast generation for prerelease tags.
+- Release DMG verification now enforces Sparkle installer-launcher and sandbox entitlement requirements for updater compatibility.
+
+### Fixed
+- Enabled Sparkle installer launcher service metadata in Helm app bundles for sandboxed update installs.
+- Added required Sparkle sandbox entitlement exceptions for installer/status mach services and shared preference access.
+- Fixed updater install failures seen in `v0.17.0-rc.1` where Sparkle could download updates but fail launching the installer.
+
+---
+
 ## 0.17.0-rc.1 — 2026-02-21
 
 ### Added


### PR DESCRIPTION
## Summary
This PR prepares `v0.17.0-rc.2` as a hotfix RC after validating updater failures seen in `v0.17.0-rc.1`.

### Issues addressed
1. Sparkle update UI reported `0.17.0` instead of `0.17.0-rc.1`.
2. Sparkle downloaded update but failed to launch installer.

### Root cause evidence (from unified logs)
- `Failed to make auth right set`
- `Failed copying system domain rights: -60005`
- `Failed to submit installer job`
- `Error: An error occurred while launching the installer. Please try again later.`

## Changes
- Added Sparkle sandbox installer entitlements in app + release profiles:
  - `com.apple.security.temporary-exception.mach-lookup.global-name`
    - `$(PRODUCT_BUNDLE_IDENTIFIER)-spks`
    - `$(PRODUCT_BUNDLE_IDENTIFIER)-spki`
  - `com.apple.security.temporary-exception.shared-preference.read-write`
    - `$(PRODUCT_BUNDLE_IDENTIFIER)`
- Enabled installer launcher service in app metadata:
  - `SUEnableInstallerLauncherService = true`
- Updated appcast generator to support explicit display version override and emit it to:
  - item title
  - `sparkle:shortVersionString`
- Updated release workflow to pass display version from tag (`${TAG_NAME#v}`), preserving prerelease labels.
- Hardened release DMG verification to enforce Sparkle installer launcher + entitlement requirements.
- Bumped workspace version metadata to `0.17.0-rc.2`.
- Updated changelog/docs/release checklist/README to `rc.2` state.

## Validation
- `cargo test -p helm-core -p helm-ffi --manifest-path core/rust/Cargo.toml`
- `apps/macos-ui/scripts/check_locale_integrity.sh`
- `apps/macos-ui/scripts/check_locale_lengths.sh`
- `xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' test`

All above passed.
