### PR TITLE
docs: reconcile product and website status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ This ensures the project can be relicensed or dual-licensed in the future.
 1. Open an issue to discuss the change
 2. Ensure the change aligns with project direction
 3. Keep changes focused and minimal
-4. Target the `dev` branch for code changes; `main` for documentation-only changes
+4. Target the `dev` branch for code changes and the `docs` branch for documentation-only changes; `main` receives approved promotions and release-critical fixes
 5. All user-facing text must use localization keys (no hardcoded English strings)
 
 ---
@@ -105,4 +105,3 @@ For questions, ideas, or discussions:
 ## 🙏 Thank You
 
 Your contributions help shape Helm into something great.
-

--- a/core/rust/README.md
+++ b/core/rust/README.md
@@ -8,31 +8,32 @@ This workspace holds the UI-agnostic core for Helm. It contains all business log
 |-------|------|
 | `helm-core` | Domain models, adapter trait, orchestration engine, SQLite persistence, all manager adapters |
 | `helm-ffi` | C ABI FFI boundary for bridging to Swift via XPC service |
+| `helm-cli` | CLI and TUI clients using the shared core/coordinator contracts |
 
-## Implemented Adapters (15)
+## Implemented Managers (28)
 
 | Category | Adapters |
 |----------|----------|
-| Toolchain / Runtime | mise, rustup |
-| System / OS / App Store | Homebrew, softwareupdate, mas |
-| Core Language | npm (global), pip (global), pipx, cargo, cargo-binstall |
-| Extended Language | pnpm (global), yarn (global), RubyGems, Poetry (self/plugins), Bundler |
+| Toolchain / Runtime | mise, asdf, rustup |
+| System / OS | Homebrew formulae and casks, MacPorts, softwareupdate, nix-darwin, Xcode Command Line Tools, Rosetta 2, firmware updates |
+| Language | npm, pnpm, yarn, pip, pipx, Poetry, RubyGems, Bundler, Cargo, cargo-binstall |
+| App / Platform | mas, Sparkle, Setapp, Docker Desktop, podman, colima, Parallels Desktop |
 
 ## Key Subsystems
 
 - **Adapter trait** — Capability-driven request/response contracts per manager
 - **Authority ordering** — Authoritative → Standard → Guarded phased execution
 - **Orchestration engine** — Task queue with per-manager serial execution, cross-manager parallelism, true process cancellation
-- **SQLite persistence** — Versioned schema (v1–v5), parameterized queries, transactional operations
-- **Post-upgrade validation** — After upgrade succeeds, re-checks `list_outdated` to verify the package was actually updated (11 adapters)
+- **SQLite persistence** — Versioned schema (v1–v16), parameterized queries, transactional operations
+- **Post-upgrade validation** — After upgrade succeeds, re-checks `list_outdated` where the manager supports validation
 - **Pinning** — Native pin support + virtual pin fallback, pin-aware upgrade-all
 - **Progressive search** — Local-first with debounced remote search and cache enrichment
 - **Structured tracing** — `#[instrument]` spans on adapter execution entry points
 
 ## Tests
 
-198+ unit and integration tests covering:
-- Adapter parsing fixtures for all 15 managers
+Unit and integration tests covering:
+- Adapter parsing fixtures across implemented managers
 - Orchestration, authority ordering, and cancellation flows
 - Post-upgrade validation scenarios
 - End-to-end integration tests

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -95,6 +95,7 @@ Active milestone:
   - delivered: pre-`v0.17.7` release-gate closure follow-up (on `dev`): runtime queue terminal waits now avoid missed-notify timeout races and emit periodic heartbeat diagnostics while waiting; graceful cancellation now re-checks terminal state before forced abort; request/response orchestration now logs start timestamp, effective timeout (`min(policy_timeout, orchestration_cap)`), retry attempts, terminal status, and cancellation path; Homebrew adapter `clippy::collapsible_if` warnings were removed; process-timeout coverage now verifies timeout termination does not leave child process-group orphans; and rustup orchestration reliability was re-validated with repeated stress runs.
   - delivered: GitHub governance hardening follow-up (on `dev`): per-branch rulesets are now explicit for `main`/`dev`/`docs`/`web` with branch-specific required checks; new `Policy Gate` + `Docs Checks` + `Web Build` workflows enforce branch targeting/scope policy; repository merge settings keep auto-merge/update-branch enabled while delete-branch-on-merge stays off to protect primary branches; blocking ruleset `update` enforcement was removed after protected-ref merge-block diagnostics; CodeQL is now main-focused (push/schedule/manual) to avoid PR gate friction.
   - `v0.17.10` stable release execution status: released on `main` with tag, publish metadata, and verification complete.
