### PR TITLE
fix(xpc): reuse service runtime across connections

### DIFF
--- a/apps/macos-ui/HelmService/Sources/HelmServiceDelegate.swift
+++ b/apps/macos-ui/HelmService/Sources/HelmServiceDelegate.swift
@@ -9,6 +9,8 @@ private let logger = Logger(subsystem: "app.jasoncavinder.Helm.HelmService", cat
 private let expectedTeamID = "V73WPJR9M4"
 
 class HelmServiceDelegate: NSObject, NSXPCListenerDelegate {
+    private let sharedService = HelmService()
+
     func listener(_ listener: NSXPCListener, shouldAcceptNewConnection newConnection: NSXPCConnection) -> Bool {
         guard validateConnection(newConnection) else {
             logger.warning("Rejected XPC connection from PID \(newConnection.processIdentifier)")
@@ -16,7 +18,7 @@ class HelmServiceDelegate: NSObject, NSXPCListenerDelegate {
         }
 
         newConnection.exportedInterface = NSXPCInterface(with: HelmServiceProtocol.self)
-        newConnection.exportedObject = HelmService()
+        newConnection.exportedObject = sharedService
         newConnection.resume()
         return true
     }


### PR DESCRIPTION
## Summary
- reuse one HelmService instance per XPC service process instead of constructing a fresh service for every connection
- prevent repeated helm_init calls from resetting the Rust runtime and orphaning active tasks
- stop the follow-on stale task cancellations seen as trigger_guard and inflight_dedupe_check noise after onboarding/reset flows

## Validation
- investigated live task DB showing cancelled tasks from trigger_guard and inflight_dedupe_check after runtime loss
- local full xcodebuild validation was blocked by unrelated host cargo/rust activity during the Rust build script phase
- CI should validate the Swift service change end-to-end
