### PR TITLE
fix: make appcast drift guard workflow yaml-safe

### DIFF
--- a/.github/workflows/appcast-drift.yml
+++ b/.github/workflows/appcast-drift.yml
@@ -40,32 +40,7 @@ jobs:
           fi
           EXPECTED_VERSION="${LATEST_STABLE_TAG#v}"
 
-          APPCAST_VERSION="$(FEED_PATH="$FEED_PATH" python3 - <<'PY'
-import os
-import xml.etree.ElementTree as ET
-
-sparkle_ns = "http://www.andymatuschak.org/xml-namespaces/sparkle"
-feed_path = os.environ["FEED_PATH"]
-
-root = ET.parse(feed_path).getroot()
-item = root.find("./channel/item")
-if item is None:
-    print("")
-    raise SystemExit(0)
-
-enclosure = item.find("enclosure")
-version = ""
-if enclosure is not None:
-    version = enclosure.attrib.get(f"{{{sparkle_ns}}}shortVersionString", "").strip()
-
-if not version:
-    title = (item.findtext("title") or "").strip()
-    if title.lower().startswith("helm "):
-        version = title[5:].strip()
-
-print(version)
-PY
-          )"
+          APPCAST_VERSION="$(FEED_PATH="$FEED_PATH" python3 -c 'import os, xml.etree.ElementTree as ET; sparkle_ns = \"http://www.andymatuschak.org/xml-namespaces/sparkle\"; root = ET.parse(os.environ[\"FEED_PATH\"]).getroot(); item = root.find(\"./channel/item\"); enclosure = item.find(\"enclosure\") if item is not None else None; version = enclosure.attrib.get(f\"{{{sparkle_ns}}}shortVersionString\", \"\").strip() if enclosure is not None else \"\"; title = (item.findtext(\"title\") or \"\").strip() if item is not None else \"\"; print(version or (title[5:].strip() if title.lower().startswith(\"helm \") else \"\"))')"
 
           if [ -z "$APPCAST_VERSION" ]; then
             echo "::error::Unable to parse top appcast version from ${FEED_PATH}"


### PR DESCRIPTION
Replaces the heredoc-based Python block in .github/workflows/appcast-drift.yml with a single-line python3 -c invocation so the workflow YAML remains valid and the drift guard can execute reliably.