+  - delivered post-`v0.17.10` integration hardening (on `dev`): task terminal transitions and request/response persistence now preserve final results deterministically; Homebrew formula and cask work share one execution lease; XPC connections reuse one service runtime; and system-manager helper paths are canonicalized before selection.
 
 Security rollout staging status:
 - Stage 0 (`<=0.16.x`): planning/docs only (active in `0.16.1`)
@@ -938,7 +939,7 @@ Based on the full codebase audit conducted on 2026-02-17 and subsequent beta.3 r
   - Pending: none
 - Redesign integration is functional with layered popover UX + control-center search; accessibility labels and semantic grouping implemented; onboarding walkthrough delivered; UI layer purity cleanup completed
 - Keyboard-only traversal: Tab navigation does not work in macOS SwiftUI (`.focusable()` does not participate in AppKit key view loop); requires NSViewRepresentable bridging approach
-- All walkthrough and redesign localization keys have been rolled out to all 6 locales
+- All walkthrough and redesign localization keys have been rolled out to all 7 locales
 - XPC call timeout enforcement added (30s data fetches, 300s mutations) with exponential backoff reconnection
 - Overflow validation now has both heuristic and on-device executable coverage for Settings, onboarding, navigation, package filters, and manager labels/states
 - Upgrade-all transparency now provides summary counts + top manager breakdown in confirmation flow
@@ -951,7 +952,7 @@ Based on the full codebase audit conducted on 2026-02-17 and subsequent beta.3 r
   - `nix_darwin` is currently detection/refresh-only in Helm. Declarative nix-darwin package/config management is not implemented, and Helm intentionally does not route `nix-env` package mutation flows through the `nix_darwin` manager because that would misrepresent system configuration state.
 - Self-update is intentionally limited to eligible direct Developer ID installs; package-manager-managed installs remain blocked by policy.
 - Diagnostics UI is available in the Inspector (`diagnostics`/`stderr`/`stdout`), including the v0.17 task-log viewer (`logs` tab with level/status filters and pagination).
-- CLI companion implementation is in progress on `dev`: draft spec published at `docs/architecture/HELM_CLI_SPEC.ms` and Rust `helm` binary exists (`core/rust/crates/helm-cli`) with read-only snapshot commands plus runtime-backed orchestration commands (`refresh`, `managers detect`) and `--wait`/`--detach` flag parsing.
+- CLI companion delivery is complete for the current scope on `dev`: the Rust `helm` binary (`core/rust/crates/helm-cli`) provides read-only snapshot commands, runtime-backed orchestration, and `--wait`/`--detach` controls. Its command and transport contracts are maintained in source and `docs/architecture/CLI_COORDINATOR_TRANSPORT_INVARIANTS.md`.
 - CLI read-only contract hardening is in place for the documented schema-safety surface: `status`, `managers list`, `packages list`, `updates summary`, and `tasks show` JSON payloads now use a stable envelope (`schema`, `schema_version`, `generated_at`, `data`), and `tasks show` is implemented as a read-only command.
 - CLI manager-selection controls now include `managers executables list|set` and `managers install-methods list|set` with persisted preferences (`selected_executable_path`, `selected_install_method`) and explicit reset modes (`path-default` / `default`).
 - CLI package mutation coverage now includes `packages install|uninstall|upgrade|pin|unpin` with explicit manager targeting (`--manager` or `name@manager`) and ambiguity-safe `packages show`.
@@ -988,7 +989,7 @@ Based on the full codebase audit conducted on 2026-02-17 and subsequent beta.3 r
   - GUI per-package Homebrew keg cleanup override UI is not yet mirrored in CLI command surface.
   - GUI manager-scoped `Upgrade All` action has no direct manager-scoped CLI bulk-run equivalent.
   - GUI onboarding/walkthrough/support-entry workflows remain GUI-only by design.
-- TUI remains pending by design.
+- TUI baseline delivery is complete; no additional TUI parity scope is currently planned.
 
 ---
 

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -303,10 +303,10 @@ Channel rules:
 
 ---
 
-## Decision 022 — Sparkle Delta Policy for 0.16.x
+## Decision 022 — Sparkle Full-Installer Policy
 
 **Decision:**
