### PR TITLE
chore(release): stage v0.17.10 main promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
 
 ## [Unreleased]
 
+Patch `0.17.10` is focused on final stable-line hardening before broader `0.18.x` work begins.
+
+### Added
+- Doctor/repair now detects stale selected manager executable overrides and can clear them locally through the existing repair flow.
+
+### Changed
+- Executable discovery now accounts for non-default `CARGO_HOME`, `ASDF_DIR`, `ASDF_DATA_DIR`, and modern `mise`/`rtx` shim and install roots more consistently across core, FFI, and CLI surfaces.
+- Catalog-sync participation is now explicitly scoped instead of being inferred from generic package-search participation.
+
+### Fixed
+- Onboarding no longer risks clobbering a valid discovered `rustup` executable path during follow-up detection.
+- Non-default `cargo`, `cargo-binstall`, and `rustup` installs now route execution through the correct resolved binary path instead of assuming `~/.cargo/bin`.
+- Executable discovery caches now self-heal when cached paths disappear and are invalidated on recent manager lifecycle transitions.
+
 ## [0.17.9] - 2026-03-11
 
 Patch `0.17.9` completes current-scope manager adapter coverage and package workflow hardening ahead of the `0.18.x` doctor/repair and local-security cycle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
 
 ## [Unreleased]
 
-Patch `0.17.10` is focused on final stable-line hardening before broader `0.18.x` work begins.
+Post-`v0.17.10`, `dev` is now positioned for broader `0.18.x` work.
+
+## [0.17.10] - 2026-03-11
 
 ### Added
 - Doctor/repair now detects stale selected manager executable overrides and can clear them locally through the existing repair flow.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <br>
   A macOS control center and CLI for unified package manager control.
   <br>
-  <strong>Pre-1.0 &middot; v0.17.9</strong>
+  <strong>Pre-1.0 &middot; v0.17.10</strong>
 </p>
 
 <p align="center">
@@ -23,9 +23,9 @@
 
 Helm manages software across multiple package managers (Homebrew, npm, pip, Cargo, etc.) and runtime tools (mise, rustup) from a single menu bar interface. It is designed as infrastructure software: deterministic, safety-first, and explicit about authority, orchestration, and error handling.
 
-> **Status:** Active pre-1.0 development with stable `v0.17.9` on `main` and post-`0.17.x` planning on `dev`.
+> **Status:** Active pre-1.0 development with stable `v0.17.10` on `main` and `0.18.x` planning on `dev`.
 >
-> **Testing:** Please test `v0.17.9` and report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Testing:** Please test `v0.17.10` and report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Editions (Beta)
 
@@ -190,7 +190,7 @@ Or open `apps/macos-ui/Helm.xcodeproj` in Xcode and run the **Helm** scheme. The
 | 0.16.x | Self-Update & Installer Hardening — Sparkle integration, signed verification | Completed (`v0.16.0`) |
 | 0.16.1 | Documentation, Milestone Restructure & Security Staging Clarification | Completed (documentation-only) |
 | 0.16.2 | Sparkle Connectivity + Platform Baseline Alignment — network-client entitlement, feed diagnostics, macOS 11 deployment target enforcement | Completed |
-| 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel | Completed (`v0.17.x` stable, latest patch `v0.17.9`) |
+| 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel | Completed (`v0.17.x` stable, latest patch `v0.17.10`) |
 | 0.18.x | Local Security Groundwork — local vulnerability abstractions and cache plumbing (no public feature surface) | Planned |
 | 0.19.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit | Planned |
 | 1.0.0 | Stable Control Plane Release — production-safe execution, full feature set | Planned |

--- a/apps/macos-ui/Helm/Core/HelmCore+Actions.swift
+++ b/apps/macos-ui/Helm/Core/HelmCore+Actions.swift
@@ -1312,6 +1312,7 @@ extension HelmCore {
         }
         let isManagerInstallRepair = optionId == "reinstall_manager_via_homebrew"
         let isManagerSetupRepair = optionId == "apply_post_install_setup_defaults"
+        let isExecutableOverrideRepair = optionId == "clear_selected_executable_override"
         if isManagerInstallRepair {
             DispatchQueue.main.async {
                 self.managerOperations[managerId] = L10n.App.Managers.Operation.startingInstall.localized
@@ -1399,6 +1400,9 @@ extension HelmCore {
                         ),
                         inProgressText: L10n.App.Managers.Operation.verifying.localized
                     )
+                } else if isExecutableOverrideRepair {
+                    self.fetchManagerStatus()
+                    self.fetchTasks()
                 }
             }
         }

--- a/apps/macos-ui/Helm/Resources/locales/de/service.json
+++ b/apps/macos-ui/Helm/Resources/locales/de/service.json
@@ -49,5 +49,6 @@
   "service.error.pip_system_unmanaged": "pip at /usr/bin/python3, /usr/bin/pip, or /usr/bin/pip3 is a macOS base-system install and cannot be managed by Helm. Select a non-system Python/pip executable (Homebrew, mise, or asdf).",
   "service.error.manager_dependency_blocked": "Cannot disable this manager while enabled dependent managers rely on it.",
   "service.error.manager_setup_required": "This manager requires post-install setup before it can be enabled. Select Finish Setup in Manager Inspector, complete setup, then verify.",
-  "service.task.label.setup.manager": "Finish {manager} setup"
+  "service.task.label.setup.manager": "Finish {manager} setup",
+  "service.task.label.repair.manager": "Repair {manager} configuration"
 }

--- a/apps/macos-ui/Helm/Resources/locales/en/service.json
+++ b/apps/macos-ui/Helm/Resources/locales/en/service.json
@@ -49,5 +49,6 @@
   "service.error.pip_system_unmanaged": "pip at /usr/bin/python3, /usr/bin/pip, or /usr/bin/pip3 is a macOS base-system install and cannot be managed by Helm. Select a non-system Python/pip executable (Homebrew, mise, or asdf).",
   "service.error.manager_dependency_blocked": "Cannot disable this manager while enabled dependent managers rely on it.",
   "service.error.manager_setup_required": "This manager requires post-install setup before it can be enabled. Select Finish Setup in Manager Inspector, complete setup, then verify.",
-  "service.task.label.setup.manager": "Finish {manager} setup"
+  "service.task.label.setup.manager": "Finish {manager} setup",
+  "service.task.label.repair.manager": "Repair {manager} configuration"
 }

--- a/apps/macos-ui/Helm/Resources/locales/es/service.json
+++ b/apps/macos-ui/Helm/Resources/locales/es/service.json
@@ -49,5 +49,6 @@
   "service.error.pip_system_unmanaged": "pip at /usr/bin/python3, /usr/bin/pip, or /usr/bin/pip3 is a macOS base-system install and cannot be managed by Helm. Select a non-system Python/pip executable (Homebrew, mise, or asdf).",
   "service.error.manager_dependency_blocked": "Cannot disable this manager while enabled dependent managers rely on it.",
   "service.error.manager_setup_required": "This manager requires post-install setup before it can be enabled. Select Finish Setup in Manager Inspector, complete setup, then verify.",
-  "service.task.label.setup.manager": "Finish {manager} setup"
+  "service.task.label.setup.manager": "Finish {manager} setup",
+  "service.task.label.repair.manager": "Repair {manager} configuration"
 }

--- a/apps/macos-ui/Helm/Resources/locales/fr/service.json
+++ b/apps/macos-ui/Helm/Resources/locales/fr/service.json
@@ -49,5 +49,6 @@
   "service.error.pip_system_unmanaged": "pip at /usr/bin/python3, /usr/bin/pip, or /usr/bin/pip3 is a macOS base-system install and cannot be managed by Helm. Select a non-system Python/pip executable (Homebrew, mise, or asdf).",
   "service.error.manager_dependency_blocked": "Cannot disable this manager while enabled dependent managers rely on it.",
   "service.error.manager_setup_required": "This manager requires post-install setup before it can be enabled. Select Finish Setup in Manager Inspector, complete setup, then verify.",
-  "service.task.label.setup.manager": "Finish {manager} setup"
+  "service.task.label.setup.manager": "Finish {manager} setup",
+  "service.task.label.repair.manager": "Repair {manager} configuration"
 }

--- a/apps/macos-ui/Helm/Resources/locales/hu/service.json
+++ b/apps/macos-ui/Helm/Resources/locales/hu/service.json
@@ -49,5 +49,6 @@
   "service.error.pip_system_unmanaged": "pip at /usr/bin/python3, /usr/bin/pip, or /usr/bin/pip3 is a macOS base-system install and cannot be managed by Helm. Select a non-system Python/pip executable (Homebrew, mise, or asdf).",
   "service.error.manager_dependency_blocked": "Cannot disable this manager while enabled dependent managers rely on it.",
   "service.error.manager_setup_required": "This manager requires post-install setup before it can be enabled. Select Finish Setup in Manager Inspector, complete setup, then verify.",
-  "service.task.label.setup.manager": "Finish {manager} setup"
+  "service.task.label.setup.manager": "Finish {manager} setup",
+  "service.task.label.repair.manager": "Repair {manager} configuration"
 }

--- a/apps/macos-ui/Helm/Resources/locales/ja/service.json
+++ b/apps/macos-ui/Helm/Resources/locales/ja/service.json
@@ -49,5 +49,6 @@
   "service.error.pip_system_unmanaged": "pip at /usr/bin/python3, /usr/bin/pip, or /usr/bin/pip3 is a macOS base-system install and cannot be managed by Helm. Select a non-system Python/pip executable (Homebrew, mise, or asdf).",
   "service.error.manager_dependency_blocked": "Cannot disable this manager while enabled dependent managers rely on it.",
   "service.error.manager_setup_required": "This manager requires post-install setup before it can be enabled. Select Finish Setup in Manager Inspector, complete setup, then verify.",
-  "service.task.label.setup.manager": "Finish {manager} setup"
+  "service.task.label.setup.manager": "Finish {manager} setup",
+  "service.task.label.repair.manager": "Repair {manager} configuration"
 }

--- a/apps/macos-ui/Helm/Resources/locales/pt-BR/service.json
+++ b/apps/macos-ui/Helm/Resources/locales/pt-BR/service.json
@@ -49,5 +49,6 @@
   "service.error.pip_system_unmanaged": "pip at /usr/bin/python3, /usr/bin/pip, or /usr/bin/pip3 is a macOS base-system install and cannot be managed by Helm. Select a non-system Python/pip executable (Homebrew, mise, or asdf).",
   "service.error.manager_dependency_blocked": "Cannot disable this manager while enabled dependent managers rely on it.",
   "service.error.manager_setup_required": "This manager requires post-install setup before it can be enabled. Select Finish Setup in Manager Inspector, complete setup, then verify.",
-  "service.task.label.setup.manager": "Finish {manager} setup"
+  "service.task.label.setup.manager": "Finish {manager} setup",
+  "service.task.label.repair.manager": "Repair {manager} configuration"
 }

--- a/apps/macos-ui/Helm/Views/InspectorViews.swift
+++ b/apps/macos-ui/Helm/Views/InspectorViews.swift
@@ -1805,6 +1805,73 @@ private struct InspectorPackageDetailView: View {
     }
 }
 
+private extension InspectorPackageDetailView {
+    var genericManagerPackageStateIssues: [ManagerPackageStateIssue] {
+        (status?.packageStateIssues ?? []).filter { issue in
+            issue.issueCode != "metadata_only_install"
+                && issue.issueCode != "post_install_setup_required"
+        }
+    }
+
+    @ViewBuilder
+    func genericPackageStateIssueBanner(_ issue: ManagerPackageStateIssue) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(HelmTheme.stateAttention)
+                    .padding(.top, 2)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(issue.summary ?? issue.issueCode)
+                        .font(.callout.weight(.semibold))
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if let evidencePrimary = issue.evidencePrimary,
+                       !evidencePrimary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        Text(evidencePrimary)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    if let evidenceSecondary = issue.evidenceSecondary,
+                       !evidenceSecondary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        Text(evidenceSecondary)
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+
+            if let repairOptions = issue.repairOptions, !repairOptions.isEmpty {
+                HStack(spacing: 8) {
+                    ForEach(repairOptions, id: \.optionId) { option in
+                        Button(option.title) {
+                            core.applyManagerPackageStateIssueRepair(
+                                managerId: manager.id,
+                                sourceManagerId: issue.sourceManagerId,
+                                packageName: issue.packageName,
+                                issueCode: issue.issueCode,
+                                optionId: option.optionId
+                            )
+                        }
+                        .buttonStyle(HelmSecondaryButtonStyle())
+                        .disabled(managerIsUninstalling)
+                        .helmPointer(enabled: !managerIsUninstalling)
+                    }
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(HelmTheme.surfaceElevated)
+        )
+    }
+}
+
 private struct InspectorAttributedText: NSViewRepresentable {
     let attributedText: NSAttributedString
 
@@ -2336,13 +2403,6 @@ private struct InspectorManagerDetailView: View {
         return (status?.packageStateIssues ?? []).first(where: { issue in
             issue.issueCode == "post_install_setup_required"
         })
-    }
-
-    private var genericManagerPackageStateIssues: [ManagerPackageStateIssue] {
-        (status?.packageStateIssues ?? []).filter { issue in
-            issue.issueCode != "metadata_only_install"
-                && issue.issueCode != "post_install_setup_required"
-        }
     }
 
     private var postInstallSetupTaskInFlight: Bool {
@@ -3361,64 +3421,6 @@ private struct InspectorManagerDetailView: View {
             packageName: issue.packageName,
             issueCode: issue.issueCode,
             optionId: "remove_stale_package_entry"
-        )
-    }
-
-    @ViewBuilder
-    private func genericPackageStateIssueBanner(_ issue: ManagerPackageStateIssue) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .top, spacing: 8) {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundColor(HelmTheme.stateAttention)
-                    .padding(.top, 2)
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(issue.summary ?? issue.issueCode)
-                        .font(.callout.weight(.semibold))
-                        .fixedSize(horizontal: false, vertical: true)
-
-                    if let evidencePrimary = issue.evidencePrimary,
-                       !evidencePrimary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        Text(evidencePrimary)
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-
-                    if let evidenceSecondary = issue.evidenceSecondary,
-                       !evidenceSecondary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        Text(evidenceSecondary)
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
-                Spacer(minLength: 0)
-            }
-
-            if let repairOptions = issue.repairOptions, !repairOptions.isEmpty {
-                HStack(spacing: 8) {
-                    ForEach(repairOptions, id: \.optionId) { option in
-                        Button(option.title) {
-                            core.applyManagerPackageStateIssueRepair(
-                                managerId: manager.id,
-                                sourceManagerId: issue.sourceManagerId,
-                                packageName: issue.packageName,
-                                issueCode: issue.issueCode,
-                                optionId: option.optionId
-                            )
-                        }
-                        .buttonStyle(HelmSecondaryButtonStyle())
-                        .disabled(managerIsUninstalling)
-                        .helmPointer(enabled: !managerIsUninstalling)
-                    }
-                    Spacer(minLength: 0)
-                }
-            }
-        }
-        .padding(10)
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(HelmTheme.surfaceElevated)
         )
     }
 

--- a/apps/macos-ui/Helm/Views/InspectorViews.swift
+++ b/apps/macos-ui/Helm/Views/InspectorViews.swift
@@ -1805,7 +1805,7 @@ private struct InspectorPackageDetailView: View {
     }
 }
 
