### PR TITLE
chore(release): publish Sparkle appcast for v0.17.11

### DIFF
--- a/web/public/updates/appcast.xml
+++ b/web/public/updates/appcast.xml
@@ -6,16 +6,16 @@
     <description>Helm direct-channel updates</description>
     <language>en</language>
     <item>
-      <title>Helm 0.17.10</title>
-      <pubDate>Thu, 12 Mar 2026 07:53:01 +0000</pubDate>
-      <sparkle:releaseNotesLink>https://helmapp.dev/updates/release-notes/v0.17.10.html</sparkle:releaseNotesLink>
+      <title>Helm 0.17.11</title>
+      <pubDate>Tue, 28 Jul 2026 21:25:25 +0000</pubDate>
+      <sparkle:releaseNotesLink>https://helmapp.dev/updates/release-notes/v0.17.11.html</sparkle:releaseNotesLink>
       <enclosure
-        url="https://github.com/jasoncavinder/Helm/releases/download/v0.17.10/Helm-v0.17.10-macos-universal.dmg"
-        sparkle:version="17010900"
-        sparkle:shortVersionString="0.17.10"
-        sparkle:edSignature="2Kg+yWbzJAsS7L5boMrXl2J42OVbzYRpJ5hQJ7lO1ZCrretYi+qc5x7Ctol4MQRZ/7vSL5Y3ywURc4LIaSfnBw=="
+        url="https://github.com/jasoncavinder/Helm/releases/download/v0.17.11/Helm-v0.17.11-macos-universal.dmg"
+        sparkle:version="17011900"
+        sparkle:shortVersionString="0.17.11"
+        sparkle:edSignature="lRkFnu+VeGuIKyGPJUPj30+U2AUH8MOhGcsNIYS5ONXLruLxcgAlAgzlpIvOD8PUAMV+ZFRLXsaMZRsYc3fGCA=="
          sparkle:minimumSystemVersion="11.0"
-        length="29673519"
+        length="29965963"
         type="application/octet-stream"/>
     </item>
   </channel>

--- a/web/public/updates/release-notes/v0.17.11.html
+++ b/web/public/updates/release-notes/v0.17.11.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Helm 0.17.11 Release Notes</title>
+  <link rel="canonical" href="https://helmapp.dev/updates/release-notes/v0.17.11.html">
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif;
+      line-height: 1.55;
+      background: #f7f8fa;
+      color: #111827;
+    }
+    main {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 24px;
+    }
+    article {
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      padding: 24px;
+    }
+    h1 {
+      margin: 0 0 4px;
+      font-size: 1.6rem;
+      line-height: 1.3;
+    }
+    h2 {
+      margin: 24px 0 8px;
+      font-size: 1.1rem;
+    }
+    p, ul {
+      margin: 8px 0;
+    }
+    ul {
+      padding-left: 20px;
+    }
+    .meta {
+      color: #4b5563;
+      font-size: 0.95rem;
+      margin: 0 0 12px;
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      background: #f3f4f6;
+      border-radius: 6px;
+      padding: 0.1rem 0.35rem;
+      font-size: 0.92em;
+    }
+    footer {
+      margin-top: 16px;
+      color: #6b7280;
+      font-size: 0.9rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      body {
+        background: #0b1220;
+        color: #e5e7eb;
+      }
+      article {
+        background: #0f172a;
+        border-color: #1f2937;
+      }
+      .meta {
+        color: #9ca3af;
+      }
+      code {
+        background: #111827;
+      }
+      footer {
+        color: #9ca3af;
+      }
+      a {
+        color: #93c5fd;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <article>
+      <h1>Helm 0.17.11 Release Notes</h1>
+      <p class="meta">Release date: July 28, 2026</p>
+    <p>Patch <code>0.17.11</code> ships manager lifecycle, release-process, and execution-safety hardening.</p>
+    <h2>Added</h2>
+    <ul>
+      <li>Manager install-instance provenance now records ownership confidence, competing evidence, and the active instance across core, CLI, service, and GUI surfaces.</li>
+      <li>Manager and package uninstall flows now provide provenance-aware blast-radius previews before mutating the system.</li>
+    </ul>
+    <h2>Changed</h2>
+    <ul>
+      <li>Manager install, update, and uninstall planning now shares deterministic lifecycle routing across the CLI, FFI, and GUI.</li>
+      <li>Release automation now validates existing releases before auxiliary builds, produces deterministic provenance manifests, and verifies publication metadata convergence.</li>
+    </ul>
+    <h2>Fixed</h2>
+    <ul>
+      <li>Cancellation now terminates registered processes after the grace period, including callers waiting on terminal state.</li>
+      <li>MacPorts self-uninstall cleanup rejects unsafe paths, and XPC access now accepts only the Helm application caller.</li>
+      <li>Dependency upgrades resolve known Rust and web-package vulnerabilities while retaining CI compatibility.</li>
+    </ul>
+    <p class="meta">Need full context? <a href="https://github.com/jasoncavinder/Helm/releases/tag/v0.17.11" rel="noopener noreferrer">View this release on GitHub</a>.</p>
+    </article>
+    <footer>Generated from <code>CHANGELOG.md</code>.</footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- publish the generated Sparkle appcast for the notarized `v0.17.11` DMG
- publish the matching hosted release-notes page

## Validation

- generated appcast and release-notes SHA-256 values match the release workflow artifacts
- `apps/macos-ui/scripts/verify_sparkle_appcast_policy.sh web/public/updates/appcast.xml`
- `npm run check:content-ids`
- `npm run build`