-For `0.16.x`, direct-channel Sparkle updates ship full signed DMG payloads only. Delta updates are explicitly disabled until a later milestone.
+Direct-channel Sparkle updates ship full signed DMG payloads only. Delta updates are explicitly disabled until a later milestone.
 
 Policy guardrails:
 

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -196,20 +196,18 @@ All process execution uses:
 Guarded actions (notably macOS OS updates) require explicit confirmation.
 
 Contract shape:
-- UI requests a guarded operation
-- Service/Core returns a “confirmation required” response including:
-  - reason code
-  - human-readable message key (localized in UI)
-  - confirmation token (short-lived)
-- UI must resubmit action with the confirmation token to proceed
+- UI presents the upgrade plan and collects explicit user approval for OS updates.
+- UI submits the upgrade request with `allow_os_updates=true` only after approval.
+- Service/Core excludes OS updates when that flag is false and rejects them when Safe Mode is enabled.
+- The request/response boundary returns structured errors and localization keys for blocked actions.
 
 **Invariant:** Silent OS updates are prohibited.
 
 ### 6.3 Safe Mode (Policy)
 
 Safe mode is an app policy flag that:
-- blocks guarded upgrade execution
-- requires explicit disabling before guarded operations can proceed
+- blocks `softwareupdate` upgrade execution
+- requires explicit disabling before macOS OS updates can proceed
 
 ---
 
@@ -270,69 +268,40 @@ When a contract changes:
 
 ## 10. Concrete Interface Inventories
 
-### 10.1 XPC Protocol Methods (32 methods)
+### 10.1 XPC Protocol Methods (65 methods)
 
 Source: `apps/macos-ui/Helm/Shared/HelmServiceProtocol.swift`
 
-All methods use asynchronous `withReply` closures. Connection security is enforced via code-signing team ID validation at `NSXPCListener` acceptance.
+All methods use asynchronous `withReply` closures. The protocol covers package and pin operations, Rustup toolchain controls, task lifecycle/output/timeout handling, discovery and search, manager lifecycle/provenance/repair controls, onboarding and settings, upgrade planning, and local-data reset. Connection security is enforced via code-signing team ID validation at `NSXPCListener` acceptance.
 
-| Method | Category | Reply Type |
-|--------|----------|------------|
-| `listInstalledPackages` | Package queries | `String?` (JSON) |
-| `listOutdatedPackages` | Package queries | `String?` (JSON) |
-| `listTasks` | Task management | `String?` (JSON) |
-| `triggerRefresh` | Task management | `Bool` |
-| `triggerDetection` | Task management | `Bool` |
-| `cancelTask(taskId:)` | Task management | `Bool` |
-| `searchLocal(query:)` | Search | `String?` (JSON) |
-| `triggerRemoteSearch(query:)` | Search | `Int64` (task ID) |
-| `listPins` | Pinning | `String?` (JSON) |
-| `pinPackage(managerId:packageName:version:)` | Pinning | `Bool` |
-| `unpinPackage(managerId:packageName:)` | Pinning | `Bool` |
-| `listManagerStatus` | Manager control | `String?` (JSON) |
-| `setManagerEnabled(managerId:enabled:)` | Manager control | `Bool` |
-| `setManagerSelectedExecutablePath(managerId:selectedPath:)` | Manager control | `Bool` |
-| `setManagerInstallMethod(managerId:installMethod:)` | Manager control | `Bool` |
-| `installManager(managerId:)` | Manager control | `Int64` (task ID) |
-| `updateManager(managerId:)` | Manager control | `Int64` (task ID) |
-| `uninstallManager(managerId:)` | Manager control | `Int64` (task ID) |
-| `previewManagerUninstall(managerId:allowUnknownProvenance:)` | Manager control | `String?` (JSON) |
-| `uninstallManagerWithOptions(managerId:allowUnknownProvenance:)` | Manager control | `Int64` (task ID) |
-| `getSafeMode` | Settings | `Bool` |
-| `setSafeMode(enabled:)` | Settings | `Bool` |
-| `getHomebrewKegAutoCleanup` | Settings | `Bool` |
-| `setHomebrewKegAutoCleanup(enabled:)` | Settings | `Bool` |
-| `listPackageKegPolicies` | Keg policies | `String?` (JSON) |
-| `setPackageKegPolicy(managerId:packageName:policyMode:)` | Keg policies | `Bool` |
-| `previewUpgradePlan(includePinned:allowOsUpdates:)` | Upgrade | `String?` (JSON) |
-| `upgradeAll(includePinned:allowOsUpdates:)` | Upgrade | `Bool` |
-| `upgradePackage(managerId:packageName:)` | Upgrade | `Int64` (task ID) |
-| `previewPackageUninstall(managerId:packageName:)` | Package mutation | `String?` (JSON) |
-| `resetDatabase` | Database | `Bool` |
-| `takeLastErrorKey` | Error | `String?` |
+The Swift protocol declaration is the canonical method-by-method inventory; it is intentionally not duplicated here to prevent contract drift.
 
 Client-side timeout enforcement: 30s for data fetch calls, 300s for mutation calls. Exponential backoff reconnection on invalidation/interruption (2s base, doubling to 60s cap).
 