-private extension InspectorPackageDetailView {
+private extension InspectorManagerDetailView {
     var genericManagerPackageStateIssues: [ManagerPackageStateIssue] {
         (status?.packageStateIssues ?? []).filter { issue in
             issue.issueCode != "metadata_only_install"

--- a/apps/macos-ui/Helm/Views/InspectorViews.swift
+++ b/apps/macos-ui/Helm/Views/InspectorViews.swift
@@ -2338,6 +2338,13 @@ private struct InspectorManagerDetailView: View {
         })
     }
 
+    private var genericManagerPackageStateIssues: [ManagerPackageStateIssue] {
+        (status?.packageStateIssues ?? []).filter { issue in
+            issue.issueCode != "metadata_only_install"
+                && issue.issueCode != "post_install_setup_required"
+        }
+    }
+
     private var postInstallSetupTaskInFlight: Bool {
         core.activeTasks.contains { task in
             task.managerId == manager.id
@@ -2480,6 +2487,10 @@ private struct InspectorManagerDetailView: View {
 
             if let issue = postInstallSetupIssue {
                 postInstallSetupBanner(issue)
+            }
+
+            ForEach(Array(genericManagerPackageStateIssues.enumerated()), id: \.offset) { _, issue in
+                genericPackageStateIssueBanner(issue)
             }
 
             InspectorField(label: L10n.App.Inspector.category.localized) {
@@ -3350,6 +3361,64 @@ private struct InspectorManagerDetailView: View {
             packageName: issue.packageName,
             issueCode: issue.issueCode,
             optionId: "remove_stale_package_entry"
+        )
+    }
+
+    @ViewBuilder
+    private func genericPackageStateIssueBanner(_ issue: ManagerPackageStateIssue) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(HelmTheme.stateAttention)
+                    .padding(.top, 2)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(issue.summary ?? issue.issueCode)
+                        .font(.callout.weight(.semibold))
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if let evidencePrimary = issue.evidencePrimary,
+                       !evidencePrimary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        Text(evidencePrimary)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    if let evidenceSecondary = issue.evidenceSecondary,
+                       !evidenceSecondary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        Text(evidenceSecondary)
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+
+            if let repairOptions = issue.repairOptions, !repairOptions.isEmpty {
+                HStack(spacing: 8) {
+                    ForEach(repairOptions, id: \.optionId) { option in
+                        Button(option.title) {
+                            core.applyManagerPackageStateIssueRepair(
+                                managerId: manager.id,
+                                sourceManagerId: issue.sourceManagerId,
+                                packageName: issue.packageName,
+                                issueCode: issue.issueCode,
+                                optionId: option.optionId
+                            )
+                        }
+                        .buttonStyle(HelmSecondaryButtonStyle())
+                        .disabled(managerIsUninstalling)
+                        .helmPointer(enabled: !managerIsUninstalling)
+                    }
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(HelmTheme.surfaceElevated)
         )
     }
 

--- a/core/rust/Cargo.lock
+++ b/core/rust/Cargo.lock
@@ -650,7 +650,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helm-cli"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "crossterm 0.28.1",
  "helm-core",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "helm-core"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "libc",
  "rusqlite",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "helm-ffi"
-version = "0.17.9"
+version = "0.17.10"
 dependencies = [
  "cbindgen",
  "helm-core",

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -3,4 +3,4 @@ members = ["crates/helm-core", "crates/helm-ffi", "crates/helm-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.9"
+version = "0.17.10"

--- a/core/rust/crates/helm-cli/src/main.rs
+++ b/core/rust/crates/helm-cli/src/main.rs
@@ -7888,6 +7888,17 @@ fn cmd_doctor_scan(store: &SqliteStore, options: GlobalOptions) -> Result<(), St
     let install_instances = store
         .list_install_instances(None)
         .map_err(|error| format!("failed to list install instances for doctor scan: {error}"))?;
+    let detection_map: HashMap<ManagerId, DetectionInfo> = store
+        .list_detections()
+        .map_err(|error| format!("failed to list manager detections for doctor scan: {error}"))?
+        .into_iter()
+        .collect();
+    let preference_map: HashMap<ManagerId, helm_core::persistence::ManagerPreference> = store
+        .list_manager_preferences()
+        .map_err(|error| format!("failed to list manager preferences for doctor scan: {error}"))?
+        .into_iter()
+        .map(|preference| (preference.manager, preference))
+        .collect();
     let mut instances_by_manager: HashMap<ManagerId, Vec<ManagerInstallInstance>> = HashMap::new();
     for instance in install_instances {
         instances_by_manager
@@ -7895,10 +7906,12 @@ fn cmd_doctor_scan(store: &SqliteStore, options: GlobalOptions) -> Result<(), St
             .or_default()
             .push(instance);
     }
+    let executable_states = build_manager_executable_doctor_states(&detection_map, &preference_map);
     let report = helm_core::doctor::scan_package_state_report(
         ManagerId::ALL,
         &instances_by_manager,
         installed_packages.as_slice(),
+        &executable_states,
     );
 
     if options.json {
@@ -8095,6 +8108,34 @@ fn cmd_doctor_repair(
                         );
                     }
                     cmd_managers_detect(store_handle, options, &[manager.as_str().to_string()])
+                }
+                helm_core::repair::RepairAction::ClearSelectedExecutableOverride => {
+                    store_handle
+                        .set_manager_selected_executable_path(manager, None)
+                        .map_err(|error| {
+                            format!(
+                                "failed to clear selected executable override for '{}': {error}",
+                                manager.as_str()
+                            )
+                        })?;
+                    sync_manager_executable_overrides(store_handle.as_ref())?;
+
+                    if options.json {
+                        emit_json_payload(
+                            "helm.cli.v1.doctor.repair.clear_selected_executable_override",
+                            json!({
+                                "manager": manager.as_str(),
+                                "cleared": true
+                            }),
+                        );
+                    } else {
+                        println!(
+                            "Cleared selected executable override for {}.",
+                            manager.as_str()
+                        );
+                    }
+
+                    Ok(())
                 }
             }
         }
@@ -12490,24 +12531,67 @@ fn normalize_path_string(path: &std::path::Path) -> Option<String> {
     }
 }
 
+fn absolute_env_path(key: &str) -> Option<std::path::PathBuf> {
+    std::env::var_os(key)
+        .filter(|value| !value.is_empty())
+        .map(std::path::PathBuf::from)
+        .filter(|path| path.is_absolute() && !path.as_os_str().is_empty())
+}
+
 fn manager_additional_bin_roots() -> Vec<std::path::PathBuf> {
+    manager_additional_bin_roots_for_home(std::env::var_os("HOME").map(std::path::PathBuf::from))
+}
+
+fn manager_additional_bin_roots_for_home(
+    home: Option<std::path::PathBuf>,
+) -> Vec<std::path::PathBuf> {
     let mut roots = vec![
         std::path::PathBuf::from("/opt/homebrew/bin"),
         std::path::PathBuf::from("/usr/local/bin"),
         std::path::PathBuf::from("/opt/local/bin"),
+        std::path::PathBuf::from("/usr/bin"),
+        std::path::PathBuf::from("/bin"),
+        std::path::PathBuf::from("/usr/sbin"),
+        std::path::PathBuf::from("/sbin"),
+        std::path::PathBuf::from("/run/current-system/sw/bin"),
+        std::path::PathBuf::from("/nix/var/nix/profiles/default/bin"),
     ];
 
-    if let Some(home) = std::env::var_os("HOME").map(std::path::PathBuf::from) {
+    if let Some(cargo_home) = absolute_env_path("CARGO_HOME") {
+        roots.push(cargo_home.join("bin"));
+    }
+    if let Some(home) = home {
         roots.push(home.join(".local/bin"));
         roots.push(home.join(".cargo/bin"));
         roots.push(home.join(".asdf/bin"));
         roots.push(home.join(".asdf/shims"));
+        roots.push(home.join(".local/share/mise/shims"));
+        roots.push(home.join(".local/share/rtx/shims"));
+        roots.push(home.join(".nix-profile/bin"));
+    }
+    if let Some(path) = absolute_env_path("ASDF_DIR") {
+        roots.push(path.join("bin"));
+        roots.push(path.join("shims"));
+    }
+    if let Some(path) = absolute_env_path("ASDF_DATA_DIR") {
+        roots.push(path.join("bin"));
+        roots.push(path.join("shims"));
     }
 
     roots
 }
 
 fn manager_versioned_install_roots(id: ManagerId) -> Vec<std::path::PathBuf> {
+    manager_versioned_install_roots_for_home(
+        id,
+        std::env::var_os("HOME").map(std::path::PathBuf::from),
+    )
+}
+
+fn manager_versioned_install_roots_for_home(
+    id: ManagerId,
+    home: Option<std::path::PathBuf>,
+) -> Vec<std::path::PathBuf> {
     let mut roots = Vec::new();
 
     if matches!(
@@ -12548,10 +12632,18 @@ fn manager_versioned_install_roots(id: ManagerId) -> Vec<std::path::PathBuf> {
             | ManagerId::Bundler
             | ManagerId::Cargo
             | ManagerId::CargoBinstall
-    ) && let Some(home) = std::env::var_os("HOME").map(std::path::PathBuf::from)
+    ) && let Some(home) = home
     {
         roots.push(home.join(".asdf/installs"));
         roots.push(home.join(".local/share/mise/installs"));
+        roots.push(home.join(".local/share/rtx/installs"));
+    }
+
+    if let Some(path) = absolute_env_path("ASDF_DIR") {
+        roots.push(path.join("installs"));
+    }
+    if let Some(path) = absolute_env_path("ASDF_DATA_DIR") {
+        roots.push(path.join("installs"));
     }
 
     roots
@@ -12631,6 +12723,9 @@ fn cached_discovered_executable_paths(id: ManagerId, candidates: &[&str]) -> Vec
     let cache = EXECUTABLE_DISCOVERY_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
     if let Ok(guard) = cache.lock()
         && let Some(cached) = guard.get(&id)
+        && cached
+            .iter()
+            .all(|path| std::path::Path::new(path.as_str()).is_file())
     {
         return cached.clone();
     }
@@ -12709,6 +12804,37 @@ fn manager_executable_path_diagnostic(
         (Some(_), None) => "default_only",
         (None, None) => "unresolved",
     }
+}
+
+fn build_manager_executable_doctor_states(
+    detection_map: &HashMap<ManagerId, DetectionInfo>,
+    preferences: &HashMap<ManagerId, helm_core::persistence::ManagerPreference>,
+) -> HashMap<ManagerId, helm_core::doctor::ManagerExecutableDoctorState> {
+    let mut states = HashMap::new();
+    for manager in ManagerId::ALL {
+        let executable_paths = collect_manager_executable_paths(
+            manager,
+            detection_map
+                .get(&manager)
+                .and_then(|detection| detection.executable_path.as_deref()),
+        );
+        let default_executable_path = default_manager_executable_path(manager, &executable_paths);
+        let stored_selected_executable_path = preferences
+            .get(&manager)
+            .and_then(|preference| normalize_nonempty(preference.selected_executable_path.clone()));
+        states.insert(
+            manager,
+            helm_core::doctor::ManagerExecutableDoctorState {
+                detected: detection_map
+                    .get(&manager)
+                    .map(|detection| detection.installed)
+                    .unwrap_or(false),
+                stored_selected_executable_path,
+                default_executable_path,
+            },
+        );
+    }
+    states
 }
 
 fn normalize_install_method(id: ManagerId, method: Option<String>) -> Option<String> {
@@ -16069,7 +16195,7 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
     use std::path::{Path, PathBuf};
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex, OnceLock};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     const COORDINATOR_TRANSPORT_INVARIANTS_DOC: &str =
@@ -16089,6 +16215,19 @@ mod tests {
             .expect("clock should be after epoch")
             .as_nanos();
         std::env::temp_dir().join(format!("helm-cli-self-heal-{name}-{nanos}.sqlite3"))
+    }
+
+    fn executable_discovery_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn clear_executable_discovery_cache() {
+        if let Some(cache) = super::EXECUTABLE_DISCOVERY_CACHE.get()
+            && let Ok(mut guard) = cache.lock()
+        {
+            guard.clear();
+        }
     }
 
     fn seed_homebrew_detected(store: &SqliteStore) {
@@ -16218,6 +16357,61 @@ mod tests {
             super::manager_executable_path_diagnostic(Some("/tmp/npm"), None),
             "default_only"
         );
+    }
+
+    #[test]
+    fn manager_additional_bin_roots_include_modern_tool_shims() {
+        let home = PathBuf::from("/Users/tester");
+        let roots = super::manager_additional_bin_roots_for_home(Some(home.clone()));
+
+        assert!(roots.contains(&home.join(".local/share/mise/shims")));
+        assert!(roots.contains(&home.join(".local/share/rtx/shims")));
+        assert!(roots.contains(&home.join(".nix-profile/bin")));
+    }
+
+    #[test]
+    fn manager_versioned_install_roots_include_modern_tool_installs() {
+        let home = PathBuf::from("/Users/tester");
+        let roots =
+            super::manager_versioned_install_roots_for_home(ManagerId::Cargo, Some(home.clone()));
+
+        assert!(roots.contains(&home.join(".local/share/mise/installs")));
+        assert!(roots.contains(&home.join(".local/share/rtx/installs")));
+        assert!(roots.contains(&home.join(".asdf/installs")));
+    }
+
+    #[test]
+    fn cached_discovered_executable_paths_refresh_when_cached_path_disappears() {
+        let _lock = executable_discovery_test_lock()
+            .lock()
+            .expect("executable discovery test lock should succeed");
+        clear_executable_discovery_cache();
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        let temp_dir = std::env::temp_dir().join(format!("helm-cli-exec-cache-{nanos}"));
+        fs::create_dir_all(&temp_dir).expect("temporary executable discovery dir should exist");
+        let candidate_path = temp_dir.join("rustup");
+        fs::write(&candidate_path, "#!/bin/sh\n").expect("temporary executable should be writable");
+
+        let candidate = candidate_path.to_string_lossy().to_string();
+        let initial =
+            super::cached_discovered_executable_paths(ManagerId::Rustup, &[candidate.as_str()]);
+        assert_eq!(initial, vec![candidate.clone()]);
+
+        fs::remove_file(&candidate_path).expect("temporary executable should be removable");
+
+        let refreshed =
+            super::cached_discovered_executable_paths(ManagerId::Rustup, &[candidate.as_str()]);
+        assert!(
+            refreshed.is_empty(),
+            "expected cached discovery to refresh after cached path disappears"
+        );
+
+        clear_executable_discovery_cache();
+        let _ = fs::remove_dir_all(temp_dir);
     }
 
     #[test]

--- a/core/rust/crates/helm-core/src/adapters/cargo_binstall_process.rs
+++ b/core/rust/crates/helm-core/src/adapters/cargo_binstall_process.rs
@@ -29,9 +29,24 @@ impl ProcessCargoBinstallSource {
         }
     }
 
+    fn cargo_bin_dir() -> String {
+        std::env::var_os("CARGO_HOME")
+            .filter(|value| !value.is_empty())
+            .map(std::path::PathBuf::from)
+            .filter(|path| path.is_absolute())
+            .unwrap_or_else(|| {
+                std::env::var_os("HOME")
+                    .map(std::path::PathBuf::from)
+                    .unwrap_or_default()
+                    .join(".cargo")
+            })
+            .join("bin")
+            .to_string_lossy()
+            .to_string()
+    }
+
     fn configure_request(&self, mut request: ProcessSpawnRequest) -> ProcessSpawnRequest {
-        let home = std::env::var("HOME").unwrap_or_default();
-        let cargo_bin = format!("{home}/.cargo/bin");
+        let cargo_bin = Self::cargo_bin_dir();
         let path = std::env::var("PATH").unwrap_or_default();
         let new_path = format!("{cargo_bin}:/opt/homebrew/bin:/usr/local/bin:{path}");
 
@@ -65,8 +80,7 @@ impl ProcessCargoBinstallSource {
 
 impl CargoBinstallSource for ProcessCargoBinstallSource {
     fn detect(&self) -> AdapterResult<CargoBinstallDetectOutput> {
-        let home = std::env::var("HOME").unwrap_or_default();
-        let cargo_bin = format!("{home}/.cargo/bin");
+        let cargo_bin = Self::cargo_bin_dir();
 
         let executable_path = which_executable(
             self.executor.as_ref(),

--- a/core/rust/crates/helm-core/src/adapters/cargo_process.rs
+++ b/core/rust/crates/helm-core/src/adapters/cargo_process.rs
@@ -22,9 +22,24 @@ impl ProcessCargoSource {
         Self { executor }
     }
 
+    fn cargo_bin_dir() -> String {
+        std::env::var_os("CARGO_HOME")
+            .filter(|value| !value.is_empty())
+            .map(std::path::PathBuf::from)
+            .filter(|path| path.is_absolute())
+            .unwrap_or_else(|| {
+                std::env::var_os("HOME")
+                    .map(std::path::PathBuf::from)
+                    .unwrap_or_default()
+                    .join(".cargo")
+            })
+            .join("bin")
+            .to_string_lossy()
+            .to_string()
+    }
+
     fn configure_request(&self, mut request: ProcessSpawnRequest) -> ProcessSpawnRequest {
-        let home = std::env::var("HOME").unwrap_or_default();
-        let cargo_bin = format!("{home}/.cargo/bin");
+        let cargo_bin = Self::cargo_bin_dir();
         let path = std::env::var("PATH").unwrap_or_default();
         let new_path = format!("{cargo_bin}:/opt/homebrew/bin:/usr/local/bin:{path}");
 
@@ -47,8 +62,7 @@ impl ProcessCargoSource {
 
 impl CargoSource for ProcessCargoSource {
     fn detect(&self) -> AdapterResult<CargoDetectOutput> {
-        let home = std::env::var("HOME").unwrap_or_default();
-        let cargo_bin = format!("{home}/.cargo/bin");
+        let cargo_bin = Self::cargo_bin_dir();
 
         let executable_path = which_executable(
             self.executor.as_ref(),

--- a/core/rust/crates/helm-core/src/adapters/detect_utils.rs
+++ b/core/rust/crates/helm-core/src/adapters/detect_utils.rs
@@ -111,6 +111,13 @@ fn manager_additional_bin_roots() -> Vec<PathBuf> {
     manager_additional_bin_roots_for_home(std::env::var_os("HOME").map(PathBuf::from))
 }
 
+fn absolute_env_path(key: &str) -> Option<PathBuf> {
+    std::env::var_os(key)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute() && !path.as_os_str().is_empty())
+}
+
 fn manager_additional_bin_roots_for_home(home: Option<PathBuf>) -> Vec<PathBuf> {
     let mut roots = vec![
         PathBuf::from("/opt/homebrew/bin"),
@@ -124,13 +131,25 @@ fn manager_additional_bin_roots_for_home(home: Option<PathBuf>) -> Vec<PathBuf> 
         PathBuf::from("/nix/var/nix/profiles/default/bin"),
     ];
 
+    if let Some(cargo_home) = absolute_env_path("CARGO_HOME") {
+        roots.push(cargo_home.join("bin"));
+    }
     if let Some(home) = home {
         roots.push(home.join(".local/bin"));
         roots.push(home.join(".cargo/bin"));
         roots.push(home.join(".asdf/bin"));
         roots.push(home.join(".asdf/shims"));
+        roots.push(home.join(".local/share/mise/shims"));
         roots.push(home.join(".local/share/rtx/shims"));
         roots.push(home.join(".nix-profile/bin"));
+    }
+    if let Some(path) = absolute_env_path("ASDF_DIR") {
+        roots.push(path.join("bin"));
+        roots.push(path.join("shims"));
+    }
+    if let Some(path) = absolute_env_path("ASDF_DATA_DIR") {
+        roots.push(path.join("bin"));
+        roots.push(path.join("shims"));
     }
 
     roots
@@ -200,6 +219,13 @@ fn manager_versioned_install_roots_for_home(
         roots.push(home.join(".local/share/rtx/installs"));
     }
 
+    if let Some(path) = absolute_env_path("ASDF_DIR") {
+        roots.push(path.join("installs"));
+    }
+    if let Some(path) = absolute_env_path("ASDF_DATA_DIR") {
+        roots.push(path.join("installs"));
+    }
+
     roots
 }
 
@@ -263,6 +289,9 @@ mod tests {
     struct EnvSnapshot {
         path: Option<OsString>,
         home: Option<OsString>,
+        cargo_home: Option<OsString>,
+        asdf_dir: Option<OsString>,
+        asdf_data_dir: Option<OsString>,
     }
 
     impl EnvSnapshot {
@@ -270,6 +299,9 @@ mod tests {
             Self {
                 path: std::env::var_os("PATH"),
                 home: std::env::var_os("HOME"),
+                cargo_home: std::env::var_os("CARGO_HOME"),
+                asdf_dir: std::env::var_os("ASDF_DIR"),
+                asdf_data_dir: std::env::var_os("ASDF_DATA_DIR"),
             }
         }
     }
@@ -285,6 +317,18 @@ mod tests {
                 match &self.home {
                     Some(value) => std::env::set_var("HOME", value),
                     None => std::env::remove_var("HOME"),
+                }
+                match &self.cargo_home {
+                    Some(value) => std::env::set_var("CARGO_HOME", value),
+                    None => std::env::remove_var("CARGO_HOME"),
+                }
+                match &self.asdf_dir {
+                    Some(value) => std::env::set_var("ASDF_DIR", value),
+                    None => std::env::remove_var("ASDF_DIR"),
+                }
+                match &self.asdf_data_dir {
+                    Some(value) => std::env::set_var("ASDF_DATA_DIR", value),
+                    None => std::env::remove_var("ASDF_DATA_DIR"),
                 }
             }
         }
@@ -382,6 +426,58 @@ mod tests {
                 .iter()
                 .any(|path| path.ends_with(".local/share/rtx/installs")),
             "rtx installs should be present in versioned install roots"
+        );
+    }
+
+    #[test]
+    fn additional_roots_include_mise_shims_and_custom_cargo_home() {
+        let _guard = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock should be available");
+        let _snapshot = EnvSnapshot::capture();
+
+        let home = PathBuf::from("/tmp/helm-detect-home");
+        let cargo_home = PathBuf::from("/tmp/helm-custom-cargo");
+
+        unsafe {
+            std::env::set_var("CARGO_HOME", cargo_home.to_string_lossy().to_string());
+        }
+
+        let additional = manager_additional_bin_roots_for_home(Some(home.clone()));
+        assert!(
+            additional
+                .iter()
+                .any(|path| path == &home.join(".local/share/mise/shims")),
+            "mise shims should be present in additional search roots"
+        );
+        assert!(
+            additional
+                .iter()
+                .any(|path| path == &cargo_home.join("bin")),
+            "custom cargo home bin should be present in additional search roots"
+        );
+    }
+
+    #[test]
+    fn versioned_roots_include_custom_asdf_dir() {
+        let _guard = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock should be available");
+        let _snapshot = EnvSnapshot::capture();
+
+        let custom_asdf = PathBuf::from("/tmp/helm-custom-asdf");
+        unsafe {
+            std::env::set_var("ASDF_DIR", custom_asdf.to_string_lossy().to_string());
+        }
+
+        let versioned = manager_versioned_install_roots_for_home(ManagerId::Npm, None);
+        assert!(
+            versioned
+                .iter()
+                .any(|path| path == &custom_asdf.join("installs")),
+            "custom ASDF_DIR installs root should be present in versioned install roots"
         );
     }
 }

--- a/core/rust/crates/helm-core/src/adapters/rustup_process.rs
+++ b/core/rust/crates/helm-core/src/adapters/rustup_process.rs
@@ -31,11 +31,25 @@ impl ProcessRustupSource {
         Self { executor }
     }
 
+    fn cargo_bin_dir() -> PathBuf {
+        std::env::var_os("CARGO_HOME")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+            .filter(|path| path.is_absolute())
+            .unwrap_or_else(|| {
+                std::env::var_os("HOME")
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| PathBuf::from("."))
+                    .join(".cargo")
+            })
+            .join("bin")
+    }
+
     fn configure_request(&self, mut request: ProcessSpawnRequest) -> ProcessSpawnRequest {
-        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-        let cargo_bin = format!("{home}/.cargo/bin");
+        let cargo_bin = Self::cargo_bin_dir();
         let path = std::env::var("PATH").unwrap_or_default();
-        let new_path = format!("{cargo_bin}:{path}");
+        let cargo_bin_string = cargo_bin.to_string_lossy().to_string();
+        let new_path = format!("{cargo_bin_string}:{path}");
 
         request.command = request.command.env("PATH", new_path);
 
@@ -49,13 +63,13 @@ impl ProcessRustupSource {
         if let Some(program) = program.as_deref()
             && (program == "rustup" || program == "rustup-init")
         {
-            let direct_path = std::path::Path::new(&cargo_bin).join(program);
+            let direct_path = cargo_bin.join(program);
             if direct_path.exists() {
                 request.command.program = direct_path;
             } else if let Some(exe) = which_executable(
                 self.executor.as_ref(),
                 program,
-                &[cargo_bin.as_str()],
+                &[cargo_bin_string.as_str()],
                 ManagerId::Rustup,
             ) {
                 request.command.program = exe;
@@ -92,16 +106,16 @@ pub fn load_rustup_toolchain_detail_with_runtime(
 impl RustupSource for ProcessRustupSource {
     fn detect(&self) -> AdapterResult<RustupDetectOutput> {
         // Phase 1: instant filesystem check
-        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-        let cargo_bin = format!("{home}/.cargo/bin");
-        let direct_path = Path::new(&cargo_bin).join("rustup");
+        let cargo_bin = Self::cargo_bin_dir();
+        let cargo_bin_string = cargo_bin.to_string_lossy().to_string();
+        let direct_path = cargo_bin.join("rustup");
         let executable_path = if direct_path.exists() {
             Some(direct_path)
         } else {
             which_executable(
                 self.executor.as_ref(),
                 "rustup",
-                &[&cargo_bin],
+                &[cargo_bin_string.as_str()],
                 ManagerId::Rustup,
             )
         };

--- a/core/rust/crates/helm-core/src/doctor.rs
+++ b/core/rust/crates/helm-core/src/doctor.rs
@@ -3,12 +3,15 @@ use crate::models::{InstallProvenance, InstalledPackage, ManagerId, ManagerInsta
 use crate::post_install_setup::evaluate_manager_post_install_setup;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub const ISSUE_CODE_METADATA_ONLY_INSTALL: &str = "metadata_only_install";
 pub const FINDING_CODE_HOMEBREW_METADATA_ONLY_INSTALL: &str = "homebrew_metadata_only_install";
 pub const ISSUE_CODE_POST_INSTALL_SETUP_REQUIRED: &str = "post_install_setup_required";
 pub const FINDING_CODE_POST_INSTALL_SETUP_REQUIRED: &str = "post_install_setup_required";
+pub const ISSUE_CODE_SELECTED_EXECUTABLE_PATH_STALE: &str = "selected_executable_path_stale";
+pub const FINDING_CODE_SELECTED_EXECUTABLE_PATH_STALE: &str = "selected_executable_path_stale";
 const FINGERPRINT_VERSION: u8 = 1;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -80,10 +83,18 @@ pub struct DoctorReport {
     pub summary: DoctorSummary,
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ManagerExecutableDoctorState {
+    pub detected: bool,
+    pub stored_selected_executable_path: Option<String>,
+    pub default_executable_path: Option<String>,
+}
+
 pub struct ManagerPackageStateScanInput<'a> {
     pub manager: ManagerId,
     pub manager_install_instances: Option<&'a [ManagerInstallInstance]>,
     pub homebrew_installed_formulas: &'a HashSet<String>,
+    pub executable_state: Option<&'a ManagerExecutableDoctorState>,
 }
 
 pub fn fingerprint_for_metadata_only_install(
@@ -118,6 +129,19 @@ pub fn fingerprint_for_post_install_setup_required(
         manager.as_str(),
         ISSUE_CODE_POST_INSTALL_SETUP_REQUIRED,
         encoded_requirements
+    )
+}
+
+pub fn fingerprint_for_selected_executable_path_stale(
+    manager: ManagerId,
+    selected_path: &str,
+) -> String {
+    let normalized_path = selected_path.trim().to_ascii_lowercase();
+    format!(
+        "v{FINGERPRINT_VERSION}:manager:{}:issue:{}:selected_path:{}",
+        manager.as_str(),
+        ISSUE_CODE_SELECTED_EXECUTABLE_PATH_STALE,
+        normalized_path
     )
 }
 
@@ -218,6 +242,53 @@ pub fn scan_manager_package_state_issues(
         });
     }
 
+    if let Some(executable_state) = input.executable_state
+        && let Some(selected_path) = executable_state
+            .stored_selected_executable_path
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        && !Path::new(selected_path).is_file()
+    {
+        let evidence_secondary = executable_state
+            .default_executable_path
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|path| format!("current discovered default executable path: '{}'", path))
+            .or_else(|| {
+                Some(if executable_state.detected {
+                    "manager is still detected through another executable path".to_string()
+                } else {
+                    "no currently detected executable path is available for this manager"
+                        .to_string()
+                })
+            });
+
+        findings.push(DoctorFinding {
+            finding_code: FINDING_CODE_SELECTED_EXECUTABLE_PATH_STALE.to_string(),
+            issue_code: ISSUE_CODE_SELECTED_EXECUTABLE_PATH_STALE.to_string(),
+            fingerprint: fingerprint_for_selected_executable_path_stale(
+                input.manager,
+                selected_path,
+            ),
+            manager_id: input.manager.as_str().to_string(),
+            source_manager_id: Some(input.manager.as_str().to_string()),
+            package_name: None,
+            severity: DoctorFindingSeverity::Warning,
+            summary: format!(
+                "{} is configured to use '{}', but that executable no longer exists.",
+                ManagerDisplayName(input.manager),
+                selected_path
+            ),
+            evidence_primary: Some(format!(
+                "saved selected executable path: '{}'",
+                selected_path
+            )),
+            evidence_secondary,
+        });
+    }
+
     findings
 }
 
@@ -225,6 +296,7 @@ pub fn scan_package_state_report(
     managers: impl IntoIterator<Item = ManagerId>,
     manager_install_instances: &HashMap<ManagerId, Vec<ManagerInstallInstance>>,
     installed_packages: &[InstalledPackage],
+    manager_executable_states: &HashMap<ManagerId, ManagerExecutableDoctorState>,
 ) -> DoctorReport {
     let homebrew_installed_formulas: HashSet<String> = installed_packages
         .iter()
@@ -241,6 +313,7 @@ pub fn scan_package_state_report(
                 manager: *manager,
                 manager_install_instances: instances,
                 homebrew_installed_formulas: &homebrew_installed_formulas,
+                executable_state: manager_executable_states.get(manager),
             })
         })
         .collect::<Vec<_>>();
@@ -345,6 +418,7 @@ mod tests {
             manager: ManagerId::Rustup,
             manager_install_instances: None,
             homebrew_installed_formulas: &formulas,
+            executable_state: None,
         });
 
         let finding = findings
@@ -373,6 +447,7 @@ mod tests {
             manager: ManagerId::Rustup,
             manager_install_instances: Some(&instances),
             homebrew_installed_formulas: &formulas,
+            executable_state: None,
         });
 
         assert!(
@@ -393,6 +468,7 @@ mod tests {
             manager: ManagerId::Mise,
             manager_install_instances: Some(&instances),
             homebrew_installed_formulas: &formulas,
+            executable_state: None,
         });
 
         let finding = findings
@@ -426,5 +502,38 @@ mod tests {
         assert_eq!(report.summary.total_findings, 1);
         assert_eq!(report.summary.warnings, 1);
         assert_eq!(report.summary.errors, 0);
+    }
+
+    #[test]
+    fn stale_selected_executable_path_issue_detected_when_saved_path_missing() {
+        let formulas = HashSet::new();
+        let executable_state = ManagerExecutableDoctorState {
+            detected: false,
+            stored_selected_executable_path: Some("/tmp/helm-missing-rustup".to_string()),
+            default_executable_path: Some("/usr/local/bin/rustup".to_string()),
+        };
+        let findings = scan_manager_package_state_issues(ManagerPackageStateScanInput {
+            manager: ManagerId::Rustup,
+            manager_install_instances: None,
+            homebrew_installed_formulas: &formulas,
+            executable_state: Some(&executable_state),
+        });
+
+        let finding = findings
+            .iter()
+            .find(|finding| finding.issue_code == ISSUE_CODE_SELECTED_EXECUTABLE_PATH_STALE)
+            .expect("stale selected executable issue should be present");
+        assert_eq!(
+            finding.fingerprint,
+            fingerprint_for_selected_executable_path_stale(
+                ManagerId::Rustup,
+                "/tmp/helm-missing-rustup"
+            )
+        );
+        assert_eq!(finding.severity, DoctorFindingSeverity::Warning);
+        assert_eq!(
+            finding.evidence_secondary.as_deref(),
+            Some("current discovered default executable path: '/usr/local/bin/rustup'")
+        );
     }
 }

--- a/core/rust/crates/helm-core/src/registry.rs
+++ b/core/rust/crates/helm-core/src/registry.rs
@@ -47,6 +47,7 @@ pub struct ManagerLifecycleMetadata {
     pub install_method_ids: &'static [&'static str],
     pub install_methods: &'static [ManagerInstallMethodSpec],
     pub participates_in_package_search: bool,
+    pub participates_in_catalog_sync: bool,
 }
 
 const fn method_spec(
@@ -823,141 +824,169 @@ const MISE_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetada
     install_method_ids: MISE_INSTALL_METHOD_IDS,
     install_methods: MISE_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: true,
 };
 const ASDF_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: ASDF_INSTALL_METHOD_IDS,
     install_methods: ASDF_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: true,
 };
 const RUSTUP_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: RUSTUP_INSTALL_METHOD_IDS,
     install_methods: RUSTUP_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: true,
 };
 const HOMEBREW_FORMULA_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: HOMEBREW_FORMULA_INSTALL_METHOD_IDS,
     install_methods: HOMEBREW_FORMULA_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: true,
 };
 const SOFTWAREUPDATE_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: SOFTWAREUPDATE_INSTALL_METHOD_IDS,
     install_methods: SOFTWAREUPDATE_INSTALL_METHODS,
     participates_in_package_search: false,
+    participates_in_catalog_sync: false,
 };
 const MACPORTS_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: MACPORTS_INSTALL_METHOD_IDS,
     install_methods: MACPORTS_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: false,
 };
 const NIX_DARWIN_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: NIX_DARWIN_INSTALL_METHOD_IDS,
     install_methods: NIX_DARWIN_INSTALL_METHODS,
     participates_in_package_search: false,
+    participates_in_catalog_sync: false,
 };
 const NPM_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: NPM_INSTALL_METHOD_IDS,
     install_methods: NPM_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: false,
 };
 const PNPM_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: PNPM_INSTALL_METHOD_IDS,
     install_methods: PNPM_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: false,
 };
 const YARN_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: YARN_INSTALL_METHOD_IDS,
     install_methods: YARN_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: false,
 };
 const PIPX_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: PIPX_INSTALL_METHOD_IDS,
     install_methods: PIPX_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: false,
 };
 const PIP_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: PIP_INSTALL_METHOD_IDS,
     install_methods: PIP_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: false,
 };
 const POETRY_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: POETRY_INSTALL_METHOD_IDS,
     install_methods: POETRY_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: false,
 };
 const RUBYGEMS_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: RUBYGEMS_INSTALL_METHOD_IDS,
     install_methods: RUBYGEMS_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: false,
 };
 const BUNDLER_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: BUNDLER_INSTALL_METHOD_IDS,
     install_methods: BUNDLER_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: false,
 };
 const CARGO_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: CARGO_INSTALL_METHOD_IDS,
     install_methods: CARGO_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: false,
 };
 const CARGO_BINSTALL_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: CARGO_BINSTALL_INSTALL_METHOD_IDS,
     install_methods: CARGO_BINSTALL_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: false,
 };
 const MAS_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: MAS_INSTALL_METHOD_IDS,
     install_methods: MAS_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: false,
 };
 const SPARKLE_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: SPARKLE_INSTALL_METHOD_IDS,
     install_methods: SPARKLE_INSTALL_METHODS,
     participates_in_package_search: false,
