### PR TITLE
fix(tasks): persist terminal transitions atomically

### DIFF
--- a/core/rust/crates/helm-core/src/orchestration/adapter_runtime.rs
+++ b/core/rust/crates/helm-core/src/orchestration/adapter_runtime.rs
@@ -867,17 +867,9 @@ fn spawn_terminal_persistence_watcher(ctx: PersistenceWatcherContext) {
                         status: TaskStatus::Running,
                         created_at: SystemTime::now(),
                     };
-                    let _ = persist_update_task(
+                    let _ = persist_update_task_with_log(
                         task_store.clone(),
                         running_record,
-                        manager,
-                        task_type,
-                        action,
-                    )
-                    .await;
-
-                    let _ = persist_append_task_log(
-                        task_store.clone(),
                         NewTaskLogRecord {
                             task_id,
                             manager,
@@ -1007,33 +999,14 @@ fn spawn_terminal_persistence_watcher(ctx: PersistenceWatcherContext) {
             created_at: SystemTime::now(),
         };
 
-        if let Err(error) = persist_update_task(
-            task_store.clone(),
-            updated,
-            snapshot.runtime.manager,
-            snapshot.runtime.task_type,
-            action,
-        )
-        .await
-        {
-            tracing::error!(
-                manager = ?manager,
-                task_id = task_id.0,
-                task_type = ?task_type,
-                action = ?action,
-                kind = ?error.kind,
-                message = %error.message,
-                "failed to persist terminal task status"
-            );
-        }
-
         let terminal_status = snapshot.runtime.status;
         let terminal_error = terminal_error_details(&snapshot);
         let terminal_level = task_log_level_for_status(terminal_status);
         let terminal_message = task_log_message_for_status(terminal_status, terminal_error.clone());
 
-        if let Err(error) = persist_append_task_log(
+        if let Err(error) = persist_update_task_with_log(
             task_store.clone(),
+            updated,
             NewTaskLogRecord {
                 task_id: snapshot.runtime.id,
                 manager: snapshot.runtime.manager,
@@ -1049,14 +1022,14 @@ fn spawn_terminal_persistence_watcher(ctx: PersistenceWatcherContext) {
         )
         .await
         {
-            tracing::warn!(
+            tracing::error!(
                 manager = ?manager,
                 task_id = task_id.0,
                 task_type = ?task_type,
                 action = ?action,
                 kind = ?error.kind,
                 message = %error.message,
-                "failed to persist terminal task log"
+                "failed to persist terminal task transition"
             );
         }
 
@@ -1358,22 +1331,43 @@ async fn persist_create_task(
     .await
 }
 
-async fn persist_update_task(
+async fn persist_update_task_with_log(
     task_store: Arc<dyn TaskStore>,
     task_record: TaskRecord,
+    log_entry: NewTaskLogRecord,
     manager: ManagerId,
     task_type: TaskType,
     action: ManagerAction,
 ) -> OrchestrationResult<()> {
-    persist_task_record_with_retry(
-        task_store,
-        task_record,
-        manager,
-        task_type,
-        action,
-        TaskStoreOperation::Update,
-    )
-    .await
+    let mut remaining_attempts = TASK_PERSIST_RETRY_ATTEMPTS;
+    loop {
+        let store = task_store.clone();
+        let record = task_record.clone();
+        let entry = log_entry.clone();
+        let op_result =
+            tokio::task::spawn_blocking(move || store.update_task_with_log(&record, &entry))
+                .await
+                .map_err(|join_error| CoreError {
+                    manager: Some(manager),
+                    task: Some(task_type),
+                    action: Some(action),
+                    kind: CoreErrorKind::Internal,
+                    message: format!("task transition persistence join failure: {join_error}"),
+                })?;
+
+        match op_result {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                let attributed = attribute_error(error, manager, task_type, action);
+                remaining_attempts = remaining_attempts.saturating_sub(1);
+                if remaining_attempts == 0 || attributed.kind != CoreErrorKind::StorageFailure {
+                    return Err(attributed);
+                }
+
+                tokio::time::sleep(Duration::from_millis(TASK_PERSIST_RETRY_DELAY_MS)).await;
+            }
+        }
+    }
 }
 
 async fn persist_append_task_log(
@@ -1710,7 +1704,6 @@ fn truncate_for_diagnostic(value: &str, max_chars: usize) -> String {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum TaskStoreOperation {
     Create,
-    Update,
 }
 
 async fn persist_task_record_with_retry(
@@ -1727,7 +1720,6 @@ async fn persist_task_record_with_retry(
         let record = task_record.clone();
         let op_result = tokio::task::spawn_blocking(move || match operation {
             TaskStoreOperation::Create => store.create_task(&record),
-            TaskStoreOperation::Update => store.update_task(&record),
         })
         .await
         .map_err(|join_error| CoreError {

--- a/core/rust/crates/helm-core/tests/orchestration_adapter_runtime.rs
+++ b/core/rust/crates/helm-core/tests/orchestration_adapter_runtime.rs
@@ -67,6 +67,7 @@ impl TestAdapter {
 struct RecordingTaskStore {
     records: Mutex<HashMap<TaskId, TaskRecord>>,
     remaining_create_failures: Mutex<usize>,
+    fail_plain_updates: bool,
 }
 
 impl RecordingTaskStore {
@@ -78,6 +79,15 @@ impl RecordingTaskStore {
         Self {
             records: Mutex::new(HashMap::new()),
             remaining_create_failures: Mutex::new(failures),
+            fail_plain_updates: false,
+        }
+    }
+
+    fn fail_plain_updates() -> Self {
+        Self {
+            records: Mutex::new(HashMap::new()),
+            remaining_create_failures: Mutex::new(0),
+            fail_plain_updates: true,
         }
     }
 
@@ -123,6 +133,40 @@ impl TaskStore for RecordingTaskStore {
     }
 
     fn update_task(&self, task: &TaskRecord) -> PersistenceResult<()> {
+        if self.fail_plain_updates {
+            return Err(CoreError {
+                manager: None,
+                task: None,
+                action: None,
+                kind: CoreErrorKind::StorageFailure,
+                message: "plain update_task forced failure".to_string(),
+            });
+        }
+        let mut records = self.records.lock().map_err(|_| CoreError {
+            manager: None,
+            task: None,
+            action: None,
+            kind: CoreErrorKind::Internal,
+            message: "recording store mutex poisoned".to_string(),
+        })?;
+        if !records.contains_key(&task.id) {
+            return Err(CoreError {
+                manager: None,
+                task: None,
+                action: None,
+                kind: CoreErrorKind::StorageFailure,
+                message: "task record not found".to_string(),
+            });
+        }
+        records.insert(task.id, task.clone());
+        Ok(())
+    }
+
+    fn update_task_with_log(
+        &self,
+        task: &TaskRecord,
+        _entry: &helm_core::models::NewTaskLogRecord,
+    ) -> PersistenceResult<()> {
         let mut records = self.records.lock().map_err(|_| CoreError {
             manager: None,
             task: None,
@@ -560,6 +604,42 @@ async fn submit_retries_initial_task_persistence_and_succeeds_after_transient_fa
     assert_eq!(record.id, task_id);
     assert_eq!(record.manager, ManagerId::Npm);
     assert_eq!(record.task_type, TaskType::Refresh);
+}
+
+#[tokio::test]
+async fn submit_with_task_store_persists_terminal_status_via_atomic_transition() {
+    let adapter: Arc<dyn ManagerAdapter> = Arc::new(TestAdapter::new(
+        ManagerId::Npm,
+        AdapterBehavior::Succeeds(AdapterResponse::Refreshed),
+    ));
+    let task_store = Arc::new(RecordingTaskStore::fail_plain_updates());
+    let runtime = AdapterRuntime::with_task_store([adapter], task_store.clone()).unwrap();
+
+    let task_id = runtime
+        .submit(ManagerId::Npm, AdapterRequest::Refresh(RefreshRequest))
+        .await
+        .unwrap();
+    let snapshot = runtime
+        .wait_for_terminal(task_id, Some(Duration::from_secs(1)))
+        .await
+        .unwrap();
+
+    assert_eq!(snapshot.runtime.status, TaskStatus::Completed);
+
+    let mut persisted = None;
+    for _ in 0..20 {
+        if let Some(record) = task_store.get(task_id)
+            && record.status == TaskStatus::Completed
+        {
+            persisted = Some(record);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let record = persisted.expect("expected completed persisted task record through atomic path");
+    assert_eq!(record.id, task_id);
+    assert_eq!(record.status, TaskStatus::Completed);
 }
 
 #[tokio::test]

--- a/core/rust/crates/helm-ffi/src/lib.rs
+++ b/core/rust/crates/helm-ffi/src/lib.rs
@@ -2129,11 +2129,45 @@ fn runtime_task_is_inflight(
         .unwrap_or(false)
 }
 
+fn latest_persisted_terminal_status(store: &SqliteStore, task_id: TaskId) -> Option<TaskStatus> {
+    store
+        .list_task_logs(task_id, 20)
+        .ok()?
+        .into_iter()
+        .find_map(|entry| match entry.status {
+            Some(status @ (TaskStatus::Completed | TaskStatus::Cancelled | TaskStatus::Failed)) => {
+                Some(status)
+            }
+            _ => None,
+        })
+}
+
 fn mark_stale_inflight_task_terminal(
     store: &SqliteStore,
     task: &helm_core::models::TaskRecord,
     context: &str,
 ) {
+    if let Some(status) = latest_persisted_terminal_status(store, task.id) {
+        update_local_task_status(
+            store,
+            task.id,
+            task.manager,
+            task.task_type,
+            status,
+            match status {
+                TaskStatus::Completed => TaskLogLevel::Info,
+                TaskStatus::Cancelled => TaskLogLevel::Warn,
+                TaskStatus::Failed => TaskLogLevel::Error,
+                TaskStatus::Queued | TaskStatus::Running => TaskLogLevel::Warn,
+            },
+            format!(
+                "task reconciled from persisted terminal lifecycle log [{}]",
+                context
+            ),
+        );
+        return;
+    }
+
     update_local_task_status(
         store,
         task.id,
@@ -11237,6 +11271,70 @@ mod tests {
             logs.iter()
                 .any(|entry| entry.message.contains("test_reconcile")),
             "reconciled task log should include reconciliation context"
+        );
+
+        let _ = fs::remove_file(store.database_path());
+    }
+
+    #[test]
+    fn stale_inflight_reconciliation_uses_persisted_terminal_log_status() {
+        let store = temp_sqlite_store("stale-inflight-reconcile-terminal-log");
+        store
+            .migrate_to_latest()
+            .expect("sqlite migrations should apply");
+
+        let stale_running = TaskRecord {
+            id: TaskId(401),
+            manager: ManagerId::Rustup,
+            task_type: TaskType::Refresh,
+            status: TaskStatus::Running,
+            created_at: SystemTime::now(),
+        };
+
+        store
+            .create_task(&stale_running)
+            .expect("running task insert should succeed");
+        store
+            .append_task_log(&helm_core::models::NewTaskLogRecord {
+                task_id: stale_running.id,
+                manager: stale_running.manager,
+                task_type: stale_running.task_type,
+                status: Some(TaskStatus::Completed),
+                level: helm_core::models::TaskLogLevel::Info,
+                message: "task completed".to_string(),
+                created_at: SystemTime::now(),
+            })
+            .expect("terminal lifecycle log insert should succeed");
+
+        let runtime = AdapterRuntime::new(Vec::<Arc<dyn ManagerAdapter>>::new())
+            .expect("empty adapter runtime should initialize");
+        let tokio_runtime =
+            tokio::runtime::Runtime::new().expect("tokio runtime should initialize");
+
+        let reconciled = super::reconcile_stale_local_inflight_tasks(
+            &store,
+            &runtime,
+            tokio_runtime.handle(),
+            "test_terminal_log",
+        );
+        assert_eq!(reconciled, 1);
+
+        let refreshed = store
+            .list_recent_tasks(10)
+            .expect("task listing should succeed");
+        let task = refreshed
+            .into_iter()
+            .find(|task| task.id == stale_running.id)
+            .expect("task should exist");
+        assert_eq!(task.status, TaskStatus::Completed);
+
+        let logs = store
+            .list_task_logs(stale_running.id, 20)
+            .expect("task logs should load");
+        assert!(
+            logs.iter()
+                .any(|entry| entry.message.contains("persisted terminal lifecycle log")),
+            "reconciled task log should note terminal lifecycle recovery"
         );
 
         let _ = fs::remove_file(store.database_path());


### PR DESCRIPTION
## Summary
- persist runtime task status transitions atomically with the terminal lifecycle log
- reconcile stale inflight task rows to the latest persisted terminal status instead of always cancelling them
- add regression coverage for runtime task persistence and stale task self-healing

## Validation
- cargo test --manifest-path core/rust/Cargo.toml -p helm-core submit_with_task_store_persists_terminal_status_via_atomic_transition
- cargo test --manifest-path core/rust/Cargo.toml -p helm-ffi stale_inflight_reconciliation
- xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -configuration Debug -destination 'platform=macOS' build
