### PR TITLE
fix: harden release publish branch push retries

### DIFF
--- a/.github/workflows/release-cli-direct.yml
+++ b/.github/workflows/release-cli-direct.yml
@@ -223,7 +223,10 @@ jobs:
           git commit -m "chore(release): publish CLI latest metadata for ${TAG_NAME}"
 
           git checkout -B "$PUBLISH_BRANCH"
-          git push -u origin "$PUBLISH_BRANCH" --force-with-lease
+          if ! git push -u origin "$PUBLISH_BRANCH" --force-with-lease; then
+            echo "::warning::force-with-lease push failed for ${PUBLISH_BRANCH}; retrying with --force."
+            git push -u origin "$PUBLISH_BRANCH" --force
+          fi
 
           EXISTING_PR="$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --head "$PUBLISH_BRANCH" --state open --json number --jq '.[0].number // empty' || true)"
           if [ -n "$EXISTING_PR" ]; then

--- a/.github/workflows/release-macos-dmg.yml
+++ b/.github/workflows/release-macos-dmg.yml
@@ -524,7 +524,10 @@ jobs:
           git commit -m "chore(release): publish Sparkle appcast + release notes for ${TAG_NAME}"
 
           git checkout -B "$PUBLISH_BRANCH"
-          git push -u origin "$PUBLISH_BRANCH" --force-with-lease
+          if ! git push -u origin "$PUBLISH_BRANCH" --force-with-lease; then
+            echo "::warning::force-with-lease push failed for ${PUBLISH_BRANCH}; retrying with --force."
+            git push -u origin "$PUBLISH_BRANCH" --force
+          fi
 
           EXISTING_PR="$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --head "$PUBLISH_BRANCH" --state open --json number --jq '.[0].number // empty' || true)"
           if [ -n "$EXISTING_PR" ]; then


### PR DESCRIPTION
Adds fallback push behavior in release-cli-direct and release-macos-dmg publish steps: if force-with-lease push is rejected due stale refs, retry with --force so repeated release attempts remain idempotent.