### PR TITLE
docs(web): add v0.17.2 website release notes and blog post

### DIFF
--- a/web/src/content/docs/blog/2026-02-22-v0-17-2-release.mdx
+++ b/web/src/content/docs/blog/2026-02-22-v0-17-2-release.mdx
@@ -1,0 +1,28 @@
+---
+title: "Helm v0.17.2 Released"
+description: "v0.17.2 is now live with manager-selection execution routing, onboarding/detection hardening, and diagnostics UX improvements."
+summary: "A quick release note for v0.17.2 and what changed in this stable patch."
+publishDate: 2026-02-22
+author: Helm Team
+sidebar:
+  label: "v0.17.2 release"
+---
+
+Helm `v0.17.2` is now released on `main`.
+
+This stable patch follows `v0.17.0` and `v0.17.1` and focuses on operator-facing reliability and control improvements across manager execution selection, onboarding detection flow, and diagnostics usability.
+
+## Highlights
+
+- Manager executable-path and install-method selections are now actionable and enforced in runtime command routing.
+- Onboarding now runs detection-only first-pass behavior with clearer version-loading state handling.
+- Failed-task diagnostics now support selectable text and `Copy All` actions across diagnostics, stdout, stderr, and logs.
+- Disabled manager behavior is now consistently enforced across refresh/search/task flows.
+- Dark-mode list-surface styling is aligned in both Tasks and Packages views.
+
+## Release links
+
+- [GitHub Release: v0.17.2](https://github.com/jasoncavinder/Helm/releases/tag/v0.17.2)
+- [Changelog](https://helmapp.dev/changelog/)
+
+If you run into issues, please file a report with environment details and reproduction steps in [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).

--- a/web/src/content/docs/changelog.md
+++ b/web/src/content/docs/changelog.md
@@ -13,6 +13,27 @@ For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncav
 
 ## Unreleased
 
+## 0.17.2 — 2026-02-22
+
+Patch `0.17.2` ships post-`0.17.x` manager-control, onboarding/detection, and Control Center execution-plan fixes as a stable incremental release.
+
+### Added
+- Manager selection controls are now operational in the Manager Inspector: users can choose a manager executable path (including PATH-default mode) and preferred install method, with preferences persisted and surfaced through XPC/FFI manager status payloads.
+- Diagnostics views for failed tasks now include selectable text and per-pane `Copy All` controls for `diagnostics`, `stderr`, `stdout`, and `logs`.
+- Runtime detection telemetry now emits structured per-manager timing events (including slow-detection warnings at `>= 3000ms`) for operator troubleshooting.
+
+### Changed
+- Core execution now routes manager commands through selected executable overrides instead of implicit PATH resolution, and manager install/update/uninstall flows honor selected install method where implemented (`mise`, `mas`, `rustup`).
+- Onboarding detection now runs a detection-only pipeline (without automatic refresh list work), pre-seeds manager presence immediately from executable-path discovery, and shows localized `Loading` version placeholders until version probes complete.
+- Onboarding flow now places license acceptance as step 2 (after welcome) and completes onboarding without a second-pass loop.
+- Execution-plan modal presentation is now scoped to the initiating surface (Control Center vs popover), preventing dual-modal presentation.
+
+### Fixed
+- Disabled managers are now fully enforced across runtime behavior: excluded from refresh/search/package/task surfaces, rejected at centralized task submission, removed from manager-scope pickers, and canceled when disabled mid-flight.
+- Manager executable discovery now falls back to direct filesystem probing across known bin locations when `which` lookup fails.
+- Packages and Tasks list background surfaces now align with dark-mode branding in the redesigned Control Center.
+- The deprecated execution-plan `Dry Run` footer action has been removed.
+
 ## 0.17.1 — 2026-02-22
 
 Patch `0.17.1` supersedes the failed `v0.17.0` artifact build attempt and ships stable signed artifacts from the corrected release source.


### PR DESCRIPTION
Website sync follow-up for v0.17.2 release visibility.\n\nChanges:\n- add explicit 0.17.2 released section to website changelog\n- add new blog entry announcing Helm v0.17.2 release\n\nValidation:\n- npm run build (web)