### PR TITLE
fix: unblock semgrep on generated release-notes pages

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,3 @@
+# Generated static release-note pages (build artifacts committed for Sparkle hosting).
+# These files are generated from CHANGELOG content and can trigger generic HTML integrity rules.
+web/public/updates/release-notes/*.html


### PR DESCRIPTION
## Summary
- add `.semgrepignore` entry for generated `web/public/updates/release-notes/*.html`

## Why
Generated release-notes HTML pages committed for Sparkle hosting are triggering a generic HTML integrity rule in Semgrep and blocking `dev` PR checks.
