### PR TITLE
Remove Unreleased section from changelog

### DIFF
--- a/web/src/content/docs/changelog.md
+++ b/web/src/content/docs/changelog.md
@@ -11,8 +11,6 @@ For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncav
 
 ---
 
-## Unreleased
-
 ## 0.17.2 — 2026-02-22
 
 Patch `0.17.2` ships post-`0.17.x` manager-control, onboarding/detection, and Control Center execution-plan fixes as a stable incremental release.


### PR DESCRIPTION
Removed 'Unreleased' section from changelog.

## Summary

- What changed: removed "unreleased" from changelog for v0.17.2 
- Why: AV0.17.2 has been released. 

## Branch Policy

- [x] Base branch is correct for this scope (`dev`, `docs`, `web`, or `main` hotfix/promotion flow).
- [x] Head branch naming follows policy (`feat/`, `fix/`, `chore/`, `test/`, `refactor/`, `docs-*`, `web-*`, `hotfix/`, `release/`, or `chore/publish-updates-*`).
- [x] If targeting `main`, source branch is valid (`dev`, `docs`, `web`, `hotfix/*`, `release/*`, or `chore/publish-updates-*`).

## Scope Declaration

- [ ] App/core/runtime changes included
- [ ] Docs-only changes included
- [x] Website-only changes included

## Validation

- [x] Relevant local validation was run (tests/lint/build as applicable).
- [x] Required CI checks for the target branch are expected to pass.
- [x] No unrelated changes were bundled.

## Release Impact

- [x] No release impact.
- [ ] Release impact exists and checklist/docs were updated (`docs/RELEASE_CHECKLIST.md`, `docs/CURRENT_STATE.md`, `docs/NEXT_STEPS.md`).