-### 10.2 FFI Exports (34 functions)
+### 10.2 FFI Exports (27 functions)
 
 Source: `core/rust/crates/helm-ffi/src/lib.rs`
 
-See the module-level documentation in `lib.rs` for the full export table with categories. All data exchange uses JSON-encoded UTF-8 `*mut c_char` strings, freed via `helm_free_string`. The FFI layer has no explicit shutdown; runtime state spans the XPC service process lifetime.
+See the module-level documentation in `lib.rs` for the full export table with categories. String payloads use JSON-encoded UTF-8 `*mut c_char` values, freed via `helm_free_string`; control operations use their declared scalar return types. The FFI layer has no explicit shutdown; runtime state spans the XPC service process lifetime.
 
-### 10.3 SQLite Schema Summary (10 tables, 10 migrations)
+### 10.3 SQLite Schema Summary (14 application tables, 16 migrations)
 
 Source: `core/rust/crates/helm-core/src/sqlite/migrations.rs`
 
 | Table | Migration | Primary Key | Purpose |
 |-------|-----------|-------------|---------|
-| `installed_packages` | v1 | `(manager_id, package_name)` | Cached installed package state |
-| `outdated_packages` | v1 (+v3 adds `restart_required`) | `(manager_id, package_name)` | Cached outdated package state |
-| `pin_records` | v1 | `(manager_id, package_name)` | Native and virtual pin records |
+| `installed_packages` | v1 | `(manager_id, package_name)` | Legacy cached installed package state |
+| `outdated_packages` | v1 (+v3, v14, v16) | `(manager_id, package_name)` | Cached outdated package state |
+| `installed_package_versions` | v13 (+v16 identifiers) | `(manager_id, package_name, installed_version)` | Version-scoped installed package state |
+| `pin_records` | v1 (+v15 version scope) | version-scoped manager/package identity | Native and virtual pin records |
 | `search_cache` | v1 | none (indexed on `originating_query` + `cached_at_unix`) | Remote search result cache |
 | `task_records` | v1 | `task_id INTEGER` | Task execution history |
+| `task_log_records` | v6 | `log_id INTEGER` | Persisted structured task logs |
 | `manager_detection` | v2 | `manager_id` | Manager install detection state |
-| `manager_preferences` | v2 (+v7 adds `selected_executable_path` and `selected_install_method`) | `manager_id` | Per-manager enablement and manager-selection preferences |
+| `manager_preferences` | v2 (+v7/v8) | `manager_id` | Per-manager enablement, selection, and timeout preferences |
 | `manager_install_instances` | v9 (+v10 adds `decision_margin`) | `(manager_id, instance_id)` | Per-manager install-instance identity, provenance confidence/margin, explainability, and strategy metadata |
+| `manager_multi_instance_ack` | v11 | `manager_id` | Acknowledgement state for multi-instance attention |
+| `package_manager_preferences` | v12 | `package_name` | Preferred manager for a package family |
 | `app_settings` | v4 | `key` | App-level key-value settings |
 | `package_keg_policies` | v5 | `(manager_id, package_name)` | Homebrew keg cleanup policy overrides |
 