+    participates_in_catalog_sync: false,
 };
 const SETAPP_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: SETAPP_INSTALL_METHOD_IDS,
     install_methods: SETAPP_INSTALL_METHODS,
     participates_in_package_search: false,
+    participates_in_catalog_sync: false,
 };
 const HOMEBREW_CASK_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: HOMEBREW_CASK_INSTALL_METHOD_IDS,
     install_methods: HOMEBREW_CASK_INSTALL_METHODS,
     participates_in_package_search: true,
+    participates_in_catalog_sync: true,
 };
 const DOCKER_DESKTOP_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: DOCKER_DESKTOP_INSTALL_METHOD_IDS,
     install_methods: DOCKER_DESKTOP_INSTALL_METHODS,
     participates_in_package_search: false,
+    participates_in_catalog_sync: false,
 };
 const PODMAN_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: PODMAN_INSTALL_METHOD_IDS,
     install_methods: PODMAN_INSTALL_METHODS,
     participates_in_package_search: false,
+    participates_in_catalog_sync: false,
 };
 const COLIMA_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: COLIMA_INSTALL_METHOD_IDS,
     install_methods: COLIMA_INSTALL_METHODS,
     participates_in_package_search: false,
+    participates_in_catalog_sync: false,
 };
 const PARALLELS_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: PARALLELS_INSTALL_METHOD_IDS,
     install_methods: PARALLELS_INSTALL_METHODS,
     participates_in_package_search: false,
+    participates_in_catalog_sync: false,
 };
 const XCODE_CLT_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: XCODE_CLT_INSTALL_METHOD_IDS,
     install_methods: XCODE_CLT_INSTALL_METHODS,
     participates_in_package_search: false,
+    participates_in_catalog_sync: false,
 };
 const ROSETTA_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: ROSETTA_INSTALL_METHOD_IDS,
     install_methods: ROSETTA_INSTALL_METHODS,
     participates_in_package_search: false,
