### PR TITLE
chore(release): publish Sparkle appcast + release notes for v0.17.1

### DIFF
--- a/web/public/updates/appcast.xml
+++ b/web/public/updates/appcast.xml
@@ -6,16 +6,16 @@
     <description>Helm direct-channel updates</description>
     <language>en</language>
     <item>
-      <title>Helm 0.17.0-rc.5</title>
-      <pubDate>Sun, 22 Feb 2026 03:16:56 +0000</pubDate>
-      <sparkle:releaseNotesLink>https://helmapp.dev/updates/release-notes/v0.17.0-rc.5.html</sparkle:releaseNotesLink>
+      <title>Helm 0.17.1</title>
+      <pubDate>Sun, 22 Feb 2026 07:05:52 +0000</pubDate>
+      <sparkle:releaseNotesLink>https://helmapp.dev/updates/release-notes/v0.17.1.html</sparkle:releaseNotesLink>
       <enclosure
-        url="https://github.com/jasoncavinder/Helm/releases/download/v0.17.0-rc.5/Helm-v0.17.0-rc.5-macos-universal.dmg"
-        sparkle:version="17000605"
-        sparkle:shortVersionString="0.17.0-rc.5"
-        sparkle:edSignature="1xLIGMqHdj6ui46uyU5eaEg0udv0rFKuK4B4il6cWWUCMEunoBLyVvdgLByS55c5ee9W1WokkWkgXumTIgDGAw=="
+        url="https://github.com/jasoncavinder/Helm/releases/download/v0.17.1/Helm-v0.17.1-macos-universal.dmg"
+        sparkle:version="17001900"
+        sparkle:shortVersionString="0.17.1"
+        sparkle:edSignature="vb8ewoXtYNKG0CqUq5LMjoTXQ1Gm93pjbRa1a4RYWaIhxJlOT5JHnMtTVSR7ScT9/nWNs01Si2RWuenix+TTCg=="
          sparkle:minimumSystemVersion="11.0"
-        length="13098147"
+        length="13091986"
         type="application/octet-stream"/>
     </item>
   </channel>

--- a/web/public/updates/release-notes/v0.17.1.html
+++ b/web/public/updates/release-notes/v0.17.1.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Helm 0.17.1 Release Notes</title>
+  <link rel="canonical" href="https://helmapp.dev/updates/release-notes/v0.17.1.html">
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif;
+      line-height: 1.55;
+      background: #f7f8fa;
+      color: #111827;
+    }
+    main {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 24px;
+    }
+    article {
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      padding: 24px;
+    }
+    h1 {
+      margin: 0 0 4px;
+      font-size: 1.6rem;
+      line-height: 1.3;
+    }
+    h2 {
+      margin: 24px 0 8px;
+      font-size: 1.1rem;
+    }
+    p, ul {
+      margin: 8px 0;
+    }
+    ul {
+      padding-left: 20px;
+    }
+    .meta {
+      color: #4b5563;
+      font-size: 0.95rem;
+      margin: 0 0 12px;
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      background: #f3f4f6;
+      border-radius: 6px;
+      padding: 0.1rem 0.35rem;
+      font-size: 0.92em;
+    }
+    footer {
+      margin-top: 16px;
+      color: #6b7280;
+      font-size: 0.9rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      body {
+        background: #0b1220;
+        color: #e5e7eb;
+      }
+      article {
+        background: #0f172a;
+        border-color: #1f2937;
+      }
+      .meta {
+        color: #9ca3af;
+      }
+      code {
+        background: #111827;
+      }
+      footer {
+        color: #9ca3af;
+      }
+      a {
+        color: #93c5fd;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <article>
+      <h1>Helm 0.17.1 Release Notes</h1>
+      <p class="meta">Release date: February 22, 2026</p>
+    <p>Patch <code>0.17.1</code> supersedes the failed <code>v0.17.0</code> artifact build attempt and ships stable signed artifacts from the corrected release source.</p>
+    <h2>Fixed</h2>
+    <ul>
+      <li>macOS release build now succeeds for stable tags by including the <code>LocalizationManager</code> explicit-<code>self</code> capture fix in release-tagged source.</li>
+      <li>Stable release packaging flow now produces signed/notarized artifacts from the corrected <code>0.17.1</code> tag lineage, avoiding the <code>v0.17.0</code> tag&#x27;s compile-time failure during DMG build.</li>
+    </ul>
+    <p class="meta">Need full context? <a href="https://github.com/jasoncavinder/Helm/releases/tag/v0.17.1" rel="noopener noreferrer">View this release on GitHub</a>.</p>
+    </article>
+    <footer>Generated from <code>CHANGELOG.md</code>.</footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
This PR publishes release metadata generated by `Release macOS DMG` for `v0.17.1`:

- `web/public/updates/appcast.xml`
- `web/public/updates/release-notes/v0.17.1.html`

The release workflow could not push directly to `main` due branch rules and could not auto-create this PR with the Actions token.
