### PR TITLE
fix(tasks): finish catalog sync before cache writes

### DIFF
--- a/core/rust/crates/helm-core/src/orchestration/adapter_runtime.rs
+++ b/core/rust/crates/helm-core/src/orchestration/adapter_runtime.rs
@@ -914,81 +914,6 @@ fn spawn_terminal_persistence_watcher(ctx: PersistenceWatcherContext) {
             }
         };
 
-        // Persist task result (domain data)
-        if let Some(package_store) = package_store
-            && let Some(AdapterTaskTerminalState::Succeeded(response)) = &snapshot.terminal_state
-            && let Err(error) =
-                persist_adapter_response(package_store, response, manager, task_type, action).await
-        {
-            tracing::error!(
-                manager = ?manager,
-                task_id = task_id.0,
-                task_type = ?task_type,
-                action = ?action,
-                kind = ?error.kind,
-                message = %error.message,
-                "failed to persist adapter response data"
-            );
-        }
-
-        // Persist search results to cache
-        if let Some(search_cache_store) = search_cache_store
-            && let Some(AdapterTaskTerminalState::Succeeded(response)) = &snapshot.terminal_state
-            && let Err(error) =
-                persist_search_response(search_cache_store, response, manager, task_type, action)
-                    .await
-        {
-            tracing::error!(
-                manager = ?manager,
-                task_id = task_id.0,
-                task_type = ?task_type,
-                action = ?action,
-                kind = ?error.kind,
-                message = %error.message,
-                "failed to persist search cache data"
-            );
-        }
-
-        if let Some(detection_store) = detection_store.as_ref()
-            && let Some(AdapterTaskTerminalState::Succeeded(response)) = &snapshot.terminal_state
-            && let Err(error) = persist_manager_uninstall_state_reset(
-                detection_store.clone(),
-                response,
-                manager,
-                task_type,
-                action,
-            )
-            .await
-        {
-            tracing::error!(
-                manager = ?manager,
-                task_id = task_id.0,
-                task_type = ?task_type,
-                action = ?action,
-                kind = ?error.kind,
-                message = %error.message,
-                "failed to persist manager uninstall state reset"
-            );
-        }
-
-        // Persist detection results
-        if let Some(detection_store) = detection_store
-            && let Some(AdapterTaskTerminalState::Succeeded(response)) = &snapshot.terminal_state
-            && let Err(error) =
-                persist_detection_response(detection_store, response, manager, task_type, action)
-                    .await
-        {
-            tracing::error!(
-                manager = ?manager,
-                task_id = task_id.0,
-                task_type = ?task_type,
-                action = ?action,
-                kind = ?error.kind,
-                message = %error.message,
-                "failed to persist detection data"
-            );
-        }
-
         let updated = TaskRecord {
             id: snapshot.runtime.id,
             manager: snapshot.runtime.manager,
@@ -1030,6 +955,85 @@ fn spawn_terminal_persistence_watcher(ctx: PersistenceWatcherContext) {
                 kind = ?error.kind,
                 message = %error.message,
                 "failed to persist terminal task transition"
+            );
+        }
+
+        // Persist task result (domain data) after the task is marked terminal so
+        // long-running snapshot/cache writes do not leave completed work looking stuck.
+        if let Some(package_store) = package_store
+            && let Some(AdapterTaskTerminalState::Succeeded(response)) = &snapshot.terminal_state
+            && let Err(error) =
+                persist_adapter_response(package_store, response, manager, task_type, action).await
+        {
+            tracing::error!(
+                manager = ?manager,
+                task_id = task_id.0,
+                task_type = ?task_type,
+                action = ?action,
+                kind = ?error.kind,
+                message = %error.message,
+                "failed to persist adapter response data"
+            );
+        }
+
+        // Persist search results to cache after the task reaches terminal state. Catalog-sync
+        // payloads can be large enough that keeping the task marked running until cache writes
+        // finish looks like a hung task even though the subprocess has already exited.
+        if let Some(search_cache_store) = search_cache_store
+            && let Some(AdapterTaskTerminalState::Succeeded(response)) = &snapshot.terminal_state
+            && let Err(error) =
+                persist_search_response(search_cache_store, response, manager, task_type, action)
+                    .await
+        {
+            tracing::error!(
+                manager = ?manager,
+                task_id = task_id.0,
+                task_type = ?task_type,
+                action = ?action,
+                kind = ?error.kind,
+                message = %error.message,
+                "failed to persist search cache data"
+            );
+        }
+
+        if let Some(detection_store) = detection_store.as_ref()
+            && let Some(AdapterTaskTerminalState::Succeeded(response)) = &snapshot.terminal_state
+            && let Err(error) = persist_manager_uninstall_state_reset(
+                detection_store.clone(),
+                response,
+                manager,
+                task_type,
+                action,
+            )
+            .await
+        {
+            tracing::error!(
+                manager = ?manager,
+                task_id = task_id.0,
+                task_type = ?task_type,
+                action = ?action,
+                kind = ?error.kind,
+                message = %error.message,
+                "failed to persist manager uninstall state reset"
+            );
+        }
+
+        // Persist detection results after the task is visible as terminal to keep manager tasks
+        // from appearing hung on store updates.
+        if let Some(detection_store) = detection_store
+            && let Some(AdapterTaskTerminalState::Succeeded(response)) = &snapshot.terminal_state
+            && let Err(error) =
+                persist_detection_response(detection_store, response, manager, task_type, action)
+                    .await
+        {
+            tracing::error!(
+                manager = ?manager,
+                task_id = task_id.0,
+                task_type = ?task_type,
+                action = ?action,
+                kind = ?error.kind,
+                message = %error.message,
+                "failed to persist detection data"
             );
         }
 

