### PR TITLE
docs(web): publish v0.17.2 website updates

### DIFF
--- a/web/src/content/docs/blog/2026-02-22-v0-17-0-release-readiness.mdx
+++ b/web/src/content/docs/blog/2026-02-22-v0-17-0-release-readiness.mdx
@@ -1,30 +1,31 @@
 ---
-title: "Toward v0.17.0: Release Readiness and Final Validation"
-description: "What changed through the v0.17.0 RC cycle and what we are validating before the stable cut."
-summary: "A concise update on RC hardening, updater reliability, diagnostics improvements, and the final validation gate for v0.17.0."
+title: "v0.17.x Stable: Current Status at v0.17.2"
+description: "v0.17.0 shipped stable and v0.17.2 is now the current patch release on main."
+summary: "A short recap of what shipped in 0.17.x and where Helm is headed next."
 publishDate: 2026-02-22
 author: Helm Team
 sidebar:
-  label: "v0.17.0 readiness"
+  label: "v0.17.2 status"
 ---
 
-Helm `v0.17.0` is moving from release-candidate hardening toward the stable cut.
+Helm `v0.17.x` has completed release-candidate hardening and shipped stable. The latest release on `main` is `v0.17.2`.
 
-## What landed during the RC cycle
+## What shipped in 0.17.x
 
-- Self-update reliability fixes for Sparkle prerelease semantics and installer launch behavior.
-- Expanded diagnostics coverage across task lifecycle logging, manager detection details, and support export workflows.
-- Inspector and task-surface quality improvements for command/output visibility and troubleshooting flow.
-- Privileged-action authentication support using managed `sudo -A` handling for elevated manager operations.
-- Responsiveness work in Control Center and popover surfaces, including adaptive polling and lazy list rendering.
+- Stable diagnostics/logging delivery: task log viewing, structured support export, service health visibility, and manager detection diagnostics.
+- Onboarding and detection hardening: detection-only first-run flow, immediate presence signals, and version-loading states while probes finish.
+- Manager execution-control improvements: explicit executable-path and install-method selection with persistence and runtime command routing.
+- Manager enablement enforcement: disabled managers are now excluded from task/search/refresh flows and their in-flight tasks are canceled.
+- Control Center and inspector polish: execution-plan presentation scoping, diagnostics usability improvements, and dark-mode list-surface fixes.
 
-## Stable-release gate
+## Release status
 
-Before the stable `v0.17.0` release, we are validating:
+- `v0.17.0`: stable cut from the full RC lineage (`rc.1` through `rc.5`).
+- `v0.17.1`: stable patch correcting artifact-release lineage after the failed `v0.17.0` build attempt.
+- `v0.17.2`: current stable patch with manager-selection execution routing, onboarding fixes, diagnostics UX improvements, and release-flow guardrail follow-up.
 
-- Core Rust and macOS test suites.
-- Localization integrity and length safety.
-- Updater feed behavior and direct-channel update checks.
-- Release-process artifacts and website/changelog synchronization.
+## What’s next
 
-If you are testing `v0.17.0-rc.5`, please file any reproducible issue details in GitHub with environment, expected behavior, and observed behavior.
+Current planning focus is `0.18.x` local security groundwork while monitoring post-release feedback from `v0.17.2`.
+
+If you hit reproducible issues, please file details in GitHub with environment, expected behavior, and observed behavior.