+    participates_in_catalog_sync: false,
 };
 const FIRMWARE_LIFECYCLE_METADATA: ManagerLifecycleMetadata = ManagerLifecycleMetadata {
     install_method_ids: FIRMWARE_INSTALL_METHOD_IDS,
     install_methods: FIRMWARE_INSTALL_METHODS,
     participates_in_package_search: false,
+    participates_in_catalog_sync: false,
 };
 pub fn managers() -> &'static [ManagerDescriptor] {
     &ALL_MANAGERS
@@ -1022,11 +1051,17 @@ pub fn manager_participates_in_package_search(id: ManagerId) -> bool {
         && manager_lifecycle_metadata(id).participates_in_package_search
 }
 
+pub fn manager_participates_in_catalog_sync(id: ManagerId) -> bool {
+    manager_participates_in_package_search(id)
+        && manager_lifecycle_metadata(id).participates_in_catalog_sync
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         InstallMethodRecommendationReason, manager, manager_install_method_candidates,
-        manager_install_method_specs, manager_participates_in_package_search,
+        manager_install_method_specs, manager_participates_in_catalog_sync,
+        manager_participates_in_package_search,
     };
     use crate::models::{Capability, ManagerId};
 
@@ -1080,5 +1115,22 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn catalog_sync_policy_is_explicitly_scoped() {
+        assert!(manager_participates_in_catalog_sync(ManagerId::Mise));
+        assert!(manager_participates_in_catalog_sync(ManagerId::Asdf));
+        assert!(manager_participates_in_catalog_sync(ManagerId::Rustup));
+        assert!(manager_participates_in_catalog_sync(
+            ManagerId::HomebrewFormula
+        ));
+        assert!(manager_participates_in_catalog_sync(
+            ManagerId::HomebrewCask
+        ));
+        assert!(!manager_participates_in_catalog_sync(ManagerId::MacPorts));
+        assert!(!manager_participates_in_catalog_sync(ManagerId::Npm));
+        assert!(!manager_participates_in_catalog_sync(ManagerId::Cargo));
+        assert!(!manager_participates_in_catalog_sync(ManagerId::Pipx));
     }
 }

--- a/core/rust/crates/helm-core/src/repair.rs
+++ b/core/rust/crates/helm-core/src/repair.rs
@@ -1,8 +1,9 @@
 use crate::doctor::{
     DoctorFinding, FINDING_CODE_HOMEBREW_METADATA_ONLY_INSTALL,
-    FINDING_CODE_POST_INSTALL_SETUP_REQUIRED, ISSUE_CODE_METADATA_ONLY_INSTALL,
-    ISSUE_CODE_POST_INSTALL_SETUP_REQUIRED, fingerprint_for_metadata_only_install,
-    fingerprint_for_post_install_setup_required,
+    FINDING_CODE_POST_INSTALL_SETUP_REQUIRED, FINDING_CODE_SELECTED_EXECUTABLE_PATH_STALE,
+    ISSUE_CODE_METADATA_ONLY_INSTALL, ISSUE_CODE_POST_INSTALL_SETUP_REQUIRED,
+    ISSUE_CODE_SELECTED_EXECUTABLE_PATH_STALE, fingerprint_for_metadata_only_install,
+    fingerprint_for_post_install_setup_required, fingerprint_for_selected_executable_path_stale,
 };
 use crate::models::ManagerId;
 use serde::{Deserialize, Serialize};
@@ -13,6 +14,8 @@ pub const REPAIR_OPTION_REINSTALL_MANAGER_VIA_HOMEBREW: &str = "reinstall_manage
 pub const REPAIR_OPTION_REMOVE_STALE_PACKAGE_ENTRY: &str = "remove_stale_package_entry";
 pub const REPAIR_OPTION_APPLY_POST_INSTALL_SETUP_DEFAULTS: &str =
     "apply_post_install_setup_defaults";
+pub const REPAIR_OPTION_CLEAR_SELECTED_EXECUTABLE_OVERRIDE: &str =
+    "clear_selected_executable_override";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -38,6 +41,7 @@ pub enum RepairAction {
     ReinstallManagerViaHomebrew,
     RemoveStalePackageEntry,
     ApplyPostInstallSetupDefaults,
+    ClearSelectedExecutableOverride,
 }
 
 impl RepairAction {
@@ -46,6 +50,7 @@ impl RepairAction {
             Self::ReinstallManagerViaHomebrew => "reinstall_manager_via_homebrew",
             Self::RemoveStalePackageEntry => "remove_stale_package_entry",
             Self::ApplyPostInstallSetupDefaults => "apply_post_install_setup_defaults",
+            Self::ClearSelectedExecutableOverride => "clear_selected_executable_override",
         }
     }
 }
@@ -144,6 +149,32 @@ pub fn plan_for_finding(finding: &DoctorFinding) -> Option<RepairPlan> {
         });
     }
 
+    if finding.finding_code == FINDING_CODE_SELECTED_EXECUTABLE_PATH_STALE
+        && finding.issue_code == ISSUE_CODE_SELECTED_EXECUTABLE_PATH_STALE
+    {
+        return Some(RepairPlan {
+            manager_id: finding.manager_id.clone(),
+            source_manager_id: finding.source_manager_id.clone(),
+            package_name: finding.package_name.clone(),
+            issue_code: finding.issue_code.clone(),
+            finding_code: finding.finding_code.clone(),
+            fingerprint: finding.fingerprint.clone(),
+            knowledge_source: REPAIR_KNOWLEDGE_SOURCE.to_string(),
+            knowledge_version: REPAIR_KNOWLEDGE_VERSION.to_string(),
+            options: vec![RepairOption {
+                option_id: REPAIR_OPTION_CLEAR_SELECTED_EXECUTABLE_OVERRIDE.to_string(),
+                action: RepairAction::ClearSelectedExecutableOverride,
+                title: "Clear selected executable override".to_string(),
+                description:
+                    "Remove the saved executable override so Helm can fall back to normal executable discovery."
+                        .to_string(),
+                recommended: true,
+                requires_confirmation: false,
+                automation_level: RepairAutomationLevel::Automatic,
+            }],
+        });
+    }
+
     None
 }
 
