### PR TITLE
fix: restore release workflow rust toolchain input

### DIFF
--- a/.github/workflows/release-all-variants.yml
+++ b/.github/workflows/release-all-variants.yml
@@ -92,6 +92,7 @@ jobs:
       - name: Install Rust toolchain (universal targets)
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: stable
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Build ${{ matrix.variant }} profile app (unsigned)

--- a/.github/workflows/release-cli-direct.yml
+++ b/.github/workflows/release-cli-direct.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Install Rust toolchain (macOS targets)
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: stable
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Build CLI binaries (arm64, x86_64, universal)

--- a/.github/workflows/release-macos-dmg.yml
+++ b/.github/workflows/release-macos-dmg.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Install Rust toolchain (universal targets)
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: stable
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Configure temporary keychain and import Developer ID certificate


### PR DESCRIPTION
Fixes release workflow failures for v0.17.3 by providing required toolchain input to dtolnay/rust-toolchain in release-macos-dmg, release-cli-direct, and release-all-variants workflows.