--- a/web/src/content/docs/blog/2026-02-22-v0-17-2-release.mdx
+++ b/web/src/content/docs/blog/2026-02-22-v0-17-2-release.mdx
@@ -1,0 +1,28 @@
+---
+title: "Helm v0.17.2 Released"
+description: "v0.17.2 is now live with manager-selection execution routing, onboarding/detection hardening, and diagnostics UX improvements."
+summary: "A quick release note for v0.17.2 and what changed in this stable patch."
+publishDate: 2026-02-22
+author: Helm Team
+sidebar:
+  label: "v0.17.2 release"
+---
+
+Helm `v0.17.2` is now released on `main`.
+
+This stable patch follows `v0.17.0` and `v0.17.1` and focuses on operator-facing reliability and control improvements across manager execution selection, onboarding detection flow, and diagnostics usability.
+
+## Highlights
+
+- Manager executable-path and install-method selections are now actionable and enforced in runtime command routing.
+- Onboarding now runs detection-only first-pass behavior with clearer version-loading state handling.
+- Failed-task diagnostics now support selectable text and `Copy All` actions across diagnostics, stdout, stderr, and logs.
+- Disabled manager behavior is now consistently enforced across refresh/search/task flows.
+- Dark-mode list-surface styling is aligned in both Tasks and Packages views.
+
+## Release links
+
+- [GitHub Release: v0.17.2](https://github.com/jasoncavinder/Helm/releases/tag/v0.17.2)
+- [Changelog](https://helmapp.dev/changelog/)
+
+If you run into issues, please file a report with environment details and reproduction steps in [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).

--- a/web/src/content/docs/changelog.md
+++ b/web/src/content/docs/changelog.md
@@ -18,21 +18,21 @@ For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncav
 Patch `0.17.2` ships post-`0.17.x` manager-control, onboarding/detection, and Control Center execution-plan fixes as a stable incremental release.
 
 ### Added
-- Manager Inspector executable/install-method selection is now actionable and persisted, including explicit PATH-default executable mode.
-- Failed-task diagnostics panes now support selectable text and `Copy All` controls for `diagnostics`, `stderr`, `stdout`, and `logs`.
-- Runtime detection now emits structured per-manager timing telemetry with slow-detection warnings at `>=3000ms`.
+- Manager selection controls are now operational in the Manager Inspector: users can choose a manager executable path (including PATH-default mode) and preferred install method, with preferences persisted and surfaced through XPC/FFI manager status payloads.
+- Diagnostics views for failed tasks now include selectable text and per-pane `Copy All` controls for `diagnostics`, `stderr`, `stdout`, and `logs`.
+- Runtime detection telemetry now emits structured per-manager timing events (including slow-detection warnings at `>= 3000ms`) for operator troubleshooting.
 
 ### Changed
-- Core manager execution now uses selected executable overrides instead of implicit PATH dependency, and manager install/update/uninstall flows honor selected install method where implemented (`mise`, `mas`, `rustup`).
-- Onboarding detection now runs detection-only (no immediate refresh list work), pre-seeds manager presence immediately, and shows localized `Loading` placeholders until version probes finish.
-- License acceptance now appears as onboarding step 2 and no longer loops onboarding after acceptance.
-- Execution-plan modal presentation is now host-scoped to the initiating surface (Control Center vs popover), preventing duplicate modal presentation.
+- Core execution now routes manager commands through selected executable overrides instead of implicit PATH resolution, and manager install/update/uninstall flows honor selected install method where implemented (`mise`, `mas`, `rustup`).
+- Onboarding detection now runs a detection-only pipeline (without automatic refresh list work), pre-seeds manager presence immediately from executable-path discovery, and shows localized `Loading` version placeholders until version probes complete.
+- Onboarding flow now places license acceptance as step 2 (after welcome) and completes onboarding without a second-pass loop.
+- Execution-plan modal presentation is now scoped to the initiating surface (Control Center vs popover), preventing dual-modal presentation.
 
 ### Fixed
-- Disabled managers are now enforced across refresh/search/package/task behavior, centralized task submission, and in-flight cancellation.
-- Manager executable discovery now falls back to direct filesystem probing when `which` lookup fails.
-- Packages and Tasks list dark-mode backgrounds now align with app branding.
-- Removed deprecated execution-plan `Dry Run` action.
+- Disabled managers are now fully enforced across runtime behavior: excluded from refresh/search/package/task surfaces, rejected at centralized task submission, removed from manager-scope pickers, and canceled when disabled mid-flight.
+- Manager executable discovery now falls back to direct filesystem probing across known bin locations when `which` lookup fails.
+- Packages and Tasks list background surfaces now align with dark-mode branding in the redesigned Control Center.
+- The deprecated execution-plan `Dry Run` footer action has been removed.
 
 ## 0.17.1 — 2026-02-22
 

--- a/web/src/content/docs/guides/visual-tour.mdx
+++ b/web/src/content/docs/guides/visual-tour.mdx
@@ -27,7 +27,7 @@ import onboardingSpotlightShotDark from '../../../assets/tour/onboarding-spotlig
 Helm has two main surfaces: a **menu bar popover** for quick triage and a **Control Center window** for deeper management. This tour walks through each.
 
 <Aside type="note">
-Screenshots show Helm `v0.16.0` UI surfaces on macOS. Minor styling may change between builds, and screenshot refreshes are applied as new app captures are published.
+Screenshots show Helm `v0.17.2` UI surfaces on macOS. Minor styling may change between builds, and screenshot refreshes are applied as new app captures are published.
 </Aside>
 
 ---

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -17,7 +17,7 @@ Helm is planned as two product lifecycles: **Helm (Consumer)** and **Helm Busine
 
 ## What it does today
 
-Helm `v0.16.x` supports twenty-eight managers:
+Helm `v0.17.2` supports twenty-eight managers:
 
 | Category | Managers |
 |---------|----------|
@@ -45,7 +45,7 @@ Key features:
 - **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, and `ja` with locale override in Settings
 - **Upgrade transparency** — dedicated upgrade preview surface with scoped execution and failure-attribution visibility
 
-> **Current Track:** `v0.16.0` release finalization is in progress for pre-1.0 testing. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.17.2` is the latest stable release on `main`; `0.18.x` planning is in progress. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## How it works
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -30,15 +30,15 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 | 0.13.x | UI/UX Analysis & Redesign — full UX audit, interaction model, visual system refresh, accessibility, onboarding walkthrough, inspector sidebar, support & feedback entry points (`v0.13.0` stable released) |
 | 0.14.x | Platform, Detection & Optional Managers — Docker, Xcode, Rosetta, Sparkle, Setapp, Homebrew casks, optional managers (`v0.14.x` stable, latest patch `v0.14.1`) |
 | 0.15.x | Advanced Upgrade Transparency — richer execution-plan visibility, failure isolation, and operator controls (`v0.15.0` released) |
-| 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification (`v0.16.0` release finalization in progress) |
+| 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification (`v0.16.x` stable, latest patch `v0.16.2`) |
+| 0.17.x | Diagnostics & Logging + Release Hardening — task log viewer, structured diagnostics export, manager-detection diagnostics, onboarding/detection hardening, manager-selection controls, and stable release follow-up fixes (`v0.17.0` stable, latest patch `v0.17.2`) |
 
-> **Testing:** `v0.16.0` is in pre-1.0 release finalization. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.17.2` is stable on `main`; planning is shifting to `0.18.x` local security groundwork. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Planned
 
 | Version | Milestone |
 |---|---|
-| 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel |
 | 0.18.x | Local Security Groundwork — local vulnerability abstractions and cache plumbing (internal only) |
 | 0.19.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit |
 | 1.0.0 | Stable Control Plane Release — production-safe execution, full feature set |


### PR DESCRIPTION
Publishes website content updates for the v0.17.2 release status.\n\nIncludes:\n- roadmap/current-track alignment (0.17.x in completed, not planned)\n- website changelog v0.17.2 entry\n- dedicated v0.17.2 release blog entry\n- updated release-status recap post and visual-tour version note\n\nValidation:\n- npm run build (web)