### PR TITLE
release: publish v0.17.3 web content

### DIFF
--- a/web/src/components/starlight/Banner.astro
+++ b/web/src/components/starlight/Banner.astro
@@ -1,5 +1,5 @@
 ---
-const globalBanner = `<strong>Help test Helm v0.17.2.</strong> Install the latest beta and report issues on <a href="https://github.com/jasoncavinder/Helm/issues/new/choose" target="_blank" rel="noreferrer">GitHub</a>.`;
+const globalBanner = `<strong>Helm v0.17.3 is live.</strong> Install the latest release and report issues on <a href="https://github.com/jasoncavinder/Helm/issues/new/choose" target="_blank" rel="noreferrer">GitHub</a>.`;
 const pageBanner = Astro.locals.starlightRoute.entry.data.banner?.content;
 const banners = [globalBanner, pageBanner].filter(Boolean);
 ---

--- a/web/src/content/docs/blog/2026-02-23-v0-17-3-release.mdx
+++ b/web/src/content/docs/blog/2026-02-23-v0-17-3-release.mdx
@@ -1,0 +1,28 @@
+---
+title: "Helm v0.17.3 Released"
+description: "v0.17.3 is now live with CLI parity hardening, provenance/update safety guardrails, and release-channel reliability improvements."
+summary: "A quick release note for v0.17.3 and what changed in this stable patch."
+publishDate: 2026-02-23
+author: Helm Team
+sidebar:
+  label: "v0.17.3 release"
+---
+
+Helm `v0.17.3` is now released on `main`.
+
+This stable patch follows `v0.17.2` and focuses on CLI contract hardening, self-update safety, and release/distribution guardrails.
+
+## Highlights
+
+- `helm doctor` is now a first-class diagnostics alias with provenance-focused default output.
+- CLI self-update now consistently enforces channel policy and direct-script safety constraints.
+- Install marker and distribution profile contracts are now machine-readable and validated in CI.
+- Shared GUI+CLI coordinator authority paths were hardened for mutation and cancellation consistency.
+- Machine-mode behavior (`--json` / `--ndjson`) is now consistent across top-level help/version/completion/error flows.
+
+## Release links
+
+- [GitHub Release: v0.17.3](https://github.com/jasoncavinder/Helm/releases/tag/v0.17.3)
+- [Changelog](https://helmapp.dev/changelog/)
+
+If you run into issues, please file a report with environment details and reproduction steps in [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).

--- a/web/src/content/docs/changelog.md
+++ b/web/src/content/docs/changelog.md
@@ -11,6 +11,27 @@ For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncav
 
 ---
 
+## Unreleased
+
+## 0.17.3 — 2026-02-23
+
+Patch `0.17.3` finalizes post-`0.17.2` CLI parity hardening and release-channel safety guardrails.
+
+### Added
+- `helm doctor` is now a first-class top-level diagnostics alias (defaulting to provenance output).
+- Install-provenance and distribution-profile contracts are now centralized as machine-readable schema files.
+- Dedicated CLI update-metadata drift checks were added to release automation workflows.
+
+### Changed
+- CLI self-update behavior is now policy-driven across install channels, with deterministic direct-script force handling and explicit channel-managed guidance.
+- GUI and CLI now converge on a shared coordinator authority path for mutation/cancellation flow consistency.
+- Top-level machine output behavior is now consistently enforced for `--json` and `--ndjson` help/version/completion/error paths.
+
+### Fixed
+- Self-update/install safety now rejects symlink targets for marker writes and binary replacement, and enforces bounded update payload size.
+- Direct install/update fetch paths now enforce allowlisted HTTPS hosts with explicit timeout policy (with opt-in `file://` testing override).
+- Exit-code mapping now uses explicit markers for task failure/partial/cancelled semantics, with deterministic runtime fallback to `1`.
+
 ## 0.17.2 — 2026-02-22
 
 Patch `0.17.2` ships post-`0.17.x` manager-control, onboarding/detection, and Control Center execution-plan fixes as a stable incremental release.

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -17,7 +17,7 @@ Helm is planned as two product lifecycles: **Helm (Consumer)** and **Helm Busine
 
 ## What it does today
 
-Helm `v0.17.2` supports twenty-eight managers:
+Helm `v0.17.3` supports twenty-eight managers:
 
 | Category | Managers |
 |---------|----------|
@@ -45,7 +45,7 @@ Key features:
 - **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, and `ja` with locale override in Settings
 - **Upgrade transparency** — dedicated upgrade preview surface with scoped execution and failure-attribution visibility
 
-> **Current Track:** `v0.17.2` is the latest stable release on `main`; `0.18.x` planning is in progress. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.17.3` is the latest stable release on `main`; `0.18.x` planning is in progress. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## How it works
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -31,9 +31,9 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 | 0.14.x | Platform, Detection & Optional Managers — Docker, Xcode, Rosetta, Sparkle, Setapp, Homebrew casks, optional managers (`v0.14.x` stable, latest patch `v0.14.1`) |
 | 0.15.x | Advanced Upgrade Transparency — richer execution-plan visibility, failure isolation, and operator controls (`v0.15.0` released) |
 | 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification (`v0.16.x` stable, latest patch `v0.16.2`) |
-| 0.17.x | Diagnostics & Logging + Release Hardening — task log viewer, structured diagnostics export, manager-detection diagnostics, onboarding/detection hardening, manager-selection controls, and stable release follow-up fixes (`v0.17.0` stable, latest patch `v0.17.2`) |
+| 0.17.x | Diagnostics & Logging + Release Hardening — task log viewer, structured diagnostics export, manager-detection diagnostics, onboarding/detection hardening, manager-selection controls, and stable release follow-up fixes (`v0.17.0` stable, latest patch `v0.17.3`) |
 
-> **Current Track:** `v0.17.2` is stable on `main`; planning is shifting to `0.18.x` local security groundwork. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.17.3` is stable on `main`; planning is shifting to `0.18.x` local security groundwork. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Planned
 


### PR DESCRIPTION
Summary: web content promotion for v0.17.3 via release branch (policy-compliant head ref). Includes changelog, overview/roadmap, banner copy, and release blog post.