### PR TITLE
chore: adopt dev/docs/web branch workflow model

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,8 +2,9 @@ name: Semgrep
 
 on:
   pull_request:
+    branches: [ "main", "dev" ]
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
 
 permissions:
   contents: read

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -2,9 +2,9 @@ name: SwiftLint
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,16 +259,20 @@ Helm is infrastructure. Treat it like one.
 ## 13. Git Workflow (Required)
 
 ### Branch model
-- `main`: stable/releasable; protected; merges come from `dev` (except hotfixes).
-- `dev`: integration branch; protected; feature work merges here first.
-- Feature branches: branch off `dev`, merge back to `dev` via PR:
-  - `feat/...`, `fix/...`, `chore/...`, `docs/...`, `test/...`, `refactor/...`
-- Hotfixes: branch off `main` as `hotfix/...`, then merge into both `main` and `dev`.
+- `main`: stable/releasable branch; protected.
+- `dev`: code integration branch; protected; app/core/runtime work merges here first.
+- `docs`: documentation integration branch; protected; docs/policy/licensing docs work merges here first.
+- `web`: website integration branch; protected; website work under `web/` merges here first.
+- Feature branches:
+  - code work: branch from `dev`, open PRs to `dev` (`feat/...`, `fix/...`, `chore/...`, `test/...`, `refactor/...`)
+  - docs work: branch from `docs`, open PRs to `docs` (`docs/...`)
+  - website work: branch from `web`, open PRs to `web` (`web/...`)
+- Hotfixes: branch from `main` as `hotfix/...`, merge to `main`, then back-merge/cherry-pick to each impacted integration branch (`dev`, `docs`, `web` as applicable).
 
 ### Rules
-- Do not commit directly to `main`.
+- Do not commit directly to long-lived branches: `main`, `dev`, `docs`, `web`.
 - Exception: direct commits to `main` are allowed when explicitly instructed by the user/repo owner in the current session.
-- Avoid committing directly to `dev` except trivial docs fixes; prefer PRs.
+- Prefer PR-based updates for all long-lived branches.
 - Do not rewrite published history (no force-push) unless explicitly instructed.
 - Prefer small, coherent commits.
 
@@ -290,7 +294,13 @@ Helm uses different integration branches depending on change type.
 
 #### Documentation-Only Changes
 - Use `docs/...` branches
-- Open PRs targeting `main`
+- Branch from `docs`
+- Open PRs targeting `docs`
+
+#### Website-Only Changes
+- Use `web/...` branches
+- Branch from `web`
+- Open PRs targeting `web`
 
 Documentation-only changes include:
 - README updates
@@ -300,6 +310,14 @@ Documentation-only changes include:
 If a change includes both code and documentation:
 - Prefer merging into `dev`
 - Or split into separate PRs if appropriate
+
+If a change includes both documentation and website updates (without app code):
+- Prefer split PRs (`docs` and `web`) unless explicitly instructed to combine.
+
+Promotion to stable `main`:
+- App releases: merge `dev` -> `main`
+- Docs publishes: merge `docs` -> `main`
+- Website publishes: merge `web` -> `main`
 
 Agents must select the correct base branch before starting work.
 If unsure, ask for clarification.
@@ -401,12 +419,22 @@ Before starting work, agents MUST:
 2. Update their branch:
 
    ```bash
+   # code branches
    git rebase origin/dev
    ```
 
-   or, for documentation branches:
+   ```bash
+   # documentation branches
+   git rebase origin/docs
+   ```
 
    ```bash
+   # website branches
+   git rebase origin/web
+   ```
+
+   ```bash
+   # hotfix/release branches based on stable
    git rebase origin/main
    ```
 
@@ -446,7 +474,7 @@ Agents SHOULD:
 Agents should:
 
 * Push their branch to origin
-* Open a PR targeting the correct base branch (`dev` or `main`)
+* Open a PR targeting the correct base branch (`dev`, `docs`, `web`, or `main`)
 * Keep PRs small and focused
 
 ---

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -36,6 +36,8 @@ This checklist is required before creating a release tag on `main`.
 ### Branch and Tag
 - [ ] Release-prep PR merged to `dev`.
 - [ ] `dev` merged into `main` for stable cut.
+- [ ] If release-critical docs updates were developed on `docs`, merge `docs` into `main`.
+- [ ] If release-critical website updates were developed on `web`, merge `web` into `main`.
 - [ ] Create annotated stable tag from `main`: `git tag -a v0.17.0 -m "Helm v0.17.0"`.
 - [ ] Push stable tag: `git push origin v0.17.0`.
 - [ ] Publish GitHub release for `v0.17.0` (mark as latest, non-prerelease).

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -71,7 +71,7 @@ Pre-1.0:
 
 ## Tagging Rules
 
-- Stable releases: tag from `main` after merging from `dev`.
+- Stable app releases: tag from `main` after merging from `dev`.
 - Pre-release tags (alpha, beta, rc): may be tagged from `dev` lineage when the release is not yet merged to `main`.
 - Format: vX.Y.Z[-tag]
 
@@ -83,6 +83,23 @@ v1.0.0
 
 ---
 
+## Branch Integration Model
+
+- `dev` is the integration branch for app/runtime/core code.
+- `docs` is the integration branch for documentation/policy/licensing docs.
+- `web` is the integration branch for website implementation under `web/`.
+- `main` remains the stable/releasable branch.
+
+Promotion flow:
+
+- code release content: `dev` -> `main`
+- docs-only publication content: `docs` -> `main`
+- website-only publication content: `web` -> `main`
+
+Only app releases are version-tagged by default; standalone docs/website publications generally do not require a SemVer tag unless explicitly tied to a release cut.
+
+---
+
 ## Release Flow
 
 1. Complete milestone work on `dev`.
@@ -90,10 +107,11 @@ v1.0.0
    - `core/rust/Cargo.toml` (workspace version)
    - Generated files: `apps/macos-ui/Generated/HelmVersion.swift` and `apps/macos-ui/Generated/HelmVersion.xcconfig` (auto-generated from build script)
 3. Update changelog and release checklist.
-4. Merge `dev` → `main`.
-5. Create annotated tag.
-6. Push tag to GitHub.
-7. Generate release notes.
+4. Merge `dev` -> `main`.
+5. If release-critical docs/website deltas were developed on `docs` or `web`, merge those branches into `main` via PR before tagging.
+6. Create annotated tag.
+7. Push tag to GitHub.
+8. Generate release notes.
 
 Release checklist document:
 - `docs/RELEASE_CHECKLIST.md`


### PR DESCRIPTION
## Summary
- formalize long-lived branch responsibilities in AGENTS (`main`, `dev`, `docs`, `web`)
- update versioning/release docs for promotion flow from `dev`, `docs`, and `web` into `main`
- align SwiftLint and Semgrep triggers to run on `main` and `dev` pushes/PRs

## Notes
- repository rulesets were also updated directly in GitHub:
  - existing `main` ruleset retained
  - new ruleset added for `dev`, `docs`, and `web` requiring PRs and blocking direct updates/force-push/deletion
- long-lived `docs` and `web` branches were created from `main`
