### PR TITLE
fix: repair Appcast Drift Guard heredoc parsing

### DIFF
--- a/.github/workflows/appcast-drift.yml
+++ b/.github/workflows/appcast-drift.yml
@@ -40,32 +40,31 @@ jobs:
           fi
           EXPECTED_VERSION="${LATEST_STABLE_TAG#v}"
 
-          APPCAST_VERSION="$(
-            FEED_PATH="$FEED_PATH" python3 - <<'PY'
-            import os
-            import xml.etree.ElementTree as ET
+          APPCAST_VERSION="$(FEED_PATH="$FEED_PATH" python3 - <<'PY'
+import os
+import xml.etree.ElementTree as ET
 
-            sparkle_ns = "http://www.andymatuschak.org/xml-namespaces/sparkle"
-            feed_path = os.environ["FEED_PATH"]
+sparkle_ns = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+feed_path = os.environ["FEED_PATH"]
 
-            root = ET.parse(feed_path).getroot()
-            item = root.find("./channel/item")
-            if item is None:
-                print("")
-                raise SystemExit(0)
+root = ET.parse(feed_path).getroot()
+item = root.find("./channel/item")
+if item is None:
+    print("")
+    raise SystemExit(0)
 
-            enclosure = item.find("enclosure")
-            version = ""
-            if enclosure is not None:
-                version = enclosure.attrib.get(f"{{{sparkle_ns}}}shortVersionString", "").strip()
+enclosure = item.find("enclosure")
+version = ""
+if enclosure is not None:
+    version = enclosure.attrib.get(f"{{{sparkle_ns}}}shortVersionString", "").strip()
 
-            if not version:
-                title = (item.findtext("title") or "").strip()
-                if title.lower().startswith("helm "):
-                    version = title[5:].strip()
+if not version:
+    title = (item.findtext("title") or "").strip()
+    if title.lower().startswith("helm "):
+        version = title[5:].strip()
 
-            print(version)
-            PY
+print(version)
+PY
           )"
 
           if [ -z "$APPCAST_VERSION" ]; then


### PR DESCRIPTION
Fixes a shell/heredoc indentation issue in .github/workflows/appcast-drift.yml that caused the drift guard script to fail with an unexpected EOF before parsing appcast versions.