### PR TITLE
fix: correct appcast drift parser quoting

### DIFF
--- a/.github/workflows/appcast-drift.yml
+++ b/.github/workflows/appcast-drift.yml
@@ -40,7 +40,7 @@ jobs:
           fi
           EXPECTED_VERSION="${LATEST_STABLE_TAG#v}"
 
-          APPCAST_VERSION="$(FEED_PATH="$FEED_PATH" python3 -c 'import os, xml.etree.ElementTree as ET; sparkle_ns = \"http://www.andymatuschak.org/xml-namespaces/sparkle\"; root = ET.parse(os.environ[\"FEED_PATH\"]).getroot(); item = root.find(\"./channel/item\"); enclosure = item.find(\"enclosure\") if item is not None else None; version = enclosure.attrib.get(f\"{{{sparkle_ns}}}shortVersionString\", \"\").strip() if enclosure is not None else \"\"; title = (item.findtext(\"title\") or \"\").strip() if item is not None else \"\"; print(version or (title[5:].strip() if title.lower().startswith(\"helm \") else \"\"))')"
+          APPCAST_VERSION="$(FEED_PATH="$FEED_PATH" python3 -c 'import os, xml.etree.ElementTree as ET; sparkle_ns = "http://www.andymatuschak.org/xml-namespaces/sparkle"; root = ET.parse(os.environ["FEED_PATH"]).getroot(); item = root.find("./channel/item"); enclosure = item.find("enclosure") if item is not None else None; version = enclosure.attrib.get(f"{{{sparkle_ns}}}shortVersionString", "").strip() if enclosure is not None else ""; title = (item.findtext("title") or "").strip() if item is not None else ""; print(version or (title[5:].strip() if title.lower().startswith("helm ") else ""))')"
 
           if [ -z "$APPCAST_VERSION" ]; then
             echo "::error::Unable to parse top appcast version from ${FEED_PATH}"


### PR DESCRIPTION
Removes escaped quotes inside the python -c string in .github/workflows/appcast-drift.yml so Python receives valid syntax and Appcast Drift Guard can execute.