@@ -340,8 +309,8 @@ Migrations are applied idempotently via `execute_batch_tolerant()` (see `sqlite/
 
 ### 10.4 Task Log Payload
 
-Task terminal output is not currently persisted as a structured payload. Task outcomes are stored via `task_records` (status transitions only). Adapter responses are persisted to domain tables (installed/outdated/search/detection) but raw terminal/process output is not retained. This is a known gap tracked for the Diagnostics milestone (0.17.x).
+Structured task logs persist in `task_log_records`; task lifecycle state persists in `task_records`. Raw command, stdout, and stderr buffers are retained in bounded runtime memory for live diagnostics rather than persisted indefinitely. Adapter responses persist to their domain tables (installed, outdated, search, and detection).
 
-### 10.5 Confirmation Token Model
+### 10.5 Guarded-Action Confirmation Model
 
-Confirmation tokens are **not used** in the current implementation. Security is enforced at the XPC connection acceptance level via code-signing team ID verification (`SecCode` + `SecRequirement`). Safe mode policy enforcement blocks guarded operations (softwareupdate upgrades) at the Rust core level before task submission. The `upgrade_all` FFI function accepts boolean parameters (`include_pinned`, `allow_os_updates`) rather than a cryptographic token. The guardrail contract described in Section 6.2 is satisfied by this policy model rather than a token-based exchange.
+Confirmation tokens are **not used**. Security is enforced at XPC connection acceptance through code-signing team ID verification (`SecCode` + `SecRequirement`). The upgrade boundary accepts boolean `include_pinned` and `allow_os_updates` parameters; `allow_os_updates` records explicit approval, while Safe Mode blocks `softwareupdate` upgrades in core before task submission.

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -319,8 +319,8 @@ Current checkpoint:
     - `Docs Checks` and `Web Build` workflows now gate `docs` and `web` branches respectively
     - blocking ruleset `update` enforcement was removed after protected-ref merge-block diagnostics so normal PR merges can complete
     - CodeQL now runs on `main` push + schedule/manual (non-PR gate) to reduce merge friction while retaining scanning coverage
-  - CLI kickoff delivered on `dev`:
-    - draft CLI spec published at `docs/architecture/HELM_CLI_SPEC.ms` with command surface, output contract, and shared-coordinator target architecture
+  - CLI delivery completed on `dev`:
+    - command surface, output contract, and shared-coordinator behavior are implemented in `core/rust/crates/helm-cli` and documented by `docs/architecture/CLI_COORDINATOR_TRANSPORT_INVARIANTS.md`
     - new Rust CLI crate scaffolded at `core/rust/crates/helm-cli` (binary: `helm`) with read-only commands (`status`, `ls`/`packages`, `updates`, `tasks`, `managers`, `settings`) and `--json` output
     - runtime-backed command slice added for `refresh` and `managers detect` using Helm core orchestration with process-adapter bootstrap + manager executable override sync
     - `--wait` / `--detach` global flags are now parsed; shared CLI coordinator routing now supports true detach for coordinator-backed single-task mutations (`packages install|uninstall|upgrade`, `managers detect <id>`, `managers install|update|uninstall`)
@@ -374,7 +374,7 @@ Next release targets:
 - `v0.18.x` — Local security groundwork (internal-only)
 - `v0.19.x` — Stability & Pre-1.0 hardening
 
-## v0.17.x Delivery Tracker (Stable `0.17.3` Complete)
+## Historical v0.17.x Delivery Tracker (0.17.3 Checkpoint)
 
 - [x] `feat/v0.17-log-foundation` — task log event model, SQLite persistence migration, FFI/XPC retrieval surface.
 - [x] `feat/v0.17-task-log-viewer` — per-task log viewer UI with filters and pagination.
@@ -1206,41 +1206,42 @@ Completed in `v0.13.0-beta.6`:
 
 ---
 
-## Post-0.14.x Priorities
+## Historical Post-0.14.x Priorities
 
-### Priority 6 — Self Update
+This archived planning snapshot records delivery sequencing through the 0.17.x line. Current priorities are defined at the top of this document.
 
-Implement:
+### Priority 6 — Self Update (Delivered)
+
+Delivered:
 
 - Signed updates
 - Integrity verification
 - Update recovery
 
-### Priority 7 — Diagnostics
+### Priority 7 — Diagnostics (Delivered)
 
-Implement:
+Delivered:
 
 - Task log viewer
 - Error export
 - Manager diagnostics panel
 
-### Priority 8 — Hardening (Remaining)
+### Priority 8 — Hardening (Continues in Current Priorities)
 
-Implement:
+Tracked:
 
 - Stress test orchestration
 - Cancellation reliability under load
 - Memory audit
 - FFI stability under extended runtime
 
-### Priority 9 — CLI Companion (New Goal)
+### Priority 9 — CLI Companion (Delivered)
 
-Implement:
+Delivered:
 
-- Approve and iterate CLI specification in `docs/architecture/HELM_CLI_SPEC.ms`
-- Keep GUI + CLI on one shared coordinator/runtime path (single task authority)
-- Scaffold `helm` binary with read-only command surface and stable `--json` output contracts
-- Add mutating command/task lifecycle coverage to match GUI capabilities incrementally
+- Shared GUI and CLI coordinator/runtime path (single task authority)
+- `helm` binary with read-only and mutating command surfaces plus stable `--json` output contracts
+- Task lifecycle coverage aligned with GUI capabilities for the current scope
 
 ---
 

--- a/docs/PROJECT_BRIEF.md
+++ b/docs/PROJECT_BRIEF.md
@@ -312,7 +312,7 @@ Helm must support self-updating via a signed update mechanism.
 Requirements:
 - Code-signed updates
 - Version integrity verification
-- Delta updates preferred
+- Full signed DMG updates are the current direct-channel policy; delta payloads are deferred
 - No shell-based update mechanisms
 - Manual approval required (auto-update optional)
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -54,40 +54,10 @@ This checklist is required before creating a release tag on `main`.
   - `CLI Update Metadata Drift Guard`
 - [ ] Review `TMP_RELEASE_FRICTION`; promote recurring friction items into durable docs (`docs/DECISIONS.md`, `docs/operations/CLI_RELEASE_AND_CI.md`) and keep temporary notes uncommitted.
 
-## v0.17.10 (Stable Patch Release Gate)
+## v0.17.10 (Stable Patch Release Gate, Completed)
 
-### Scope and Documentation
-- [x] `CHANGELOG.md` includes finalized `0.17.10` patch notes for final stable-line hardening and manager discovery/repair follow-through.
-- [x] `docs/CURRENT_STATE.md` and `docs/NEXT_STEPS.md` reflect `v0.17.10` as the current stable release on `main` and `0.18.x` planning on `dev`.
-- [x] Website changelog and current-version surfaces reflect `v0.17.10`.
-- [x] README current stable version markers reflect `v0.17.10`.
-- [x] Canonical release-line contract targets `v0.17.10` on the promotion branch.
-- [x] Internal prep branch version artifacts reflect `0.17.10` for workspace/app build outputs.
-- [x] Canonical release-line contract check passes: `scripts/release/check_release_line_copy.sh`.
-
-### Versioning
-- [x] Workspace version bumped to `0.17.10` in `core/rust/Cargo.toml`.
-- [x] Rust lockfile local package versions aligned to `0.17.10` in `core/rust/Cargo.lock`.
-- [x] Generated app version artifacts aligned to `0.17.10` (`apps/macos-ui/Generated/HelmVersion.swift`, `apps/macos-ui/Generated/HelmVersion.xcconfig`).
-
-### Validation
-- [x] Rust tests pass (`cargo test -p helm-core -p helm-ffi --manifest-path core/rust/Cargo.toml`).
-- [x] `HelmTests` pass (`xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' test`).
-- [x] Locale checks pass (`apps/macos-ui/scripts/check_locale_integrity.sh` and `apps/macos-ui/scripts/check_locale_lengths.sh`).
-- [x] Third-party license audit commands complete without runtime-license scope regressions (`cargo metadata`, `cargo tree`, website lockfile license scan).
-- [x] Sparkle feed publication + direct-channel update smoke validation complete against the stable appcast entry.
-
-### Branch and Tag
-- [x] Release-prep PR merged to `dev`.
-- [ ] `dev` merged into `main` for stable cut.
-- [ ] If release-critical docs updates were developed on `docs`, merge `docs` into `main`.
-- [ ] If release-critical website updates were developed on `web`, merge `web` into `main`.
-- [ ] Create annotated stable tag from `main`: `git tag -a v0.17.10 -m "Helm v0.17.10"`.
-- [ ] Push stable tag: `git push origin v0.17.10`.
-- [ ] Publish GitHub release for `v0.17.10` (mark as latest, non-prerelease).
-- [ ] Confirm release-generated publish PR (`chore/publish-updates-v0.17.10`) merged to `main`.
-- [ ] Confirm release-generated CLI metadata publish PR (`chore/publish-cli-updates-v0.17.10-stable`) merged to `main`.
-- [ ] Confirm `Release Publish Verify`, `Appcast Drift Guard`, and `CLI Update Metadata Drift Guard` are green after publication.
+- Published on `main` on 2026-03-11 with tag, release metadata, and post-publication verification complete.
+- Historical execution details remain preserved in git history, published release metadata, and the `v0.17.10` changelog entry.
 
 ## v0.17.9 (Stable Patch Release Gate, Completed)
 

--- a/docs/architecture/HELM_TUI_IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/HELM_TUI_IMPLEMENTATION_PLAN.md
@@ -416,15 +416,15 @@ Acceptance:
 
 ## 12. Delivery Tracking and Documentation Updates
 
-When each phase lands, update:
+This plan is a historical delivery record. The TUI implementation is delivered; when its contract changes, update:
 
 - `docs/CURRENT_STATE.md` (implementation reality)
 - `docs/NEXT_STEPS.md` (priority and completion status)
-- `docs/architecture/HELM_CLI_SPEC.ms` (contract updates if behavior changes)
+- `docs/architecture/CLI_COORDINATOR_TRANSPORT_INVARIANTS.md` (transport-contract updates if behavior changes)
 
 ---
 
-## 13. Immediate Next Slice (Execution Order)
+## 13. Completed Delivery Sequence (Historical)
 
 1. Add dependencies (`ratatui`, `crossterm`) and create TUI module scaffold.
 2. Implement no-arg TTY routing to `tui::run()`.

--- a/service/macos-service/README.md
+++ b/service/macos-service/README.md
@@ -8,7 +8,7 @@ apps/macos-ui/HelmService/
 
 The XPC service hosts the Rust FFI layer (`helm-ffi`) in a separate unsandboxed process, providing:
 
-- 25 XPC protocol methods (package queries, task management, manager operations, settings, pin management)
+- XPC protocol methods for package queries and mutations, task management, manager operations, settings, pin management, diagnostics, and onboarding
 - Code-signing validation on all connections (team ID verification via SecCode)
 - Graceful reconnection with exponential backoff (2s base, doubling to 60s cap)
 - Timeout enforcement on all calls (30s data fetches, 300s mutations)

--- a/web/src/content/docs/blog/2026-02-22-v0-17-0-release-readiness.mdx
+++ b/web/src/content/docs/blog/2026-02-22-v0-17-0-release-readiness.mdx
@@ -1,14 +1,14 @@
 ---
-title: "v0.17.x Stable: Current Status at v0.17.2"
-description: "v0.17.0 shipped stable and v0.17.2 is now the current patch release on main."
-summary: "A short recap of what shipped in 0.17.x and where Helm is headed next."
+title: "v0.17.x Stable: Status at v0.17.2"
+description: "As of February 22, 2026, v0.17.0 had shipped stable and v0.17.2 was the current patch release on main."
+summary: "A historical recap of what had shipped in 0.17.x and the next planned work."
 publishDate: 2026-02-22
 author: Helm Team
 sidebar:
-  label: "v0.17.2 status"
+  label: "v0.17.2 historical status"
 ---
 
-Helm `v0.17.x` has completed release-candidate hardening and shipped stable. The latest release on `main` is `v0.17.2`.
+As of February 22, 2026, Helm `v0.17.x` had completed release-candidate hardening and shipped stable. The latest release on `main` was `v0.17.2`.
 
 ## What shipped in 0.17.x
 
@@ -22,10 +22,10 @@ Helm `v0.17.x` has completed release-candidate hardening and shipped stable. The
 
 - `v0.17.0`: stable cut from the full RC lineage (`rc.1` through `rc.5`).
 - `v0.17.1`: stable patch correcting artifact-release lineage after the failed `v0.17.0` build attempt.
-- `v0.17.2`: current stable patch with manager-selection execution routing, onboarding fixes, diagnostics UX improvements, and release-flow guardrail follow-up.
+- `v0.17.2`: the then-current stable patch with manager-selection execution routing, onboarding fixes, diagnostics UX improvements, and release-flow guardrail follow-up.
 
 ## What’s next
 
-Current planning focus is `0.18.x` local security groundwork while monitoring post-release feedback from `v0.17.2`.
+The planning focus at that time was `0.18.x` local security groundwork while monitoring post-release feedback from `v0.17.2`.
 
 If you hit reproducible issues, please file details in GitHub with environment, expected behavior, and observed behavior.

--- a/web/src/content/docs/blog/index.mdx
+++ b/web/src/content/docs/blog/index.mdx
@@ -15,8 +15,7 @@ hero:
       icon: document
       variant: secondary
 sidebar:
-  label: Blog
-  order: 50
+  hidden: true
 ---
 
 import BlogPostList from '../../../components/blog/BlogPostList.astro';

--- a/web/src/content/docs/guides/faq.md
+++ b/web/src/content/docs/guides/faq.md
@@ -73,7 +73,7 @@ Within each phase, managers refresh in parallel. A failure in one manager does n
 
 ### What is Safe Mode?
 
-Safe Mode prevents guarded managers from executing upgrades during "Upgrade All" operations. When enabled, OS-level updates require explicit confirmation. You can toggle Safe Mode in Settings.
+Safe Mode blocks macOS Software Update upgrades during "Upgrade All" operations. Disable it and explicitly approve OS updates to include them. You can toggle Safe Mode in Settings.
 
 ### How does search work?
 

--- a/web/src/content/docs/guides/usage.md
+++ b/web/src/content/docs/guides/usage.md
@@ -57,7 +57,7 @@ Within each phase, managers refresh in parallel. If one manager fails, the other
 ## Pinning and Safe Mode
 
 - **Pinning** — pin individual packages to prevent them from being included in bulk upgrades. Pinned packages still appear in the updates list but are skipped during Upgrade All.
-- **Safe mode** — guarded managers (Homebrew, softwareupdate) require explicit confirmation before executing upgrades, and OS updates that require a restart show a dedicated warning.
+- **Safe mode** — blocks macOS Software Update upgrades during Upgrade All. Disable it and explicitly approve OS updates to include them; restart-required updates show a dedicated warning.
 
 ## Search
 

--- a/web/src/content/docs/index.mdx
+++ b/web/src/content/docs/index.mdx
@@ -88,8 +88,8 @@ import statusMenuShotDark from '../../assets/tour/status-menu-dark.png';
 
   <section id="audiences" class="landing-section">
     <div class="section-head">
-      <p class="section-kicker">Editions</p>
-      <h2>Built for individual developers and enterprise platform teams.</h2>
+      <p class="section-kicker">Planned Editions</p>
+      <h2>Built today for individual developers, with enterprise workflows planned for the future.</h2>
     </div>
     <div class="split-grid">
       <article class="panel edition-card">
@@ -99,9 +99,9 @@ import statusMenuShotDark from '../../assets/tour/status-menu-dark.png';
         <LinkButton href="/guides/usage/" icon="right-arrow" variant="minimal">Usage guide</LinkButton>
       </article>
       <article class="panel edition-card">
-        <p class="edition-label">Helm Business</p>
-        <h3>Governance workflows for organizations</h3>
-        <p>Policy-oriented, auditable operations for managed macOS development environments.</p>
+        <p class="edition-label">Helm Business (Planned)</p>
+        <h3>Future governance workflows for organizations</h3>
+        <p>Planned policy-oriented, auditable operations for managed macOS development environments.</p>
         <LinkButton href="/product-overview/" icon="right-arrow" variant="minimal">Product overview</LinkButton>
       </article>
     </div>
@@ -142,16 +142,16 @@ import statusMenuShotDark from '../../assets/tour/status-menu-dark.png';
 
   <section id="pro" class="landing-section">
     <div class="section-head">
-      <p class="section-kicker">Helm Pro</p>
-      <h2>Advanced operational intelligence for high-control environments.</h2>
+      <p class="section-kicker">Helm Pro (Planned)</p>
+      <h2>Future operational intelligence for high-control environments.</h2>
     </div>
     <div class="panel pro-panel">
-      <p class="pro-badge">Pro</p>
+      <p class="pro-badge">Planned</p>
       <ul>
-        <li>CVE awareness</li>
-        <li>Priority upgrade recommendations</li>
-        <li>Audit-ready update history</li>
-        <li>Proactive risk insights</li>
+        <li>Planned CVE awareness</li>
+        <li>Planned priority upgrade recommendations</li>
+        <li>Planned audit-ready update history</li>
+        <li>Planned proactive risk insights</li>
       </ul>
       <LinkButton href="/licensing/" icon="right-arrow" variant="secondary">Edition and licensing details</LinkButton>
     </div>

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -42,7 +42,7 @@ Key features:
 - **Post-upgrade validation** — verify package state after upgrades complete
 - **Background tasks** — real-time task tracking with per-manager serial execution
 - **Onboarding walkthrough** — guided first-launch experience with spotlight highlights across popover and control center
-- **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, and `ja` with locale override in Settings
+- **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, `ja`, and `hu` with locale override in Settings
 - **Upgrade transparency** — dedicated upgrade preview surface with scoped execution and failure-attribution visibility
 
 > **Current Track:** `v0.17.10` is the latest stable release on `main`; `0.18.x` planning is in progress. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).


### PR DESCRIPTION
## Summary

- Reconcile documentation with current interface, persistence, release, CLI, and updater behavior.
- Correct website Safe Mode, locale, historical-release, and planned-product messaging.
- Archive completed release and planning snapshots while retaining traceability.

## Validation

- `ops/codex/skills/docs-sync/scripts/docs-sync-check.sh`
- `npm run check:content-ids`
- `npm run build`
