### PR TITLE
fix(release): serialize DMG Rust test gate

### DIFF
--- a/.github/workflows/release-macos-dmg.yml
+++ b/.github/workflows/release-macos-dmg.yml
@@ -146,7 +146,7 @@ jobs:
         run: |
           set -euo pipefail
           cd core/rust
-          cargo test --workspace
+          cargo test --workspace -- --test-threads=1
 
       - name: Run Swift tests before release build
         if: ${{ env.VERIFY_ONLY != 'true' }}


### PR DESCRIPTION
## Summary

- serialize Rust test execution in the macOS DMG release gate
- prevent unrelated concurrent timing tests from causing false release failures

## Validation

- `cargo test --workspace -- --test-threads=1`
- Ruby YAML syntax validation for `.github/workflows/release-macos-dmg.yml`
