### PR TITLE
chore: prepare v0.17.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-02-22
+
+Patch `0.17.1` supersedes the failed `v0.17.0` artifact build attempt and ships stable signed artifacts from the corrected release source.
+
+### Fixed
+- macOS release build now succeeds for stable tags by including the `LocalizationManager` explicit-`self` capture fix in release-tagged source.
+- Stable release packaging flow now produces signed/notarized artifacts from the corrected `0.17.1` tag lineage, avoiding the `v0.17.0` tag's compile-time failure during DMG build.
+
 ## [0.17.0] - 2026-02-22
 
 Stable `0.17.0` consolidates all `rc.1` through `rc.5` delivery slices plus final release-readiness hardening across diagnostics, updater reliability, UI responsiveness, and website release surfaces.

--- a/core/rust/Cargo.lock
+++ b/core/rust/Cargo.lock
@@ -238,7 +238,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helm-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "libc",
  "rusqlite",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "helm-ffi"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cbindgen",
  "helm-core",

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -3,4 +3,4 @@ members = ["crates/helm-core", "crates/helm-ffi"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.1"

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -14,17 +14,17 @@ This checklist is required before creating a release tag on `main`.
 - [x] Confirm `.github/workflows/deploy-web.yml` is absent (Cloudflare Pages is the production website host).
 - [x] Confirm website hosting/operations docs still point to Cloudflare Pages and not GitHub Pages.
 
-## v0.17.0 (Stable Release Gate)
+## v0.17.1 (Stable Patch Release Gate)
 
 ### Scope and Documentation
-- [ ] `CHANGELOG.md` includes finalized `0.17.0` stable notes with RC consolidation context.
-- [ ] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect stable release-cut status from `v0.17.0-rc.5`.
-- [ ] Website changelog includes `0.17.0` stable entry and release-order alignment.
+- [ ] `CHANGELOG.md` includes finalized `0.17.1` patch notes for the stable artifact rebuild cut.
+- [ ] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect `v0.17.1` stable release-cut status.
+- [ ] Website changelog includes `0.17.1` patch entry and release-order alignment.
 
 ### Versioning
-- [ ] Workspace version bumped to `0.17.0` in `core/rust/Cargo.toml`.
-- [ ] Rust lockfile local package versions aligned to `0.17.0` in `core/rust/Cargo.lock`.
-- [ ] Generated app version artifacts aligned to `0.17.0` (`apps/macos-ui/Generated/HelmVersion.swift`, `apps/macos-ui/Generated/HelmVersion.xcconfig`).
+- [ ] Workspace version bumped to `0.17.1` in `core/rust/Cargo.toml`.
+- [ ] Rust lockfile local package versions aligned to `0.17.1` in `core/rust/Cargo.lock`.
+- [ ] Generated app version artifacts aligned to `0.17.1` (`apps/macos-ui/Generated/HelmVersion.swift`, `apps/macos-ui/Generated/HelmVersion.xcconfig`).
 
 ### Validation
 - [ ] Rust tests pass (`cargo test -p helm-core -p helm-ffi --manifest-path core/rust/Cargo.toml`).
@@ -38,9 +38,9 @@ This checklist is required before creating a release tag on `main`.
 - [ ] `dev` merged into `main` for stable cut.
 - [ ] If release-critical docs updates were developed on `docs`, merge `docs` into `main`.
 - [ ] If release-critical website updates were developed on `web`, merge `web` into `main`.
-- [ ] Create annotated stable tag from `main`: `git tag -a v0.17.0 -m "Helm v0.17.0"`.
-- [ ] Push stable tag: `git push origin v0.17.0`.
-- [ ] Publish GitHub release for `v0.17.0` (mark as latest, non-prerelease).
+- [ ] Create annotated stable tag from `main`: `git tag -a v0.17.1 -m "Helm v0.17.1"`.
+- [ ] Push stable tag: `git push origin v0.17.1`.
+- [ ] Publish GitHub release for `v0.17.1` (mark as latest, non-prerelease).
 
 ## Historical RC and Prior-Release Checklists (Archive)
 

--- a/web/src/content/docs/changelog.md
+++ b/web/src/content/docs/changelog.md
@@ -13,6 +13,14 @@ For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncav
 
 ## Unreleased
 
+## 0.17.1 — 2026-02-22
+
+Patch `0.17.1` supersedes the failed `v0.17.0` artifact build attempt and ships stable signed artifacts from the corrected release source.
+
+### Fixed
+- Stable macOS release builds now include the `LocalizationManager` explicit-`self` capture fix required by release compilation settings.
+- Release packaging now publishes signed/notarized artifacts from the corrected `0.17.1` tag lineage instead of the failed `v0.17.0` tag build.
+
 ## 0.17.0 — 2026-02-22
 
 Stable `0.17.0` consolidates all `rc.1` through `rc.5` deliveries and includes final release-readiness hardening across diagnostics, updater reliability, responsiveness, and website release surfaces.


### PR DESCRIPTION
## Summary
- bump workspace version to `0.17.1`
- align local crate versions in `Cargo.lock` to `0.17.1`
- add `0.17.1` patch notes to root and website changelogs
- retarget active release checklist gate to `v0.17.1`

## Why
`v0.17.0` artifact packaging failed because the tag points to pre-fix source. This patch release re-cuts stable artifacts from corrected source without rewriting existing tag history.