--- a/core/rust/crates/helm-core/tests/orchestration_adapter_runtime.rs
+++ b/core/rust/crates/helm-core/tests/orchestration_adapter_runtime.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::Mutex;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Condvar, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use helm_core::adapters::{
@@ -15,7 +15,9 @@ use helm_core::models::{
     SearchQuery, TaskId, TaskRecord, TaskStatus, TaskType,
 };
 use helm_core::orchestration::{AdapterRuntime, AdapterTaskTerminalState};
-use helm_core::persistence::{DetectionStore, PackageStore, PersistenceResult, TaskStore};
+use helm_core::persistence::{
+    DetectionStore, PackageStore, PersistenceResult, SearchCacheStore, TaskStore,
+};
 use helm_core::sqlite::SqliteStore;
 
 const TEST_CAPABILITIES: &[Capability] = &[Capability::Refresh, Capability::Search];
@@ -229,6 +231,80 @@ impl TaskStore for RecordingTaskStore {
         })?;
         records.clear();
         Ok(())
+    }
+}
+
+#[derive(Default)]
+struct BlockingSearchState {
+    entered: bool,
+    released: bool,
+}
+
+struct BlockingSearchCacheStore {
+    inner: Arc<SqliteStore>,
+    entered: AtomicBool,
+    state: Mutex<BlockingSearchState>,
+    condvar: Condvar,
+}
+
+impl BlockingSearchCacheStore {
+    fn new(inner: Arc<SqliteStore>) -> Self {
+        Self {
+            inner,
+            entered: AtomicBool::new(false),
+            state: Mutex::new(BlockingSearchState::default()),
+            condvar: Condvar::new(),
+        }
+    }
+
+    fn has_entered(&self) -> bool {
+        self.entered.load(Ordering::SeqCst)
+    }
+
+    fn release(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("blocking search state mutex poisoned");
+        state.released = true;
+        self.condvar.notify_all();
+    }
+}
+
+impl SearchCacheStore for BlockingSearchCacheStore {
+    fn upsert_search_results(
+        &self,
+        results: &[helm_core::models::CachedSearchResult],
+    ) -> PersistenceResult<()> {
+        let mut state = self.state.lock().map_err(|_| CoreError {
+            manager: None,
+            task: None,
+            action: None,
+            kind: CoreErrorKind::Internal,
+            message: "blocking search state mutex poisoned".to_string(),
+        })?;
+        self.entered.store(true, Ordering::SeqCst);
+        state.entered = true;
+        self.condvar.notify_all();
+        while !state.released {
+            state = self.condvar.wait(state).map_err(|_| CoreError {
+                manager: None,
+                task: None,
+                action: None,
+                kind: CoreErrorKind::Internal,
+                message: "blocking search state wait poisoned".to_string(),
+            })?;
+        }
+        drop(state);
+        self.inner.upsert_search_results(results)
+    }
+
+    fn query_local(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> PersistenceResult<Vec<helm_core::models::CachedSearchResult>> {
+        self.inner.query_local(query, limit)
     }
 }
 
@@ -640,6 +716,90 @@ async fn submit_with_task_store_persists_terminal_status_via_atomic_transition()
     let record = persisted.expect("expected completed persisted task record through atomic path");
     assert_eq!(record.id, task_id);
     assert_eq!(record.status, TaskStatus::Completed);
+}
+
+#[tokio::test]
+async fn submit_catalog_sync_marks_task_complete_before_search_cache_persistence_finishes() {
+    let path = test_db_path("orchestration-runtime-catalog-sync-terminal-before-cache");
+    let store = Arc::new(SqliteStore::new(&path));
+    store.migrate_to_latest().unwrap();
+    let search_cache_store = Arc::new(BlockingSearchCacheStore::new(store.clone()));
+    let adapter: Arc<dyn ManagerAdapter> = Arc::new(TestAdapter::new(
+        ManagerId::HomebrewCask,
+        AdapterBehavior::Succeeds(AdapterResponse::SearchResults(vec![
+            helm_core::models::CachedSearchResult {
+                result: helm_core::models::PackageCandidate {
+                    package: PackageRef {
+                        manager: ManagerId::HomebrewCask,
+                        name: "visual-studio-code".to_string(),
+                    },
+                    package_identifier: None,
+                    version: None,
+                    summary: Some("Code editor".to_string()),
+                },
+                source_manager: ManagerId::HomebrewCask,
+                originating_query: String::new(),
+                cached_at: SystemTime::now(),
+            },
+        ])),
+    ));
+    let runtime = AdapterRuntime::with_all_stores(
+        [adapter],
+        store.clone(),
+        store.clone(),
+        search_cache_store.clone(),
+        store.clone(),
+    )
+    .unwrap();
+
+    let task_id = runtime
+        .submit(
+            ManagerId::HomebrewCask,
+            AdapterRequest::Search(SearchRequest {
+                query: SearchQuery {
+                    text: String::new(),
+                    issued_at: SystemTime::now(),
+                },
+            }),
+        )
+        .await
+        .unwrap();
+    let snapshot = runtime
+        .wait_for_terminal(task_id, Some(Duration::from_secs(1)))
+        .await
+        .unwrap();
+    assert_eq!(snapshot.runtime.status, TaskStatus::Completed);
+
+    for _ in 0..100 {
+        if search_cache_store.has_entered() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        search_cache_store.has_entered(),
+        "expected search cache persistence to start"
+    );
+
+    let mut persisted_completed = false;
+    for _ in 0..20 {
+        let records = store.list_recent_tasks(10).unwrap();
+        if records
+            .iter()
+            .any(|record| record.id == task_id && record.status == TaskStatus::Completed)
+        {
+            persisted_completed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    search_cache_store.release();
+
+    assert!(
+        persisted_completed,
+        "catalog sync task should be marked completed before search-cache persistence finishes"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- mark runtime tasks terminal before expensive response/cache persistence so completed work does not look hung
- keep catalog-sync search cache persistence asynchronous relative to terminal task visibility
- add regressions for atomic terminal persistence and slow catalog-sync cache writes

## Validation
- /Users/jasoncavinder/.cargo/bin/cargo fmt --all --manifest-path core/rust/Cargo.toml
- env -u RUSTC_WRAPPER CARGO_HOME=/tmp/helm-cargo-home CARGO_TARGET_DIR=/tmp/helm-target-orch-search RUSTC=/Users/jasoncavinder/.rustup/toolchains/stable-x86_64-apple-darwin/bin/rustc /Users/jasoncavinder/.rustup/toolchains/stable-x86_64-apple-darwin/bin/cargo test --manifest-path core/rust/Cargo.toml -p helm-core --test orchestration_adapter_runtime submit_catalog_sync_marks_task_complete_before_search_cache_persistence_finishes -- --nocapture
- env -u RUSTC_WRAPPER CARGO_HOME=/tmp/helm-cargo-home CARGO_TARGET_DIR=/tmp/helm-target-orch-search RUSTC=/Users/jasoncavinder/.rustup/toolchains/stable-x86_64-apple-darwin/bin/rustc /Users/jasoncavinder/.rustup/toolchains/stable-x86_64-apple-darwin/bin/cargo test --manifest-path core/rust/Cargo.toml -p helm-core --test orchestration_adapter_runtime submit_with_task_store_persists_terminal_status_via_atomic_transition