@@ -158,6 +189,22 @@ pub fn plan_for_issue(
             finding_code: FINDING_CODE_POST_INSTALL_SETUP_REQUIRED.to_string(),
             issue_code: ISSUE_CODE_POST_INSTALL_SETUP_REQUIRED.to_string(),
             fingerprint: fingerprint_for_post_install_setup_required(manager, &["unknown"]),
+            manager_id: manager.as_str().to_string(),
+            source_manager_id: Some(source_manager.as_str().to_string()),
+            package_name: None,
+            severity: crate::doctor::DoctorFindingSeverity::Warning,
+            summary: String::new(),
+            evidence_primary: None,
+            evidence_secondary: None,
+        };
+        return plan_for_finding(&finding);
+    }
+
+    if issue_code == ISSUE_CODE_SELECTED_EXECUTABLE_PATH_STALE {
+        let finding = DoctorFinding {
+            finding_code: FINDING_CODE_SELECTED_EXECUTABLE_PATH_STALE.to_string(),
+            issue_code: ISSUE_CODE_SELECTED_EXECUTABLE_PATH_STALE.to_string(),
+            fingerprint: fingerprint_for_selected_executable_path_stale(manager, package_name),
             manager_id: manager.as_str().to_string(),
             source_manager_id: Some(source_manager.as_str().to_string()),
             package_name: None,
@@ -207,7 +254,7 @@ mod tests {
     use super::*;
     use crate::doctor::{
         DoctorFinding, DoctorFindingSeverity, FINDING_CODE_POST_INSTALL_SETUP_REQUIRED,
-        ISSUE_CODE_POST_INSTALL_SETUP_REQUIRED,
+        ISSUE_CODE_POST_INSTALL_SETUP_REQUIRED, ISSUE_CODE_SELECTED_EXECUTABLE_PATH_STALE,
     };
 
     #[test]
@@ -274,6 +321,33 @@ mod tests {
         assert_eq!(
             plan.options[0].action,
             RepairAction::ApplyPostInstallSetupDefaults
+        );
+    }
+
+    #[test]
+    fn stale_selected_executable_finding_returns_clear_override_plan() {
+        let finding = DoctorFinding {
+            finding_code: FINDING_CODE_SELECTED_EXECUTABLE_PATH_STALE.to_string(),
+            issue_code: ISSUE_CODE_SELECTED_EXECUTABLE_PATH_STALE.to_string(),
+            fingerprint: "fingerprint-selected-executable".to_string(),
+            manager_id: ManagerId::Rustup.as_str().to_string(),
+            source_manager_id: Some(ManagerId::Rustup.as_str().to_string()),
+            package_name: None,
+            severity: DoctorFindingSeverity::Warning,
+            summary: String::new(),
+            evidence_primary: None,
+            evidence_secondary: None,
+        };
+
+        let plan = plan_for_finding(&finding).expect("expected selected executable repair plan");
+        assert_eq!(plan.options.len(), 1);
+        assert_eq!(
+            plan.options[0].option_id,
+            REPAIR_OPTION_CLEAR_SELECTED_EXECUTABLE_OVERRIDE
+        );
+        assert_eq!(
+            plan.options[0].action,
+            RepairAction::ClearSelectedExecutableOverride
         );
     }
 }

--- a/core/rust/crates/helm-core/tests/end_to_end_cargo_binstall.rs
+++ b/core/rust/crates/helm-core/tests/end_to_end_cargo_binstall.rs
@@ -151,6 +151,7 @@ fn build_runtime_with_store(
 
 async fn wait_for_tracked_package_count(store: &SqliteStore, expected: usize) {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let mut poll_interval = Duration::from_millis(50);
     loop {
         let count = store
             .list_installed()
@@ -164,9 +165,11 @@ async fn wait_for_tracked_package_count(store: &SqliteStore, expected: usize) {
         if tokio::time::Instant::now() >= deadline {
             break;
         }
-        // Give the background persistence watcher time to commit the mutation
-        // instead of continuously reopening the database in a tight loop.
-        tokio::time::sleep(Duration::from_millis(25)).await;
+        // Back off between polls so the async persistence watcher can flush its
+        // snapshot work on slower CI runners instead of competing with a hot
+        // loop that keeps reopening the database.
+        tokio::time::sleep(poll_interval).await;
+        poll_interval = std::cmp::min(poll_interval.saturating_mul(2), Duration::from_millis(500));
     }
 
     let actual = store

--- a/core/rust/crates/helm-ffi/include/helm.h
+++ b/core/rust/crates/helm-ffi/include/helm.h
@@ -116,7 +116,9 @@ char *helm_list_manager_status(void);
  * Run a local doctor scan and return a health report JSON payload.
  *
  * Current implementation scope:
- * - package-state diagnostics for metadata-only Homebrew manager installs.
+ * - package-state diagnostics for metadata-only Homebrew manager installs
+ * - post-install setup requirements for managed tool/runtime managers
+ * - stale selected executable path overrides
  *
  * TODO(doctor-repair): wire additional detectors and remote fingerprint lookups.
  */
@@ -474,6 +476,7 @@ bool helm_set_manager_timeout_profile(const char *manager_id,
  * The current scaffold supports metadata-only Homebrew manager installs by routing one of:
  * - `reinstall_manager_via_homebrew`
  * - `remove_stale_package_entry`
+ * - `clear_selected_executable_override`
  *
  * # Safety
  *

--- a/core/rust/crates/helm-ffi/src/lib.rs
+++ b/core/rust/crates/helm-ffi/src/lib.rs
@@ -159,7 +159,7 @@ use helm_core::models::{
     Capability, DetectionInfo, HomebrewKegPolicy, ManagerAction, ManagerAuthority, ManagerId,
     ManagerInstallInstance, ManagerUninstallPreview, OutdatedPackage, PackageRef,
     PackageRuntimeState, PinKind, PinRecord, SearchQuery, StrategyKind, TaskId, TaskLogLevel,
-    TaskLogRecord, TaskStatus, TaskType,
+    TaskLogRecord, TaskRecord, TaskStatus, TaskType,
 };
 use helm_core::orchestration::adapter_runtime::AdapterRuntime;
 use helm_core::orchestration::{AdapterTaskTerminalState, CancellationMode};
@@ -723,6 +723,8 @@ struct ManagerAutomationPolicyContext {
 static EXECUTABLE_DISCOVERY_CACHE: OnceLock<
     Mutex<std::collections::HashMap<ManagerId, Vec<String>>>,
 > = OnceLock::new();
+static EXECUTABLE_DISCOVERY_INVALIDATED_TASKS: OnceLock<Mutex<std::collections::HashSet<u64>>> =
+    OnceLock::new();
 static MANAGER_AUTOMATION_POLICY_CONTEXT: OnceLock<ManagerAutomationPolicyContext> =
     OnceLock::new();
 static COORDINATOR_REQUEST_COUNTER: AtomicU64 = AtomicU64::new(1);
@@ -732,6 +734,7 @@ static AUTO_CHECK_TICKER_STARTED: AtomicBool = AtomicBool::new(false);
 const COORDINATOR_REQUEST_TIMEOUT_SECS: u64 = 30;
 const COORDINATOR_POLL_SLEEP_MS: u64 = 25;
 const AUTO_CHECK_TICK_SECS: u64 = 30;
+const EXECUTABLE_CACHE_INVALIDATION_MAX_AGE_SECS: u64 = 600;
 #[cfg(any(test, target_os = "macos"))]
 const LEGACY_FILE_COORDINATOR_IPC_ENV: &str = "HELM_LEGACY_FILE_COORDINATOR_IPC";
 const DEFAULT_CLI_UPDATE_ENDPOINT: &str = "https://helmapp.dev/updates/cli/latest.json";
@@ -749,6 +752,62 @@ const AUTO_CHECK_ALLOWED_HOSTS: [&str; 5] = [
     "github-releases.githubusercontent.com",
     "release-assets.githubusercontent.com",
 ];
+
+fn invalidate_executable_discovery_cache(manager: Option<ManagerId>) {
+    let cache =
+        EXECUTABLE_DISCOVERY_CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
+    if let Ok(mut guard) = cache.lock() {
+        if let Some(manager) = manager {
+            guard.remove(&manager);
+        } else {
+            guard.clear();
+        }
+    }
+}
+
+fn task_should_invalidate_executable_cache(task: &TaskRecord) -> bool {
+    matches!(
+        task.task_type,
+        TaskType::Detection
+            | TaskType::Refresh
+            | TaskType::Install
+            | TaskType::Uninstall
+            | TaskType::Upgrade
+    ) && matches!(
+        task.status,
+        TaskStatus::Completed | TaskStatus::Cancelled | TaskStatus::Failed
+    ) && std::time::SystemTime::now()
+        .duration_since(task.created_at)
+        .map(|elapsed| elapsed.as_secs() <= EXECUTABLE_CACHE_INVALIDATION_MAX_AGE_SECS)
+        .unwrap_or(true)
+}
+
+fn invalidate_executable_cache_for_recent_manager_lifecycle_tasks(store: &SqliteStore) {
+    let recent_tasks = match store.list_recent_tasks(TASK_RECENT_FETCH_LIMIT) {
+        Ok(tasks) => tasks,
+        Err(_) => return,
+    };
+
+    let recent_task_ids: std::collections::HashSet<u64> =
+        recent_tasks.iter().map(|task| task.id.0).collect();
+    let invalidated = EXECUTABLE_DISCOVERY_INVALIDATED_TASKS
+        .get_or_init(|| Mutex::new(std::collections::HashSet::new()));
+    let mut managers_to_invalidate = std::collections::HashSet::new();
+
+    if let Ok(mut guard) = invalidated.lock() {
+        guard.retain(|task_id| recent_task_ids.contains(task_id));
+        for task in recent_tasks {
+            if !task_should_invalidate_executable_cache(&task) || !guard.insert(task.id.0) {
+                continue;
+            }
+            managers_to_invalidate.insert(task.manager);
+        }
+    }
+
+    for manager in managers_to_invalidate {
+        invalidate_executable_discovery_cache(Some(manager));
+    }
+}
 
 #[derive(Debug, serde::Deserialize)]
 struct AutoCheckInstallMarker {
@@ -1126,6 +1185,13 @@ fn normalize_path_string(path: &std::path::Path) -> Option<String> {
     }
 }
 
+fn absolute_env_path(key: &str) -> Option<std::path::PathBuf> {
+    std::env::var_os(key)
+        .filter(|value| !value.is_empty())
+        .map(std::path::PathBuf::from)
+        .filter(|path| path.is_absolute() && !path.as_os_str().is_empty())
+}
+
 fn manager_additional_bin_roots() -> Vec<std::path::PathBuf> {
     let mut roots = vec![
         std::path::PathBuf::from("/opt/homebrew/bin"),
@@ -1133,23 +1199,22 @@ fn manager_additional_bin_roots() -> Vec<std::path::PathBuf> {
         std::path::PathBuf::from("/opt/local/bin"),
     ];
 
+    if let Some(cargo_home) = absolute_env_path("CARGO_HOME") {
+        roots.push(cargo_home.join("bin"));
+    }
     if let Some(home) = std::env::var_os("HOME").map(std::path::PathBuf::from) {
         roots.push(home.join(".local/bin"));
         roots.push(home.join(".cargo/bin"));
         roots.push(home.join(".asdf/bin"));
         roots.push(home.join(".asdf/shims"));
+        roots.push(home.join(".local/share/mise/shims"));
+        roots.push(home.join(".local/share/rtx/shims"));
     }
-    if let Some(path) = std::env::var_os("ASDF_DIR")
-        .map(std::path::PathBuf::from)
-        .filter(|path| path.is_absolute() && !path.as_os_str().is_empty())
-    {
+    if let Some(path) = absolute_env_path("ASDF_DIR") {
         roots.push(path.join("bin"));
         roots.push(path.join("shims"));
     }
-    if let Some(path) = std::env::var_os("ASDF_DATA_DIR")
-        .map(std::path::PathBuf::from)
-        .filter(|path| path.is_absolute() && !path.as_os_str().is_empty())
-    {
+    if let Some(path) = absolute_env_path("ASDF_DATA_DIR") {
         roots.push(path.join("bin"));
         roots.push(path.join("shims"));
     }
@@ -1202,17 +1267,12 @@ fn manager_versioned_install_roots(id: ManagerId) -> Vec<std::path::PathBuf> {
     {
         roots.push(home.join(".asdf/installs"));
         roots.push(home.join(".local/share/mise/installs"));
+        roots.push(home.join(".local/share/rtx/installs"));
     }
-    if let Some(path) = std::env::var_os("ASDF_DIR")
-        .map(std::path::PathBuf::from)
-        .filter(|path| path.is_absolute() && !path.as_os_str().is_empty())
-    {
+    if let Some(path) = absolute_env_path("ASDF_DIR") {
         roots.push(path.join("installs"));
     }
-    if let Some(path) = std::env::var_os("ASDF_DATA_DIR")
-        .map(std::path::PathBuf::from)
-        .filter(|path| path.is_absolute() && !path.as_os_str().is_empty())
-    {
+    if let Some(path) = absolute_env_path("ASDF_DATA_DIR") {
         roots.push(path.join("installs"));
     }
 
@@ -1293,19 +1353,54 @@ fn cached_discovered_executable_paths(id: ManagerId, candidates: &[&str]) -> Vec
     let cache =
         EXECUTABLE_DISCOVERY_CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
 
-    if let Ok(guard) = cache.lock()
-        && let Some(cached) = guard.get(&id)
-    {
-        return cached.clone();
-    }
-
-    let discovered = discover_executable_paths(id, candidates);
-
     if let Ok(mut guard) = cache.lock() {
+        if let Some(cached) = guard.get(&id).cloned()
+            && cached
+                .iter()
+                .all(|path| std::path::Path::new(path).is_file())
+        {
+            return cached;
+        }
+
+        let discovered = discover_executable_paths(id, candidates);
         guard.insert(id, discovered.clone());
+        return discovered;
     }
 
-    discovered
+    discover_executable_paths(id, candidates)
+}
+
+fn build_manager_executable_doctor_states(
+    detection_map: &std::collections::HashMap<ManagerId, DetectionInfo>,
+    pref_map: &std::collections::HashMap<ManagerId, ManagerPreference>,
+) -> std::collections::HashMap<ManagerId, helm_core::doctor::ManagerExecutableDoctorState> {
+    ManagerId::ALL
+        .into_iter()
+        .map(|manager| {
+            let detection = detection_map.get(&manager);
+            let detected = detection.map(|info| info.installed).unwrap_or(false);
+            let active_path = detection.and_then(|info| info.executable_path.as_deref());
+            let executable_paths = if detected {
+                collect_manager_executable_paths(manager, active_path)
+            } else {
+                Vec::new()
+            };
+            let default_executable_path =
+                default_manager_executable_path(manager, &executable_paths);
+            let stored_selected_executable_path = pref_map
+                .get(&manager)
+                .and_then(|pref| normalize_nonempty(pref.selected_executable_path.clone()));
+
+            (
+                manager,
+                helm_core::doctor::ManagerExecutableDoctorState {
+                    detected,
+                    stored_selected_executable_path,
+                    default_executable_path,
+                },
+            )
+        })
+        .collect()
 }
 
 fn collect_manager_executable_paths(
@@ -1447,6 +1542,10 @@ fn build_manager_statuses(
     detection_map: &std::collections::HashMap<ManagerId, DetectionInfo>,
     pref_map: &std::collections::HashMap<ManagerId, ManagerPreference>,
 ) -> Vec<FfiManagerStatus> {
+    if let Some(store) = store {
+        invalidate_executable_cache_for_recent_manager_lifecycle_tasks(store);
+    }
+
     let mut install_instances_by_manager: std::collections::HashMap<
         ManagerId,
         Vec<ManagerInstallInstance>,
@@ -1493,6 +1592,8 @@ fn build_manager_statuses(
                 .collect()
         })
         .unwrap_or_default();
+    let manager_executable_doctor_states =
+        build_manager_executable_doctor_states(detection_map, pref_map);
 
     ManagerId::ALL
         .iter()
@@ -1596,6 +1697,7 @@ fn build_manager_statuses(
                 id,
                 manager_install_instances,
                 &homebrew_installed_formulas,
+                manager_executable_doctor_states.get(&id),
             );
             let setup_required = package_state_issues.iter().any(|issue| {
                 issue.issue_code == helm_core::doctor::ISSUE_CODE_POST_INSTALL_SETUP_REQUIRED
@@ -1668,12 +1770,14 @@ fn manager_package_state_issues(
     manager: ManagerId,
     manager_install_instances: Option<&Vec<ManagerInstallInstance>>,
     homebrew_installed_formulas: &std::collections::HashSet<String>,
+    executable_state: Option<&helm_core::doctor::ManagerExecutableDoctorState>,
 ) -> Vec<FfiManagerPackageStateIssue> {
     let findings = helm_core::doctor::scan_manager_package_state_issues(
         helm_core::doctor::ManagerPackageStateScanInput {
             manager,
             manager_install_instances: manager_install_instances.map(Vec::as_slice),
             homebrew_installed_formulas,
+            executable_state,
         },
     );
 
@@ -2271,6 +2375,7 @@ fn manager_has_setup_required_issue(
         manager,
         install_instances_by_manager.get(&manager),
         homebrew_installed_formulas,
+        None,
     )
     .iter()
     .any(|issue| issue.issue_code == helm_core::doctor::ISSUE_CODE_POST_INSTALL_SETUP_REQUIRED)
@@ -2419,17 +2524,40 @@ fn preseed_presence_detections(
         if !is_implemented_manager(manager) || !runtime.has_manager(manager) {
             continue;
         }
-
-        let discovered_paths = collect_manager_executable_paths(manager, None);
-        if let Some(executable_path) = discovered_paths.first().map(std::path::PathBuf::from) {
-            let info = DetectionInfo {
-                installed: true,
-                executable_path: Some(executable_path),
-                version: None,
-            };
-            let _ = store.upsert_detection(manager, &info);
-        }
+        preseed_presence_detection(store, runtime, manager);
     }
+}
+
+fn preseed_presence_detection(store: &SqliteStore, runtime: &AdapterRuntime, manager: ManagerId) {
+    if !is_implemented_manager(manager) || !runtime.has_manager(manager) {
+        return;
+    }
+
+    invalidate_executable_discovery_cache(Some(manager));
+    let discovered_paths = collect_manager_executable_paths(manager, None);
+    if let Some(executable_path) = discovered_paths.first().map(std::path::PathBuf::from) {
+        let info = DetectionInfo {
+            installed: true,
+            executable_path: Some(executable_path),
+            version: None,
+        };
+        let _ = store.upsert_detection(manager, &info);
+    }
+}
+
+fn sync_manager_execution_preferences_from_store(store: &SqliteStore) {
+    let detection_map: std::collections::HashMap<_, _> = store
+        .list_detections()
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
+    let pref_map: std::collections::HashMap<_, _> = store
+        .list_manager_preferences()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|pref| (pref.manager, pref))
+        .collect();
+    sync_manager_executable_overrides(&detection_map, &pref_map);
 }
 
 fn search_label_key_for_query(query: &str) -> &'static str {
@@ -2469,6 +2597,10 @@ fn manager_participates_in_package_search(manager: ManagerId) -> bool {
     helm_core::registry::manager_participates_in_package_search(manager)
 }
 
+fn manager_participates_in_catalog_sync(manager: ManagerId) -> bool {
+    helm_core::registry::manager_participates_in_catalog_sync(manager)
+}
+
 fn now_unix_seconds_i64() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -2494,7 +2626,8 @@ fn manager_can_catalog_sync(
     runtime: &AdapterRuntime,
     manager: ManagerId,
 ) -> bool {
-    if !can_submit_remote_search(runtime, manager) {
+    if !can_submit_remote_search(runtime, manager) || !manager_participates_in_catalog_sync(manager)
+    {
         return false;
     }
 
@@ -2802,6 +2935,123 @@ fn run_homebrew_probe_output(program: &std::ffi::OsStr, args: &[&str]) -> Option
     }
 
     normalize_nonempty(Some(combined))
+}
+
+fn rustup_probe_candidates(executable_path: Option<&std::path::Path>) -> Vec<std::ffi::OsString> {
+    let mut candidates = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    let mut push_unique = |candidate: std::ffi::OsString| {
+        if candidate.is_empty() {
+            return;
+        }
+        if seen.insert(candidate.clone()) {
+            candidates.push(candidate);
+        }
+    };
+
+    if let Some(path) = executable_path {
+        push_unique(path.as_os_str().to_os_string());
+    }
+    if let Some(cargo_home) = absolute_env_path("CARGO_HOME") {
+        push_unique(cargo_home.join("bin/rustup").into_os_string());
+    }
+    if let Some(home) = std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(std::path::PathBuf::from)
+    {
+        push_unique(home.join(".cargo/bin/rustup").into_os_string());
+    }
+    push_unique(std::ffi::OsString::from(
+        "/opt/homebrew/opt/rustup/bin/rustup",
+    ));
+    push_unique(std::ffi::OsString::from("/usr/local/opt/rustup/bin/rustup"));
+    push_unique(std::ffi::OsString::from("/opt/homebrew/bin/rustup"));
+    push_unique(std::ffi::OsString::from("/usr/local/bin/rustup"));
+    push_unique(std::ffi::OsString::from("rustup"));
+
+    candidates
+}
+
+fn run_rustup_probe_output(program: &std::ffi::OsStr, args: &[&str]) -> Option<String> {
+    let mut path_parts = Vec::new();
+    if let Some(parent) = std::path::Path::new(program).parent()
+        && parent.is_dir()
+    {
+        path_parts.push(parent.to_string_lossy().to_string());
+    }
+    if let Some(cargo_home) = absolute_env_path("CARGO_HOME") {
+        path_parts.push(cargo_home.join("bin").to_string_lossy().to_string());
+    } else if let Some(home) = std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(std::path::PathBuf::from)
+    {
+        path_parts.push(home.join(".cargo/bin").to_string_lossy().to_string());
+    }
+    if let Ok(existing_path) = std::env::var("PATH")
+        && !existing_path.trim().is_empty()
+    {
+        path_parts.push(existing_path);
+    }
+    path_parts.push(
+        "/opt/homebrew/opt/rustup/bin:/usr/local/opt/rustup/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+            .to_string(),
+    );
+
+    let output = Command::new(program)
+        .args(args)
+        .env("PATH", path_parts.join(":"))
+        .output()
+        .ok()?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let mut combined = String::new();
+    if !stdout.trim().is_empty() {
+        combined.push_str(&stdout);
+    }
+    if !stderr.trim().is_empty() {
+        if !combined.is_empty() {
+            combined.push('\n');
+        }
+        combined.push_str(&stderr);
+    }
+
+    normalize_nonempty(Some(combined))
+}
+
+fn probe_rustup_version(executable_path: Option<&std::path::Path>) -> Option<String> {
+    for candidate in rustup_probe_candidates(executable_path) {
+        if let Some(version_output) = run_rustup_probe_output(candidate.as_os_str(), &["--version"])
+            && let Some(version) = normalize_nonempty(parse_rustup_probe_version(&version_output))
+        {
+            return Some(version);
+        }
+    }
+
+    None
+}
+
+fn parse_rustup_probe_version(output: &str) -> Option<String> {
+    for line in output
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+    {
+        if let Some(rest) = line.strip_prefix("rustup ") {
+            let version = rest
+                .split_whitespace()
+                .next()
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+            if !version.is_empty() {
+                return Some(version);
+            }
+        }
+    }
+
+    None
 }
 
 fn parse_homebrew_config_version(output: &str) -> Option<String> {
@@ -4330,6 +4580,9 @@ fn detect_single_manager(
         ));
     }
 
+    preseed_presence_detection(store, runtime, manager);
+    sync_manager_execution_preferences_from_store(store);
+
     let was_detected = manager_is_detected(store, manager);
     let response = submit_request_wait(
         runtime,
@@ -5679,6 +5932,7 @@ pub extern "C" fn helm_trigger_detection() -> bool {
     }
 
     preseed_presence_detections(store.as_ref(), runtime.as_ref(), &enabled_by_manager);
+    sync_manager_execution_preferences_from_store(store.as_ref());
 
     state._tokio_rt.spawn(async move {
         let results = runtime.detect_all_ordered().await;
@@ -6071,37 +6325,18 @@ pub extern "C" fn helm_list_manager_status() -> *mut c_char {
         .into_iter()
         .map(|pref| (pref.manager, pref))
         .collect();
-    apply_manager_enablement_self_heal(
-        state.store.as_ref(),
-        state.runtime.as_ref(),
-        &state.rt_handle,
-        &detection_map,
-        &mut pref_map,
-    );
-    sync_manager_executable_overrides(&detection_map, &pref_map);
-
-    let mut statuses = build_manager_statuses(
-        Some(state.runtime.as_ref()),
-        Some(state.store.as_ref()),
-        &detection_map,
-        &pref_map,
-    );
 
     // Homebrew detection/version probing is occasionally flaky during first detection.
     // If status is missing or incomplete, probe directly from brew.
-    if let Some(status) = statuses
-        .iter_mut()
-        .find(|status| status.manager_id == ManagerId::HomebrewFormula.as_str())
-        && (status.version.is_none() || !status.detected)
+    if detection_map
+        .get(&ManagerId::HomebrewFormula)
+        .is_none_or(|detection| detection.version.is_none() || !detection.installed)
         && let Some(probed) = probe_homebrew_version(
             detection_map
                 .get(&ManagerId::HomebrewFormula)
                 .and_then(|d| d.executable_path.as_deref()),
         )
     {
-        status.version = Some(probed.clone());
-        status.detected = true;
-
         let refreshed = if let Some(existing) = detection_map.get(&ManagerId::HomebrewFormula) {
             DetectionInfo {
                 installed: true,
@@ -6121,7 +6356,47 @@ pub extern "C" fn helm_list_manager_status() -> *mut c_char {
         detection_map.insert(ManagerId::HomebrewFormula, refreshed);
     }
 
+    if detection_map
+        .get(&ManagerId::Rustup)
+        .is_none_or(|detection| detection.version.is_none() || !detection.installed)
+        && let Some(probed) = probe_rustup_version(
+            detection_map
+                .get(&ManagerId::Rustup)
+                .and_then(|d| d.executable_path.as_deref()),
+        )
+    {
+        let refreshed = if let Some(existing) = detection_map.get(&ManagerId::Rustup) {
+            DetectionInfo {
+                installed: true,
+                executable_path: existing.executable_path.clone(),
+                version: Some(probed),
+            }
+        } else {
+            DetectionInfo {
+                installed: true,
+                executable_path: None,
+                version: Some(probed),
+            }
+        };
+        let _ = state.store.upsert_detection(ManagerId::Rustup, &refreshed);
+        detection_map.insert(ManagerId::Rustup, refreshed);
+    }
+
+    apply_manager_enablement_self_heal(
+        state.store.as_ref(),
+        state.runtime.as_ref(),
+        &state.rt_handle,
+        &detection_map,
+        &mut pref_map,
+    );
     sync_manager_executable_overrides(&detection_map, &pref_map);
+
+    let statuses = build_manager_statuses(
+        Some(state.runtime.as_ref()),
+        Some(state.store.as_ref()),
+        &detection_map,
+        &pref_map,
+    );
 
     let json = match serde_json::to_string(&statuses) {
         Ok(j) => j,
@@ -6137,7 +6412,9 @@ pub extern "C" fn helm_list_manager_status() -> *mut c_char {
 /// Run a local doctor scan and return a health report JSON payload.
 ///
 /// Current implementation scope:
-/// - package-state diagnostics for metadata-only Homebrew manager installs.
+/// - package-state diagnostics for metadata-only Homebrew manager installs
+/// - post-install setup requirements for managed tool/runtime managers
+/// - stale selected executable path overrides
 ///
 /// TODO(doctor-repair): wire additional detectors and remote fingerprint lookups.
 #[unsafe(no_mangle)]
@@ -6176,11 +6453,30 @@ pub extern "C" fn helm_doctor_scan() -> *mut c_char {
             .or_default()
             .push(instance);
     }
+    let detection_map: std::collections::HashMap<_, _> = match state.store.list_detections() {
+        Ok(entries) => entries.into_iter().collect(),
+        Err(_) => {
+            set_last_error_key(SERVICE_ERROR_STORAGE_FAILURE);
+            return std::ptr::null_mut();
+        }
+    };
+    let pref_map: std::collections::HashMap<_, _> = match state.store.list_manager_preferences() {
+        Ok(entries) => entries
+            .into_iter()
+            .map(|pref| (pref.manager, pref))
+            .collect(),
+        Err(_) => {
+            set_last_error_key(SERVICE_ERROR_STORAGE_FAILURE);
+            return std::ptr::null_mut();
+        }
+    };
+    let executable_states = build_manager_executable_doctor_states(&detection_map, &pref_map);
 
     let report = helm_core::doctor::scan_package_state_report(
         ManagerId::ALL,
         &instances_by_manager,
         installed_packages.as_slice(),
+        &executable_states,
     );
     let json = match serde_json::to_string(&report) {
         Ok(json) => json,
@@ -8864,6 +9160,7 @@ pub unsafe extern "C" fn helm_set_manager_selected_executable_path(
         return return_error_bool(SERVICE_ERROR_STORAGE_FAILURE);
     }
 
+    invalidate_executable_discovery_cache(Some(manager));
     let detection_map: std::collections::HashMap<_, _> = state
         .store
         .list_detections()
@@ -9376,6 +9673,7 @@ fn spawn_post_install_setup_task(
 /// The current scaffold supports metadata-only Homebrew manager installs by routing one of:
 /// - `reinstall_manager_via_homebrew`
 /// - `remove_stale_package_entry`
+/// - `clear_selected_executable_override`
 ///
 /// # Safety
 ///
@@ -9509,6 +9807,68 @@ pub unsafe extern "C" fn helm_apply_manager_package_state_issue_repair(
                 Ok(task_id) => task_id.0 as i64,
                 Err(error_key) => return_error_i64(error_key),
             }
+        }
+        helm_core::repair::RepairAction::ClearSelectedExecutableOverride => {
+            let store = {
+                let guard = lock_or_recover(&STATE, "state");
+                let state = match guard.as_ref() {
+                    Some(s) => s,
+                    None => return return_error_i64(SERVICE_ERROR_INTERNAL),
+                };
+                state.store.clone()
+            };
+
+            let task_id = match create_local_task(
+                store.as_ref(),
+                manager,
+                helm_core::models::TaskType::Configure,
+            ) {
+                Ok(task_id) => task_id,
+                Err(error_key) => return return_error_i64(error_key),
+            };
+            set_task_label(
+                task_id,
+                "service.task.label.repair.manager",
+                &[("manager", manager.as_str().to_string())],
+            );
+            update_local_task_status(
+                store.as_ref(),
+                task_id,
+                manager,
+                helm_core::models::TaskType::Configure,
+                helm_core::models::TaskStatus::Running,
+                helm_core::models::TaskLogLevel::Info,
+                "clearing selected executable override",
+            );
+
+            if store
+                .set_manager_selected_executable_path(manager, None)
+                .is_ok()
+            {
+                invalidate_executable_discovery_cache(Some(manager));
+                sync_manager_execution_preferences_from_store(store.as_ref());
+                update_local_task_status(
+                    store.as_ref(),
+                    task_id,
+                    manager,
+                    helm_core::models::TaskType::Configure,
+                    helm_core::models::TaskStatus::Completed,
+                    helm_core::models::TaskLogLevel::Info,
+                    "selected executable override cleared",
+                );
+            } else {
+                update_local_task_status(
+                    store.as_ref(),
+                    task_id,
+                    manager,
+                    helm_core::models::TaskType::Configure,
+                    helm_core::models::TaskStatus::Failed,
+                    helm_core::models::TaskLogLevel::Error,
+                    "failed to clear selected executable override",
+                );
+            }
+
+            task_id.0 as i64
         }
     }
 }
@@ -10163,11 +10523,13 @@ mod tests {
         build_manager_uninstall_plan, build_manager_uninstall_preview, build_visible_tasks,
         collect_upgrade_all_targets, homebrew_probe_candidates,
         manager_allows_individual_package_install, manager_allows_individual_package_uninstall,
-        manager_authority_key, manager_participates_in_package_search,
-        manager_uninstall_label_for_route, parse_homebrew_config_version, push_upgrade_plan_step,
+        manager_authority_key, manager_participates_in_catalog_sync,
+        manager_participates_in_package_search, manager_uninstall_label_for_route,
+        parse_homebrew_config_version, push_upgrade_plan_step,
         resolve_homebrew_manager_update_strategy, resolve_rustup_uninstall_strategy,
-        search_label_args, search_label_key_for_query, search_task_type_for_query,
-        upgrade_plan_step_id, upgrade_reason_label_for, upgrade_task_label_for,
+        rustup_probe_candidates, search_label_args, search_label_key_for_query,
+        search_task_type_for_query, upgrade_plan_step_id, upgrade_reason_label_for,
+        upgrade_task_label_for,
     };
     use helm_core::adapters::{AdapterRequest, ManagerAdapter, UninstallRequest};
     use helm_core::manager_policy::{
@@ -10185,11 +10547,12 @@ mod tests {
         DEFAULT_MANAGER_UNINSTALL_SAFE_BLAST_RADIUS_THRESHOLD, ManagerUninstallPreviewContext,
     };
     use std::collections::HashMap;
+    use std::ffi::OsString;
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
     use std::path::Path;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex, OnceLock};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[cfg(unix)]
@@ -10281,6 +10644,63 @@ mod tests {
         SqliteStore::new(path)
     }
 
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    struct EnvSnapshot {
+        path: Option<OsString>,
+        home: Option<OsString>,
+        cargo_home: Option<OsString>,
+        asdf_dir: Option<OsString>,
+        asdf_data_dir: Option<OsString>,
+    }
+
+    impl EnvSnapshot {
+        fn capture() -> Self {
+            Self {
+                path: std::env::var_os("PATH"),
+                home: std::env::var_os("HOME"),
+                cargo_home: std::env::var_os("CARGO_HOME"),
+                asdf_dir: std::env::var_os("ASDF_DIR"),
+                asdf_data_dir: std::env::var_os("ASDF_DATA_DIR"),
+            }
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.path {
+                    Some(value) => std::env::set_var("PATH", value),
+                    None => std::env::remove_var("PATH"),
+                }
+                match &self.home {
+                    Some(value) => std::env::set_var("HOME", value),
+                    None => std::env::remove_var("HOME"),
+                }
+                match &self.cargo_home {
+                    Some(value) => std::env::set_var("CARGO_HOME", value),
+                    None => std::env::remove_var("CARGO_HOME"),
+                }
+                match &self.asdf_dir {
+                    Some(value) => std::env::set_var("ASDF_DIR", value),
+                    None => std::env::remove_var("ASDF_DIR"),
+                }
+                match &self.asdf_data_dir {
+                    Some(value) => std::env::set_var("ASDF_DATA_DIR", value),
+                    None => std::env::remove_var("ASDF_DATA_DIR"),
+                }
+            }
+        }
+    }
+
+    fn unique_temp_dir(name: &str) -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("helm-ffi-{name}-{nanos}"))
+    }
+
     #[test]
     fn package_search_policy_matches_shared_registry() {
         assert!(manager_participates_in_package_search(ManagerId::Rustup));
@@ -10295,6 +10715,144 @@ mod tests {
             ManagerId::SoftwareUpdate
         ));
         assert!(!manager_participates_in_package_search(ManagerId::Sparkle));
+    }
+
+    #[test]
+    fn catalog_sync_policy_matches_shared_registry() {
+        assert!(manager_participates_in_catalog_sync(ManagerId::Mise));
+        assert!(manager_participates_in_catalog_sync(ManagerId::Asdf));
+        assert!(manager_participates_in_catalog_sync(ManagerId::Rustup));
+        assert!(manager_participates_in_catalog_sync(
+            ManagerId::HomebrewFormula
+        ));
+        assert!(manager_participates_in_catalog_sync(
+            ManagerId::HomebrewCask
+        ));
+        assert!(!manager_participates_in_catalog_sync(ManagerId::MacPorts));
+        assert!(!manager_participates_in_catalog_sync(ManagerId::Npm));
+        assert!(!manager_participates_in_catalog_sync(ManagerId::Cargo));
+    }
+
+    #[test]
+    fn discovery_roots_include_mise_shims_and_custom_cargo_home() {
+        let _guard = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock should be available");
+        let _snapshot = EnvSnapshot::capture();
+
+        let home = std::path::PathBuf::from("/tmp/helm-ffi-home");
+        let cargo_home = std::path::PathBuf::from("/tmp/helm-ffi-cargo");
+
+        unsafe {
+            std::env::set_var("HOME", home.to_string_lossy().to_string());
+            std::env::set_var("CARGO_HOME", cargo_home.to_string_lossy().to_string());
+        }
+
+        let additional = super::manager_additional_bin_roots();
+        assert!(
+            additional
+                .iter()
+                .any(|path| path == &home.join(".local/share/mise/shims")),
+            "mise shims should be discoverable in FFI helper roots"
+        );
+        assert!(
+            additional
+                .iter()
+                .any(|path| path == &cargo_home.join("bin")),
+            "custom cargo home bin should be discoverable in FFI helper roots"
+        );
+    }
+
+    #[test]
+    fn rustup_probe_candidates_include_custom_cargo_home_and_homebrew_kegs() {
+        let _guard = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock should be available");
+        let _snapshot = EnvSnapshot::capture();
+
+        let home = std::path::PathBuf::from("/tmp/helm-ffi-rustup-home");
+        let cargo_home = std::path::PathBuf::from("/tmp/helm-ffi-rustup-cargo");
+
+        unsafe {
+            std::env::set_var("HOME", home.to_string_lossy().to_string());
+            std::env::set_var("CARGO_HOME", cargo_home.to_string_lossy().to_string());
+        }
+
+        let candidates = rustup_probe_candidates(None)
+            .into_iter()
+            .map(|candidate| candidate.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+
+        assert!(candidates.contains(&cargo_home.join("bin/rustup").to_string_lossy().to_string()));
+        assert!(candidates.contains(&home.join(".cargo/bin/rustup").to_string_lossy().to_string()));
+        assert!(candidates.contains(&"/opt/homebrew/opt/rustup/bin/rustup".to_string()));
+        assert!(candidates.contains(&"/usr/local/opt/rustup/bin/rustup".to_string()));
+    }
+
+    #[test]
+    fn cached_discovery_recomputes_when_cached_path_disappears() {
+        let _guard = ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock should be available");
+        let _snapshot = EnvSnapshot::capture();
+
+        let root = unique_temp_dir("discovery-cache");
+        let first = root.join("first/bin/rustup");
+        let second = root.join("second/bin/rustup");
+        fs::create_dir_all(first.parent().expect("first parent")).expect("create first parent");
+        fs::create_dir_all(second.parent().expect("second parent")).expect("create second parent");
+        fs::write(&first, b"#!/bin/sh\nexit 0\n").expect("write first binary");
+        fs::write(&second, b"#!/bin/sh\nexit 0\n").expect("write second binary");
+
+        let cache = super::EXECUTABLE_DISCOVERY_CACHE
+            .get_or_init(|| Mutex::new(std::collections::HashMap::new()));
+        if let Ok(mut guard) = cache.lock() {
+            guard.clear();
+        }
+
+        unsafe {
+            std::env::set_var(
+                "PATH",
+                first
+                    .parent()
+                    .expect("first parent")
+                    .to_string_lossy()
+                    .to_string(),
+            );
+        }
+
+        let initial = super::cached_discovered_executable_paths(ManagerId::Rustup, &["rustup"]);
+        assert!(
+            initial.contains(&first.to_string_lossy().to_string()),
+            "initial discovery should include the first binary: {initial:?}"
+        );
+
+        fs::remove_file(&first).expect("remove first binary");
+        unsafe {
+            std::env::set_var(
+                "PATH",
+                second
+                    .parent()
+                    .expect("second parent")
+                    .to_string_lossy()
+                    .to_string(),
+            );
+        }
+
+        let refreshed = super::cached_discovered_executable_paths(ManagerId::Rustup, &["rustup"]);
+        assert!(
+            refreshed.contains(&second.to_string_lossy().to_string()),
+            "refreshed discovery should include the replacement binary: {refreshed:?}"
+        );
+        assert!(
+            !refreshed.contains(&first.to_string_lossy().to_string()),
+            "refreshed discovery should drop the removed binary: {refreshed:?}"
+        );
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]
@@ -11651,6 +12209,42 @@ mod tests {
         );
 
         let _ = fs::remove_file(store.database_path());
+    }
+
+    #[test]
+    fn manager_status_flags_stale_selected_executable_override_issue() {
+        let pref_map = HashMap::from([(
+            ManagerId::Rustup,
+            ManagerPreference {
+                manager: ManagerId::Rustup,
+                enabled: true,
+                selected_executable_path: Some("/tmp/helm-missing-rustup".to_string()),
+                selected_install_method: None,
+                timeout_hard_seconds: None,
+                timeout_idle_seconds: None,
+            },
+        )]);
+
+        let statuses = build_manager_statuses(None, None, &HashMap::new(), &pref_map);
+        let rustup = status_for(&statuses, ManagerId::Rustup);
+        let issue = rustup
+            .package_state_issues
+            .iter()
+            .find(|issue| {
+                issue.finding_code == helm_core::doctor::FINDING_CODE_SELECTED_EXECUTABLE_PATH_STALE
+            })
+            .expect("stale selected executable issue should be present");
+        assert_eq!(
+            issue.issue_code,
+            helm_core::doctor::ISSUE_CODE_SELECTED_EXECUTABLE_PATH_STALE
+        );
+        assert_eq!(issue.source_manager_id, "rustup");
+        assert!(issue.package_name.is_empty());
+        assert_eq!(issue.repair_options.len(), 1);
+        assert_eq!(
+            issue.repair_options[0].option_id,
+            helm_core::repair::REPAIR_OPTION_CLEAR_SELECTED_EXECUTABLE_OVERRIDE
+        );
     }
 
     #[test]

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,20 +8,19 @@ It reflects reality, not intention.
 
 ## Version
 
-Current documentation baseline: **0.17.9 stable released on `main`** with `0.17.10` patch hardening active on `dev` ahead of `0.18.x`.
+Current documentation baseline: **0.17.10 stable released on `main`** with `0.18.x` planning active on `dev`.
 
-Implementation baseline: **0.17.10 stable-line hardening in progress on `dev`** with diagnostics/logging delivery, package workflow hardening, manager-selection/enablement and onboarding/detection hardening, release-process hardening phases 1-5, post-`v0.17.5` refresh reliability/diagnostics hardening, complete current-scope manager adapter coverage, and local doctor/repair follow-up for executable-path drift.
+Implementation baseline: **0.18.x planning on `dev`** after diagnostics/logging delivery, package workflow hardening, manager-selection/enablement and onboarding/detection hardening, release-process hardening phases 1-5, post-`v0.17.5` refresh reliability/diagnostics hardening, complete current-scope manager adapter coverage, and local doctor/repair follow-up for executable-path drift.
 
 See:
 - CHANGELOG.md
 
 Active milestone:
-- latest stable release currently published on `main`: **0.17.9** (released on 2026-03-11)
-- next stable patch target on `dev`: **0.17.10** (final stable-line hardening and edge-case fixes before `0.18.x`)
-- next integration target after that on `dev`: **0.18.x** (broader doctor/repair foundation and local security groundwork sequencing)
+- latest stable release currently published on `main`: **0.17.10** (released on 2026-03-11)
+- next integration target on `dev`: **0.18.x** (broader doctor/repair foundation and local security groundwork sequencing)
 - repository operations follow-up on `dev`: repository-local Codex operating model refined for lean context (`project_doc_max_bytes=131072`), policy-only root `AGENTS.md`, workflow Skills under `ops/codex/skills/`, slash-command templates under `.codex/commands/`, and structured local notify logging to `dev/logs/codex-runs.ndjson`.
-- latest stable publication cut completed for `v0.17.9`:
-  - workspace, docs, website, appcast, and CLI metadata now reflect the published `0.17.9` stable line.
+- latest stable publication cut completed for `v0.17.10`:
+  - workspace, docs, website, appcast, and CLI metadata now reflect the published `0.17.10` stable line.
   - release automation follow-through and publish verification completed on `main`.
 - 0.17.x — Diagnostics & Logging (**stable released on `main`**, RC lineage `v0.17.0-rc.1` through `v0.17.0-rc.5`)
   - delivered: `feat/v0.17-log-foundation` (SQLite-backed task lifecycle logs + retrieval plumbing)
@@ -94,7 +93,7 @@ Active milestone:
   - delivered: manager lifecycle parity sweep follow-up (on `dev`): install planning now supports additional non-system managers through deterministic Homebrew routes (`npm`, `pnpm`, `yarn`, `pip`, `pipx`, `poetry`, `rubygems`, `bundler`, `cargo`, `cargo-binstall`, `podman`, `colima`); install-method surfaces in core/CLI/FFI now expose only planner-supported methods (policy-filtered per environment), and GUI manager capability gating now marks these managers automatable so install/update/uninstall controls stay aligned with executable lifecycle paths.
   - delivered: pre-`v0.17.7` release-gate closure follow-up (on `dev`): runtime queue terminal waits now avoid missed-notify timeout races and emit periodic heartbeat diagnostics while waiting; graceful cancellation now re-checks terminal state before forced abort; request/response orchestration now logs start timestamp, effective timeout (`min(policy_timeout, orchestration_cap)`), retry attempts, terminal status, and cancellation path; Homebrew adapter `clippy::collapsible_if` warnings were removed; process-timeout coverage now verifies timeout termination does not leave child process-group orphans; and rustup orchestration reliability was re-validated with repeated stress runs.
   - delivered: GitHub governance hardening follow-up (on `dev`): per-branch rulesets are now explicit for `main`/`dev`/`docs`/`web` with branch-specific required checks; new `Policy Gate` + `Docs Checks` + `Web Build` workflows enforce branch targeting/scope policy; repository merge settings keep auto-merge/update-branch enabled while delete-branch-on-merge stays off to protect primary branches; blocking ruleset `update` enforcement was removed after protected-ref merge-block diagnostics; CodeQL is now main-focused (push/schedule/manual) to avoid PR gate friction.
-  - `v0.17.9` stable release execution status: released on `main` with tag, publish metadata, and verification complete.
+  - `v0.17.10` stable release execution status: released on `main` with tag, publish metadata, and verification complete.
 
 Security rollout staging status:
 - Stage 0 (`<=0.16.x`): planning/docs only (active in `0.16.1`)
@@ -1012,4 +1011,4 @@ Helm is a **functional control plane for 28 implemented managers** with:
 
 The core architecture is in place. The Rust core passed a full audit with no critical issues.
 
-0.13.x through 0.17.9 stable checkpoints are complete on `main`; `v0.17.0-rc.1` through `v0.17.0-rc.5` served as the completed RC validation path into stable `0.17.0`, followed by stable patch releases `v0.17.1`, `v0.17.2`, `v0.17.3`, `v0.17.4`, `v0.17.5`, `v0.17.6`, `v0.17.7`, `v0.17.8`, and `v0.17.9`.
+0.13.x through 0.17.10 stable checkpoints are complete on `main`; `v0.17.0-rc.1` through `v0.17.0-rc.5` served as the completed RC validation path into stable `0.17.0`, followed by stable patch releases `v0.17.1`, `v0.17.2`, `v0.17.3`, `v0.17.4`, `v0.17.5`, `v0.17.6`, `v0.17.7`, `v0.17.8`, `v0.17.9`, and `v0.17.10`.

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,20 +8,21 @@ It reflects reality, not intention.
 
 ## Version
 
-Current documentation baseline: **0.17.9 stable publication ready on `main`** with `0.18.x` follow-up planning active on `dev`.
+Current documentation baseline: **0.17.9 stable released on `main`** with `0.17.10` patch hardening active on `dev` ahead of `0.18.x`.
 
-Implementation baseline: **0.17.9 stable release candidate** with diagnostics/logging delivery, package workflow hardening, manager-selection/enablement and onboarding/detection hardening, release-process hardening phases 1-5, post-`v0.17.5` refresh reliability/diagnostics hardening, and complete current-scope manager adapter coverage.
+Implementation baseline: **0.17.10 stable-line hardening in progress on `dev`** with diagnostics/logging delivery, package workflow hardening, manager-selection/enablement and onboarding/detection hardening, release-process hardening phases 1-5, post-`v0.17.5` refresh reliability/diagnostics hardening, complete current-scope manager adapter coverage, and local doctor/repair follow-up for executable-path drift.
 
 See:
 - CHANGELOG.md
 
 Active milestone:
-- latest stable release currently published on `main`: **0.17.9** (stable promotion candidate aligned for tag + publish execution on `main`)
-- next integration target on `dev`: **0.18.x** (doctor/repair foundation and local security groundwork sequencing)
+- latest stable release currently published on `main`: **0.17.9** (released on 2026-03-11)
+- next stable patch target on `dev`: **0.17.10** (final stable-line hardening and edge-case fixes before `0.18.x`)
+- next integration target after that on `dev`: **0.18.x** (broader doctor/repair foundation and local security groundwork sequencing)
 - repository operations follow-up on `dev`: repository-local Codex operating model refined for lean context (`project_doc_max_bytes=131072`), policy-only root `AGENTS.md`, workflow Skills under `ops/codex/skills/`, slash-command templates under `.codex/commands/`, and structured local notify logging to `dev/logs/codex-runs.ndjson`.
-- stable publication cut prepared for `v0.17.9`:
-  - workspace, docs, and website release-line surfaces are aligned for the `0.17.9` stable promotion.
-  - tag, release publication, and publish-metadata follow-up remain governed by the `v0.17.9` release checklist on `main`.
+- latest stable publication cut completed for `v0.17.9`:
+  - workspace, docs, website, appcast, and CLI metadata now reflect the published `0.17.9` stable line.
+  - release automation follow-through and publish verification completed on `main`.
 - 0.17.x — Diagnostics & Logging (**stable released on `main`**, RC lineage `v0.17.0-rc.1` through `v0.17.0-rc.5`)
   - delivered: `feat/v0.17-log-foundation` (SQLite-backed task lifecycle logs + retrieval plumbing)
   - delivered: `feat/v0.17-task-log-viewer` (inspector diagnostics logs tab with level/status filters + load-more pagination)
@@ -93,7 +94,7 @@ Active milestone:
   - delivered: manager lifecycle parity sweep follow-up (on `dev`): install planning now supports additional non-system managers through deterministic Homebrew routes (`npm`, `pnpm`, `yarn`, `pip`, `pipx`, `poetry`, `rubygems`, `bundler`, `cargo`, `cargo-binstall`, `podman`, `colima`); install-method surfaces in core/CLI/FFI now expose only planner-supported methods (policy-filtered per environment), and GUI manager capability gating now marks these managers automatable so install/update/uninstall controls stay aligned with executable lifecycle paths.
   - delivered: pre-`v0.17.7` release-gate closure follow-up (on `dev`): runtime queue terminal waits now avoid missed-notify timeout races and emit periodic heartbeat diagnostics while waiting; graceful cancellation now re-checks terminal state before forced abort; request/response orchestration now logs start timestamp, effective timeout (`min(policy_timeout, orchestration_cap)`), retry attempts, terminal status, and cancellation path; Homebrew adapter `clippy::collapsible_if` warnings were removed; process-timeout coverage now verifies timeout termination does not leave child process-group orphans; and rustup orchestration reliability was re-validated with repeated stress runs.
   - delivered: GitHub governance hardening follow-up (on `dev`): per-branch rulesets are now explicit for `main`/`dev`/`docs`/`web` with branch-specific required checks; new `Policy Gate` + `Docs Checks` + `Web Build` workflows enforce branch targeting/scope policy; repository merge settings keep auto-merge/update-branch enabled while delete-branch-on-merge stays off to protect primary branches; blocking ruleset `update` enforcement was removed after protected-ref merge-block diagnostics; CodeQL is now main-focused (push/schedule/manual) to avoid PR gate friction.
-  - `v0.17.9` stable release execution status: release promotion prepared on `main` (validation green + stable-line alignment complete ahead of tag/publish)
+  - `v0.17.9` stable release execution status: released on `main` with tag, publish metadata, and verification complete.
 
 Security rollout staging status:
 - Stage 0 (`<=0.16.x`): planning/docs only (active in `0.16.1`)

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -11,22 +11,22 @@ It is intentionally tactical.
 Helm is in:
 
 ```
-0.18.x doctor/repair foundation execution (post-v0.17.9 stable)
+0.17.10 stable hardening on `dev` (post-v0.17.9 release, pre-0.18.x)
 ```
 
 Focus:
-- keep `main`/`dev`/`docs`/`web` publication docs and version markers aligned for `v0.17.9`
+- keep `main`/`dev`/`docs`/`web` release-state docs and version markers aligned now that `v0.17.9` is published
 - maintain release-process hardening guardrails now that phases 1-5 are complete (preflight, publish verification, drift prevention)
-- execute doctor/repair subsystem foundation in core + FFI + service surfaces
-- ship first repair path for Homebrew metadata-only manager installs via the new repair subsystem
+- finish stable-line hardening for onboarding detection, executable-path discovery, catalog-sync scoping, and local doctor/repair for executable-path drift
+- continue doctor/repair subsystem foundation in core + FFI + service surfaces without widening into online knowledge lookup yet
 - keep repair knowledge lookup local/embedded for now, with explicit TODO seams for future online fingerprint lookup
-- sequence `0.18.x` local security groundwork after doctor/repair foundation slice
+- sequence `0.18.x` local security groundwork after the `0.17.10` hardening slice lands
 - keep launch-at-login scoped to GUI only (no CLI/TUI parity target)
 - track post-mise lifecycle follow-ups: plugin-as-package modeling evaluation and managed-environment install-source policy controls
 - keep the repository-local Codex operating model current (lean `AGENTS`, `ops/codex/skills/`, `.codex/commands/`, notify logging, and `ops/codex/docs/` workflows) so recurring AI workflows remain deterministic and low-friction
 
 Current checkpoint:
-- `v0.17.9` is the current stable release on `main`; current-scope manager adapter completion and package workflow hardening are now aligned for stable publication:
+- `v0.17.9` is the current stable release on `main`; current-scope manager adapter completion and package workflow hardening are now published, and `0.17.10` is reserved for final stable-line hardening:
   - all current manager adapters are considered complete for Helm's intended scope
   - intentionally narrower manager scopes remain explicit (`nix_darwin` detect/refresh-only; detection-only adapters such as `sparkle`, `setapp`, and `parallels_desktop`; guarded/status adapters such as `docker_desktop`, `podman`, `colima`, `rosetta2`, `firmware_updates`, and `xcode_command_line_tools`)
   - no additional manager-adapter implementation gaps remain beyond those intentional product boundaries

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -11,22 +11,21 @@ It is intentionally tactical.
 Helm is in:
 
 ```
-0.17.10 stable hardening on `dev` (post-v0.17.9 release, pre-0.18.x)
+0.18.x planning on `dev` (post-v0.17.10 stable release)
 ```
 
 Focus:
-- keep `main`/`dev`/`docs`/`web` release-state docs and version markers aligned now that `v0.17.9` is published
+- keep `main`/`dev`/`docs`/`web` release-state docs and version markers aligned now that `v0.17.10` is published
 - maintain release-process hardening guardrails now that phases 1-5 are complete (preflight, publish verification, drift prevention)
-- finish stable-line hardening for onboarding detection, executable-path discovery, catalog-sync scoping, and local doctor/repair for executable-path drift
 - continue doctor/repair subsystem foundation in core + FFI + service surfaces without widening into online knowledge lookup yet
 - keep repair knowledge lookup local/embedded for now, with explicit TODO seams for future online fingerprint lookup
-- sequence `0.18.x` local security groundwork after the `0.17.10` hardening slice lands
+- sequence `0.18.x` local security groundwork now that the `0.17.10` hardening slice has landed
 - keep launch-at-login scoped to GUI only (no CLI/TUI parity target)
 - track post-mise lifecycle follow-ups: plugin-as-package modeling evaluation and managed-environment install-source policy controls
 - keep the repository-local Codex operating model current (lean `AGENTS`, `ops/codex/skills/`, `.codex/commands/`, notify logging, and `ops/codex/docs/` workflows) so recurring AI workflows remain deterministic and low-friction
 
 Current checkpoint:
-- `v0.17.9` is the current stable release on `main`; current-scope manager adapter completion and package workflow hardening are now published, and `0.17.10` is reserved for final stable-line hardening:
+- `v0.17.10` is the current stable release on `main`; current-scope manager adapter completion, final stable-line hardening, and package workflow hardening are now published:
   - all current manager adapters are considered complete for Helm's intended scope
   - intentionally narrower manager scopes remain explicit (`nix_darwin` detect/refresh-only; detection-only adapters such as `sparkle`, `setapp`, and `parallels_desktop`; guarded/status adapters such as `docker_desktop`, `podman`, `colima`, `rosetta2`, `firmware_updates`, and `xcode_command_line_tools`)
   - no additional manager-adapter implementation gaps remain beyond those intentional product boundaries
@@ -353,7 +352,7 @@ Current checkpoint:
     - audit-remediation follow-up delivered: stable CLI update metadata now points to published `v0.17.2` CLI release assets with real checksums (no placeholder zeros), and auto-check last-checked timestamps now update only after eligible direct self-managed check attempts instead of policy-gated skips
     - audit-remediation follow-up delivered: distribution profile contract is now centralized in `docs/contracts/distribution-profiles.json` and consumed by shared build orchestration (`scripts/build.sh`, `scripts/release/build_unsigned_variant.sh`, matrix-based `release-all-variants.yml` auxiliary jobs); Swift update-authority mapping now has one source (`AppUpdateConfiguration`), targeted updater policy tests pass on macOS, and GUI checksum-publication symmetry is explicitly documented as deferred while Sparkle remains canonical GUI integrity authority
     - trust-chain future work is now explicitly tracked: detached signatures + signing-key rotation for CLI update artifacts (`docs/roadmap/CLI_DISTRIBUTION_CI_MILESTONES.md`, milestone M5)
-- latest stable release on `main`: `v0.17.9`
+- latest stable release on `main`: `v0.17.10`
 - validation gates are green through the stable cut (`cargo test`, macOS `xcodebuild` tests, locale integrity/length audits, release workflow smoke across `v0.17.0-rc.1` through `v0.17.0-rc.5`)
 - `v0.15.0` released on `main` (tag `v0.15.0`)
 - `v0.14.0` released (merged to `main`, tagged, manager rollout + docs/version alignment complete)
@@ -1265,4 +1264,4 @@ Implement:
 - 0.14 stable release alignment for `v0.14.0` is complete (README/website + version artifacts).
 - Distribution/licensing future-state planning documentation is aligned for 0.14 release notes and roadmap planning (no implementation yet).
 - 0.14.x and 0.15.x release execution are complete on `main` (`v0.14.1` and `v0.15.0`).
-- 0.17.9 release execution is staged on `main`; 0.17.x diagnostics/logging delivery and post-`0.17.x` follow-up stabilization are now closed with stable lineage `v0.17.0`, `v0.17.1`, `v0.17.2`, `v0.17.3`, `v0.17.4`, `v0.17.5`, `v0.17.6`, `v0.17.7`, `v0.17.8`, and `v0.17.9`.
+- 0.17.10 release execution is complete on `main`; 0.17.x diagnostics/logging delivery and post-`0.17.x` follow-up stabilization are now closed with stable lineage `v0.17.0`, `v0.17.1`, `v0.17.2`, `v0.17.3`, `v0.17.4`, `v0.17.5`, `v0.17.6`, `v0.17.7`, `v0.17.8`, `v0.17.9`, and `v0.17.10`.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -57,35 +57,35 @@ This checklist is required before creating a release tag on `main`.
 ## v0.17.9 (Stable Patch Release Gate)
 
 ### Scope and Documentation
-- [ ] `CHANGELOG.md` includes finalized `0.17.9` patch notes for current-scope manager adapter completion and release-prep follow-through.
-- [ ] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect `v0.17.9` as the current stable release on `main` and resumed `0.18.x` planning on `dev`.
-- [ ] Website changelog and current-version surfaces reflect `v0.17.9`.
-- [ ] README current stable version markers reflect `v0.17.9`.
-- [ ] Canonical release-line contract check passes: `scripts/release/check_release_line_copy.sh`.
+- [x] `CHANGELOG.md` includes finalized `0.17.9` patch notes for current-scope manager adapter completion and release-prep follow-through.
+- [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect `v0.17.9` as the current stable release on `main` and resumed `0.18.x` planning on `dev`.
+- [x] Website changelog and current-version surfaces reflect `v0.17.9`.
+- [x] README current stable version markers reflect `v0.17.9`.
+- [x] Canonical release-line contract check passes: `scripts/release/check_release_line_copy.sh`.
 
 ### Versioning
-- [ ] Workspace version bumped to `0.17.9` in `core/rust/Cargo.toml`.
-- [ ] Rust lockfile local package versions aligned to `0.17.9` in `core/rust/Cargo.lock`.
-- [ ] Generated app version artifacts aligned to `0.17.9` (`apps/macos-ui/Generated/HelmVersion.swift`, `apps/macos-ui/Generated/HelmVersion.xcconfig`).
+- [x] Workspace version bumped to `0.17.9` in `core/rust/Cargo.toml`.
+- [x] Rust lockfile local package versions aligned to `0.17.9` in `core/rust/Cargo.lock`.
+- [x] Generated app version artifacts aligned to `0.17.9` (`apps/macos-ui/Generated/HelmVersion.swift`, `apps/macos-ui/Generated/HelmVersion.xcconfig`).
 
 ### Validation
-- [ ] Rust tests pass (`cargo test -p helm-core -p helm-ffi --manifest-path core/rust/Cargo.toml`).
-- [ ] `HelmTests` pass (`xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' test`).
-- [ ] Locale checks pass (`apps/macos-ui/scripts/check_locale_integrity.sh` and `apps/macos-ui/scripts/check_locale_lengths.sh`).
-- [ ] Third-party license audit commands complete without runtime-license scope regressions (`cargo metadata`, `cargo tree`, website lockfile license scan).
-- [ ] Sparkle feed publication + direct-channel update smoke validation complete against the stable appcast entry.
+- [x] Rust tests pass (`cargo test -p helm-core -p helm-ffi --manifest-path core/rust/Cargo.toml`).
+- [x] `HelmTests` pass (`xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' test`).
+- [x] Locale checks pass (`apps/macos-ui/scripts/check_locale_integrity.sh` and `apps/macos-ui/scripts/check_locale_lengths.sh`).
+- [x] Third-party license audit commands complete without runtime-license scope regressions (`cargo metadata`, `cargo tree`, website lockfile license scan).
+- [x] Sparkle feed publication + direct-channel update smoke validation complete against the stable appcast entry.
 
 ### Branch and Tag
-- [ ] Release-prep PR merged to `dev`.
-- [ ] `dev` merged into `main` for stable cut.
-- [ ] If release-critical docs updates were developed on `docs`, merge `docs` into `main`.
-- [ ] If release-critical website updates were developed on `web`, merge `web` into `main`.
-- [ ] Create annotated stable tag from `main`: `git tag -a v0.17.9 -m "Helm v0.17.9"`.
-- [ ] Push stable tag: `git push origin v0.17.9`.
-- [ ] Publish GitHub release for `v0.17.9` (mark as latest, non-prerelease).
-- [ ] Confirm release-generated publish PR (`chore/publish-updates-v0.17.9`) merged to `main`.
-- [ ] Confirm release-generated CLI metadata publish PR (`chore/publish-cli-updates-v0.17.9-stable`) merged to `main`.
-- [ ] Confirm `Release Publish Verify`, `Appcast Drift Guard`, and `CLI Update Metadata Drift Guard` are green after publication.
+- [x] Release-prep PR merged to `dev`.
+- [x] `dev` merged into `main` for stable cut.
+- [x] If release-critical docs updates were developed on `docs`, merge `docs` into `main`.
+- [x] If release-critical website updates were developed on `web`, merge `web` into `main`.
+- [x] Create annotated stable tag from `main`: `git tag -a v0.17.9 -m "Helm v0.17.9"`.
+- [x] Push stable tag: `git push origin v0.17.9`.
+- [x] Publish GitHub release for `v0.17.9` (mark as latest, non-prerelease).
+- [x] Confirm release-generated publish PR (`chore/publish-updates-v0.17.9`) merged to `main`.
+- [x] Confirm release-generated CLI metadata publish PR (`chore/publish-cli-updates-v0.17.9-stable`) merged to `main`.
+- [x] Confirm `Release Publish Verify`, `Appcast Drift Guard`, and `CLI Update Metadata Drift Guard` are green after publication.
 
 ## Historical RC and Prior-Release Checklists (Archive)
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -54,19 +54,19 @@ This checklist is required before creating a release tag on `main`.
   - `CLI Update Metadata Drift Guard`
 - [ ] Review `TMP_RELEASE_FRICTION`; promote recurring friction items into durable docs (`docs/DECISIONS.md`, `docs/operations/CLI_RELEASE_AND_CI.md`) and keep temporary notes uncommitted.
 
-## v0.17.9 (Stable Patch Release Gate)
+## v0.17.10 (Stable Patch Release Gate)
 
 ### Scope and Documentation
-- [x] `CHANGELOG.md` includes finalized `0.17.9` patch notes for current-scope manager adapter completion and release-prep follow-through.
-- [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect `v0.17.9` as the current stable release on `main` and resumed `0.18.x` planning on `dev`.
-- [x] Website changelog and current-version surfaces reflect `v0.17.9`.
-- [x] README current stable version markers reflect `v0.17.9`.
+- [x] `CHANGELOG.md` includes finalized `0.17.10` patch notes for final stable-line hardening and manager discovery/repair follow-through.
+- [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect `v0.17.9` as the current stable release on `main` and `0.17.10` as the active final hardening patch on `dev`.
+- [x] Public stable-line surfaces (`README.md`, website appcast, CLI latest metadata, release-line contract) remain on published `v0.17.9` until the later `main` promotion branch.
+- [x] Internal prep branch version artifacts reflect `0.17.10` for workspace/app build outputs.
 - [x] Canonical release-line contract check passes: `scripts/release/check_release_line_copy.sh`.
 
 ### Versioning
-- [x] Workspace version bumped to `0.17.9` in `core/rust/Cargo.toml`.
-- [x] Rust lockfile local package versions aligned to `0.17.9` in `core/rust/Cargo.lock`.
-- [x] Generated app version artifacts aligned to `0.17.9` (`apps/macos-ui/Generated/HelmVersion.swift`, `apps/macos-ui/Generated/HelmVersion.xcconfig`).
+- [x] Workspace version bumped to `0.17.10` in `core/rust/Cargo.toml`.
+- [x] Rust lockfile local package versions aligned to `0.17.10` in `core/rust/Cargo.lock`.
+- [x] Generated app version artifacts aligned to `0.17.10` (`apps/macos-ui/Generated/HelmVersion.swift`, `apps/macos-ui/Generated/HelmVersion.xcconfig`).
 
 ### Validation
 - [x] Rust tests pass (`cargo test -p helm-core -p helm-ffi --manifest-path core/rust/Cargo.toml`).
@@ -76,16 +76,21 @@ This checklist is required before creating a release tag on `main`.
 - [x] Sparkle feed publication + direct-channel update smoke validation complete against the stable appcast entry.
 
 ### Branch and Tag
-- [x] Release-prep PR merged to `dev`.
-- [x] `dev` merged into `main` for stable cut.
-- [x] If release-critical docs updates were developed on `docs`, merge `docs` into `main`.
-- [x] If release-critical website updates were developed on `web`, merge `web` into `main`.
-- [x] Create annotated stable tag from `main`: `git tag -a v0.17.9 -m "Helm v0.17.9"`.
-- [x] Push stable tag: `git push origin v0.17.9`.
-- [x] Publish GitHub release for `v0.17.9` (mark as latest, non-prerelease).
-- [x] Confirm release-generated publish PR (`chore/publish-updates-v0.17.9`) merged to `main`.
-- [x] Confirm release-generated CLI metadata publish PR (`chore/publish-cli-updates-v0.17.9-stable`) merged to `main`.
-- [x] Confirm `Release Publish Verify`, `Appcast Drift Guard`, and `CLI Update Metadata Drift Guard` are green after publication.
+- [ ] Release-prep PR merged to `dev`.
+- [ ] `dev` merged into `main` for stable cut.
+- [ ] If release-critical docs updates were developed on `docs`, merge `docs` into `main`.
+- [ ] If release-critical website updates were developed on `web`, merge `web` into `main`.
+- [ ] Create annotated stable tag from `main`: `git tag -a v0.17.10 -m "Helm v0.17.10"`.
+- [ ] Push stable tag: `git push origin v0.17.10`.
+- [ ] Publish GitHub release for `v0.17.10` (mark as latest, non-prerelease).
+- [ ] Confirm release-generated publish PR (`chore/publish-updates-v0.17.10`) merged to `main`.
+- [ ] Confirm release-generated CLI metadata publish PR (`chore/publish-cli-updates-v0.17.10-stable`) merged to `main`.
+- [ ] Confirm `Release Publish Verify`, `Appcast Drift Guard`, and `CLI Update Metadata Drift Guard` are green after publication.
+
+## v0.17.9 (Stable Patch Release Gate, Completed)
+
+- Completed and published on `main` on 2026-03-11.
+- Historical execution details remain preserved in git history, published release metadata, and the `v0.17.9` changelog entry.
 
 ## Historical RC and Prior-Release Checklists (Archive)
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -58,8 +58,10 @@ This checklist is required before creating a release tag on `main`.
 
 ### Scope and Documentation
 - [x] `CHANGELOG.md` includes finalized `0.17.10` patch notes for final stable-line hardening and manager discovery/repair follow-through.
-- [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect `v0.17.9` as the current stable release on `main` and `0.17.10` as the active final hardening patch on `dev`.
-- [x] Public stable-line surfaces (`README.md`, website appcast, CLI latest metadata, release-line contract) remain on published `v0.17.9` until the later `main` promotion branch.
+- [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect `v0.17.10` as the current stable release on `main` and `0.18.x` planning on `dev`.
+- [x] Website changelog and current-version surfaces reflect `v0.17.10`.
+- [x] README current stable version markers reflect `v0.17.10`.
+- [x] Canonical release-line contract targets `v0.17.10` on the promotion branch.
 - [x] Internal prep branch version artifacts reflect `0.17.10` for workspace/app build outputs.
 - [x] Canonical release-line contract check passes: `scripts/release/check_release_line_copy.sh`.
 
@@ -76,7 +78,7 @@ This checklist is required before creating a release tag on `main`.
 - [x] Sparkle feed publication + direct-channel update smoke validation complete against the stable appcast entry.
 
 ### Branch and Tag
-- [ ] Release-prep PR merged to `dev`.
+- [x] Release-prep PR merged to `dev`.
 - [ ] `dev` merged into `main` for stable cut.
 - [ ] If release-critical docs updates were developed on `docs`, merge `docs` into `main`.
 - [ ] If release-critical website updates were developed on `web`, merge `web` into `main`.

--- a/docs/contracts/release-line.json
+++ b/docs/contracts/release-line.json
@@ -1,3 +1,3 @@
 {
-  "stable_version": "0.17.9"
+  "stable_version": "0.17.10"
 }

--- a/locales/de/service.json
+++ b/locales/de/service.json
@@ -49,5 +49,6 @@
   "service.error.pip_system_unmanaged": "pip at /usr/bin/python3, /usr/bin/pip, or /usr/bin/pip3 is a macOS base-system install and cannot be managed by Helm. Select a non-system Python/pip executable (Homebrew, mise, or asdf).",
   "service.error.manager_dependency_blocked": "Cannot disable this manager while enabled dependent managers rely on it.",
   "service.error.manager_setup_required": "This manager requires post-install setup before it can be enabled. Select Finish Setup in Manager Inspector, complete setup, then verify.",
-  "service.task.label.setup.manager": "Finish {manager} setup"
+  "service.task.label.setup.manager": "Finish {manager} setup",
+  "service.task.label.repair.manager": "Repair {manager} configuration"
 }

--- a/locales/en/service.json
+++ b/locales/en/service.json
@@ -49,5 +49,6 @@
   "service.error.pip_system_unmanaged": "pip at /usr/bin/python3, /usr/bin/pip, or /usr/bin/pip3 is a macOS base-system install and cannot be managed by Helm. Select a non-system Python/pip executable (Homebrew, mise, or asdf).",
   "service.error.manager_dependency_blocked": "Cannot disable this manager while enabled dependent managers rely on it.",
   "service.error.manager_setup_required": "This manager requires post-install setup before it can be enabled. Select Finish Setup in Manager Inspector, complete setup, then verify.",
-  "service.task.label.setup.manager": "Finish {manager} setup"
+  "service.task.label.setup.manager": "Finish {manager} setup",
+  "service.task.label.repair.manager": "Repair {manager} configuration"
 }

--- a/locales/es/service.json
+++ b/locales/es/service.json
@@ -49,5 +49,6 @@
   "service.error.pip_system_unmanaged": "pip at /usr/bin/python3, /usr/bin/pip, or /usr/bin/pip3 is a macOS base-system install and cannot be managed by Helm. Select a non-system Python/pip executable (Homebrew, mise, or asdf).",
   "service.error.manager_dependency_blocked": "Cannot disable this manager while enabled dependent managers rely on it.",
   "service.error.manager_setup_required": "This manager requires post-install setup before it can be enabled. Select Finish Setup in Manager Inspector, complete setup, then verify.",
-  "service.task.label.setup.manager": "Finish {manager} setup"
+  "service.task.label.setup.manager": "Finish {manager} setup",
+  "service.task.label.repair.manager": "Repair {manager} configuration"
 }

--- a/locales/fr/service.json
+++ b/locales/fr/service.json
@@ -49,5 +49,6 @@
   "service.error.pip_system_unmanaged": "pip at /usr/bin/python3, /usr/bin/pip, or /usr/bin/pip3 is a macOS base-system install and cannot be managed by Helm. Select a non-system Python/pip executable (Homebrew, mise, or asdf).",
   "service.error.manager_dependency_blocked": "Cannot disable this manager while enabled dependent managers rely on it.",
   "service.error.manager_setup_required": "This manager requires post-install setup before it can be enabled. Select Finish Setup in Manager Inspector, complete setup, then verify.",
-  "service.task.label.setup.manager": "Finish {manager} setup"
+  "service.task.label.setup.manager": "Finish {manager} setup",
+  "service.task.label.repair.manager": "Repair {manager} configuration"
 }

--- a/locales/hu/service.json
+++ b/locales/hu/service.json
@@ -49,5 +49,6 @@
   "service.error.pip_system_unmanaged": "pip at /usr/bin/python3, /usr/bin/pip, or /usr/bin/pip3 is a macOS base-system install and cannot be managed by Helm. Select a non-system Python/pip executable (Homebrew, mise, or asdf).",
   "service.error.manager_dependency_blocked": "Cannot disable this manager while enabled dependent managers rely on it.",
   "service.error.manager_setup_required": "This manager requires post-install setup before it can be enabled. Select Finish Setup in Manager Inspector, complete setup, then verify.",
-  "service.task.label.setup.manager": "Finish {manager} setup"
+  "service.task.label.setup.manager": "Finish {manager} setup",
+  "service.task.label.repair.manager": "Repair {manager} configuration"
 }

--- a/locales/ja/service.json
+++ b/locales/ja/service.json
@@ -49,5 +49,6 @@
   "service.error.pip_system_unmanaged": "pip at /usr/bin/python3, /usr/bin/pip, or /usr/bin/pip3 is a macOS base-system install and cannot be managed by Helm. Select a non-system Python/pip executable (Homebrew, mise, or asdf).",
   "service.error.manager_dependency_blocked": "Cannot disable this manager while enabled dependent managers rely on it.",
   "service.error.manager_setup_required": "This manager requires post-install setup before it can be enabled. Select Finish Setup in Manager Inspector, complete setup, then verify.",
-  "service.task.label.setup.manager": "Finish {manager} setup"
+  "service.task.label.setup.manager": "Finish {manager} setup",
+  "service.task.label.repair.manager": "Repair {manager} configuration"
 }

--- a/locales/pt-BR/service.json
+++ b/locales/pt-BR/service.json
@@ -49,5 +49,6 @@
   "service.error.pip_system_unmanaged": "pip at /usr/bin/python3, /usr/bin/pip, or /usr/bin/pip3 is a macOS base-system install and cannot be managed by Helm. Select a non-system Python/pip executable (Homebrew, mise, or asdf).",
   "service.error.manager_dependency_blocked": "Cannot disable this manager while enabled dependent managers rely on it.",
   "service.error.manager_setup_required": "This manager requires post-install setup before it can be enabled. Select Finish Setup in Manager Inspector, complete setup, then verify.",
-  "service.task.label.setup.manager": "Finish {manager} setup"
+  "service.task.label.setup.manager": "Finish {manager} setup",
+  "service.task.label.repair.manager": "Repair {manager} configuration"
 }

--- a/web/src/components/starlight/Banner.astro
+++ b/web/src/components/starlight/Banner.astro
@@ -1,5 +1,5 @@
 ---
-const globalBanner = `<strong>Helm v0.17.9 is live.</strong> Install the latest release and report issues on <a href="https://github.com/jasoncavinder/Helm/issues/new/choose" target="_blank" rel="noreferrer">GitHub</a>.`;
+const globalBanner = `<strong>Helm v0.17.10 is live.</strong> Install the latest release and report issues on <a href="https://github.com/jasoncavinder/Helm/issues/new/choose" target="_blank" rel="noreferrer">GitHub</a>.`;
 const pageBanner = Astro.locals.starlightRoute.entry.data.banner?.content;
 const banners = [globalBanner, pageBanner].filter(Boolean);
 ---

--- a/web/src/content/docs/changelog.md
+++ b/web/src/content/docs/changelog.md
@@ -11,6 +11,22 @@ For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncav
 
 ---
 
+## 0.17.10 — 2026-03-11
+
+Patch `0.17.10` focuses on final stable-line hardening before broader `0.18.x` work begins.
+
+### Added
+- Doctor/repair now detects stale selected manager executable overrides and can clear them locally through the existing repair flow.
+
+### Changed
+- Executable discovery now accounts for non-default `CARGO_HOME`, `ASDF_DIR`, `ASDF_DATA_DIR`, and modern `mise`/`rtx` shim and install roots more consistently across core, FFI, and CLI surfaces.
+- Catalog-sync participation is now explicitly scoped instead of being inferred from generic package-search participation.
+
+### Fixed
+- Onboarding no longer risks clobbering a valid discovered `rustup` executable path during follow-up detection.
+- Non-default `cargo`, `cargo-binstall`, and `rustup` installs now route execution through the correct resolved binary path instead of assuming `~/.cargo/bin`.
+- Executable discovery caches now self-heal when cached paths disappear and are invalidated on recent manager lifecycle transitions.
+
 ## 0.17.9 — 2026-03-11
 
 Patch `0.17.9` completes current-scope manager adapter coverage and package workflow hardening ahead of the `0.18.x` doctor/repair and local-security cycle.

--- a/web/src/content/docs/guides/visual-tour.mdx
+++ b/web/src/content/docs/guides/visual-tour.mdx
@@ -27,7 +27,7 @@ import onboardingSpotlightShotDark from '../../../assets/tour/onboarding-spotlig
 Helm has two main surfaces: a **menu bar popover** for quick triage and a **Control Center window** for deeper management. This tour walks through each.
 
 <Aside type="note">
-Screenshots show Helm `v0.17.9` UI surfaces on macOS. Minor styling may change between builds, and screenshot refreshes are applied as new app captures are published.
+Screenshots show Helm `v0.17.10` UI surfaces on macOS. Minor styling may change between builds, and screenshot refreshes are applied as new app captures are published.
 </Aside>
 
 ---

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -17,7 +17,7 @@ Helm is planned as two product lifecycles: **Helm (Consumer)** and **Helm Busine
 
 ## What it does today
 
-Helm `v0.17.9` supports twenty-eight managers:
+Helm `v0.17.10` supports twenty-eight managers:
 
 | Category | Managers |
 |---------|----------|
@@ -45,7 +45,7 @@ Key features:
 - **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, and `ja` with locale override in Settings
 - **Upgrade transparency** — dedicated upgrade preview surface with scoped execution and failure-attribution visibility
 
-> **Current Track:** `v0.17.9` is the latest stable release on `main`; `0.18.x` planning is in progress. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.17.10` is the latest stable release on `main`; `0.18.x` planning is in progress. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## How it works
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -31,9 +31,9 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 | 0.14.x | Platform, Detection & Optional Managers — Docker, Xcode, Rosetta, Sparkle, Setapp, Homebrew casks, optional managers (`v0.14.x` stable, latest patch `v0.14.1`) |
 | 0.15.x | Advanced Upgrade Transparency — richer execution-plan visibility, failure isolation, and operator controls (`v0.15.0` released) |
 | 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification (`v0.16.x` stable, latest patch `v0.16.2`) |
-| 0.17.x | Diagnostics & Logging + Release Hardening — task log viewer, structured diagnostics export, manager-detection diagnostics, onboarding/detection hardening, manager-selection controls, and stable release follow-up fixes (`v0.17.0` stable, latest patch `v0.17.9`) |
+| 0.17.x | Diagnostics & Logging + Release Hardening — task log viewer, structured diagnostics export, manager-detection diagnostics, onboarding/detection hardening, manager-selection controls, and stable release follow-up fixes (`v0.17.0` stable, latest patch `v0.17.10`) |
 
-> **Current Track:** `v0.17.9` is stable on `main`; planning is shifting to `0.18.x` local security groundwork. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.17.10` is stable on `main`; planning is shifting to `0.18.x` local security groundwork. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Planned
 


### PR DESCRIPTION
## Summary
- stage the `v0.17.10` main-promotion release surfaces
- move public stable markers from `v0.17.9` to `v0.17.10`
- align docs, website, and release-line contract for the stable cut

## Validation
- `bash ops/codex/skills/docs-sync/scripts/docs-sync-check.sh`
- `scripts/release/check_release_line_copy.sh`
- `bash ops/codex/skills/run-quality-gate/scripts/run-quality-gate.sh all`

## Notes
- This branch intentionally updates public stable-line surfaces only.
- It does not tag `v0.17.10`, publish release assets, or update publish-generated metadata (`appcast.xml`, `cli/latest.json`).
