### PR TITLE
fix(release): harden publication flow

### DIFF
--- a/.github/workflows/release-all-variants.yml
+++ b/.github/workflows/release-all-variants.yml
@@ -64,7 +64,7 @@ jobs:
       TAG_NAME: ${{ inputs.tag }}
     steps:
       - name: Checkout tag
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
         with:
           ref: ${{ env.TAG_NAME }}
 
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload ${{ matrix.variant }} artifacts to workflow run
         if: ${{ matrix.variant == 'business' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: ${{ matrix.artifact_prefix }}-${{ env.TAG_NAME }}
           path: |
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload ${{ matrix.variant }} artifact to workflow run
         if: ${{ matrix.variant != 'business' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: ${{ matrix.artifact_prefix }}-${{ env.TAG_NAME }}
           path: ${{ steps.build_variant.outputs.zip_path }}

--- a/.github/workflows/release-cli-direct.yml
+++ b/.github/workflows/release-cli-direct.yml
@@ -39,6 +39,7 @@ jobs:
       EVENT_NAME: ${{ github.event_name }}
       EVENT_RELEASE_PRERELEASE: ${{ github.event.release.prerelease || '' }}
       VERIFY_ONLY: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.verify_only == 'true' && 'true' || 'false') || 'false' }}
+      WORKFLOW_SHA: ${{ github.workflow_sha }}
       LANG: en_US.UTF-8
       LC_ALL: en_US.UTF-8
 
@@ -89,6 +90,7 @@ jobs:
             echo "PUBLISH_FOLLOWUP_REQUIRED=no"
             echo "MAIN_METADATA_SYNCED=unknown"
             echo "PUBLISH_AUTH_MODE=unknown"
+            echo "SOURCE_TAG_SHA=unknown"
           } >> "$GITHUB_ENV"
 
       - name: Resolve release publish auth mode
@@ -107,9 +109,17 @@ jobs:
 
       - name: Checkout tag
         if: ${{ env.VERIFY_ONLY != 'true' }}
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
         with:
           ref: ${{ env.TAG_NAME }}
+
+      - name: Record source tag revision
+        if: ${{ env.VERIFY_ONLY != 'true' }}
+        run: |
+          set -euo pipefail
+          SOURCE_TAG_SHA="$(git rev-parse HEAD)"
+          echo "SOURCE_TAG_SHA=${SOURCE_TAG_SHA}" >> "$GITHUB_ENV"
+          echo "[preflight] source_tag_sha=${SOURCE_TAG_SHA} workflow_sha=${WORKFLOW_SHA}"
 
       - name: Install Rust toolchain (macOS targets)
         if: ${{ env.VERIFY_ONLY != 'true' }}
@@ -152,9 +162,10 @@ jobs:
           } > "$ASSET_DIR/helm-cli-${TAG_NAME}-checksums.txt"
 
           export ARM64_SHA X64_SHA UNIVERSAL_SHA
-          export ARM64_NAME="$(basename "$ARM64_ASSET")"
-          export X64_NAME="$(basename "$X64_ASSET")"
-          export UNIVERSAL_NAME="$(basename "$UNIVERSAL_ASSET")"
+          ARM64_NAME="$(basename "$ARM64_ASSET")"
+          X64_NAME="$(basename "$X64_ASSET")"
+          UNIVERSAL_NAME="$(basename "$UNIVERSAL_ASSET")"
+          export ARM64_NAME X64_NAME UNIVERSAL_NAME
 
           python3 - <<'PY'
           import datetime
@@ -226,7 +237,7 @@ jobs:
 
       - name: Upload CLI artifacts to workflow run
         if: ${{ env.VERIFY_ONLY != 'true' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: helm-cli-${{ env.TAG_NAME }}
           path: |
@@ -257,6 +268,7 @@ jobs:
         if: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && env.VERIFY_ONLY != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PUBLISH_PAT != '' && secrets.RELEASE_PUBLISH_PAT || github.token }}
+          FALLBACK_GH_TOKEN: ${{ github.token }}
           PUBLISH_WITH_PAT: ${{ secrets.RELEASE_PUBLISH_PAT != '' && 'true' || 'false' }}
           ASSET_DIR: ${{ github.workspace }}/build/cli-release
         run: |
@@ -268,7 +280,23 @@ jobs:
           PUBLISH_BRANCH="chore/publish-cli-updates-${TAG_NAME}-${CLI_RELEASE_CHANNEL}"
           TARGET_ENDPOINT="https://helmapp.dev/updates/cli/$(basename "$TARGET_PATH")"
 
-          git clone --depth 1 --branch main "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$PUBLISH_DIR"
+          clone_publish_repo() {
+            git clone --depth 1 --branch main "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$PUBLISH_DIR"
+          }
+
+          if ! clone_publish_repo; then
+            if [ "$PUBLISH_WITH_PAT" != "true" ]; then
+              echo "::error::Unable to clone main with github.token for metadata publication."
+              exit 1
+            fi
+
+            echo "::warning::RELEASE_PUBLISH_PAT could not clone the repository; retrying with github.token."
+            PUBLISH_DIR="${RUNNER_TEMP}/cli-updates-publish-fallback"
+            GH_TOKEN="$FALLBACK_GH_TOKEN"
+            PUBLISH_WITH_PAT="false"
+            echo "PUBLISH_AUTH_MODE=github_token_fallback" >> "$GITHUB_ENV"
+            clone_publish_repo
+          fi
           mkdir -p "$PUBLISH_DIR/$(dirname "$TARGET_PATH")"
           cp "$SOURCE_JSON" "$PUBLISH_DIR/$TARGET_PATH"
 
@@ -285,7 +313,19 @@ jobs:
           git commit -m "chore(release): publish CLI latest metadata for ${TAG_NAME}"
 
           git checkout -B "$PUBLISH_BRANCH"
-          git push -u origin "$PUBLISH_BRANCH" --force-with-lease
+          if ! git push -u origin "$PUBLISH_BRANCH" --force-with-lease; then
+            if [ "$PUBLISH_WITH_PAT" != "true" ]; then
+              echo "::error::Unable to push metadata publish branch with github.token."
+              exit 1
+            fi
+
+            echo "::warning::RELEASE_PUBLISH_PAT could not push the publish branch; retrying with github.token."
+            GH_TOKEN="$FALLBACK_GH_TOKEN"
+            PUBLISH_WITH_PAT="false"
+            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+            echo "PUBLISH_AUTH_MODE=github_token_fallback" >> "$GITHUB_ENV"
+            git push -u origin "$PUBLISH_BRANCH" --force-with-lease
+          fi
 
           EXISTING_PR="$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --head "$PUBLISH_BRANCH" --state open --json number --jq '.[0].number // empty' || true)"
           if [ -n "$EXISTING_PR" ]; then
@@ -309,14 +349,26 @@ jobs:
               --head "$PUBLISH_BRANCH" \
               --title "chore(release): publish CLI latest metadata for ${TAG_NAME}" \
               --body-file "$PR_BODY_FILE" 2>&1)" || {
+              if [ "$PUBLISH_WITH_PAT" = "true" ]; then
+                echo "::warning::RELEASE_PUBLISH_PAT could not create the publish PR; retrying with github.token."
+                GH_TOKEN="$FALLBACK_GH_TOKEN"
+                PUBLISH_WITH_PAT="false"
+                echo "PUBLISH_AUTH_MODE=github_token_fallback" >> "$GITHUB_ENV"
+                PR_URL="$(gh pr create \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --base main \
+                  --head "$PUBLISH_BRANCH" \
+                  --title "chore(release): publish CLI latest metadata for ${TAG_NAME}" \
+                  --body-file "$PR_BODY_FILE" 2>&1)" && true
+              fi
+            }
+            if [ -z "${PR_URL:-}" ] || ! PR_NUMBER="$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --head "$PUBLISH_BRANCH" --state open --json number --jq '.[0].number // empty' || true)"; then
               echo "::error::Unable to create CLI publish PR via GitHub Actions token."
               echo "::error::Fallback branch was pushed: ${PUBLISH_BRANCH}"
               echo "::error::Open manual PR: https://github.com/${GITHUB_REPOSITORY}/compare/main...${PUBLISH_BRANCH}?expand=1"
               echo "::error::gh output: ${PR_URL}"
               exit 1
-            }
-
-            PR_NUMBER="$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --head "$PUBLISH_BRANCH" --state open --json number --jq '.[0].number // empty' || true)"
+            fi
             if [ -z "$PR_NUMBER" ]; then
               echo "::error::CLI publish PR was created but could not be resolved to an open PR number."
               echo "::error::Open manual PR: https://github.com/${GITHUB_REPOSITORY}/compare/main...${PUBLISH_BRANCH}?expand=1"
@@ -448,6 +500,8 @@ jobs:
           publish_pr_opened="${PUBLISH_PR_OPENED:-no}"
           main_metadata_synced="${MAIN_METADATA_SYNCED:-unknown}"
           publish_auth_mode="${PUBLISH_AUTH_MODE:-unknown}"
+          workflow_sha="${WORKFLOW_SHA:-unknown}"
+          source_tag_sha="${SOURCE_TAG_SHA:-unknown}"
           publish_pr_number="${PUBLISH_PR_NUMBER:-}"
           publish_pr_url="${PUBLISH_PR_URL:-}"
           publish_followup_required="${PUBLISH_FOLLOWUP_REQUIRED:-no}"
@@ -458,6 +512,8 @@ jobs:
             echo "- Verify only run: ${VERIFY_ONLY}"
             echo "- Artifacts uploaded: ${artifacts_uploaded}"
             echo "- Publish auth mode: ${publish_auth_mode}"
+            echo "- Workflow revision: ${workflow_sha}"
+            echo "- Source tag revision: ${source_tag_sha}"
             echo "- Publish PR opened: ${publish_pr_opened}"
             echo "- Main metadata synced: ${main_metadata_synced}"
             if [ -n "${publish_pr_number}" ]; then

--- a/.github/workflows/release-contract-checks.yml
+++ b/.github/workflows/release-contract-checks.yml
@@ -16,7 +16,18 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
+
+      - name: Install actionlint
+        run: |
+          ACTIONLINT_DIR="$RUNNER_TEMP/actionlint-bin"
+          mkdir -p "$ACTIONLINT_DIR"
+          GOBIN="$ACTIONLINT_DIR" go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.8
+          echo "ACTIONLINT_BIN=$ACTIONLINT_DIR/actionlint" >> "$GITHUB_ENV"
+
+      - name: Validate GitHub Actions workflows
+        run: |
+          "$ACTIONLINT_BIN"
 
       - name: Validate unsigned build script safety contracts
         run: scripts/release/tests/build_unsigned_variant_contract.sh
@@ -93,7 +104,7 @@ jobs:
           PY
 
       - name: Upload release rehearsal report artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: release-rehearsal-report
           path: ${{ runner.temp }}/release-rehearsal-report.json

--- a/.github/workflows/release-macos-canary.yml
+++ b/.github/workflows/release-macos-canary.yml
@@ -1,0 +1,80 @@
+name: Release macOS Canary
+
+on:
+  schedule:
+    - cron: "17 13 * * 2"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-macos-canary
+  cancel-in-progress: false
+
+jobs:
+  release-macos-canary:
+    runs-on: macos-26
+    env:
+      EXPECTED_XCODE_MAJOR: "26"
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
+
+      - name: Verify macOS release runtime
+        run: |
+          set -euo pipefail
+          MACOS_VERSION="$(sw_vers -productVersion)"
+          XCODE_VERSION="$(xcodebuild -version | awk '/^Xcode / {print $2; exit}')"
+          XCODE_MAJOR="${XCODE_VERSION%%.*}"
+
+          if [ -z "$XCODE_VERSION" ] || [ "$XCODE_MAJOR" != "$EXPECTED_XCODE_MAJOR" ]; then
+            echo "::error::Release runner requires Xcode ${EXPECTED_XCODE_MAJOR}.x; found '${XCODE_VERSION:-unavailable}'."
+            exit 1
+          fi
+
+          echo "[preflight] runner=${RUNNER_OS} macOS=${MACOS_VERSION} xcode=${XCODE_VERSION}"
+
+      - name: Install Rust toolchain (universal targets)
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: 1.93.1
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      - name: Run serialized Rust release gate
+        run: cargo test --workspace --manifest-path core/rust/Cargo.toml -- --test-threads=1
+
+      - name: Run Swift release gate
+        run: |
+          set -euo pipefail
+          HELM_CHANNEL_PROFILE=developer_id \
+          xcodebuild \
+            -project apps/macos-ui/Helm.xcodeproj \
+            -scheme Helm \
+            -destination "platform=macOS" \
+            -configuration Debug \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            test
+
+      - name: Build unsigned universal release app
+        run: |
+          set -euo pipefail
+          DERIVED_DATA="$RUNNER_TEMP/release-canary-derived-data"
+          HELM_CHANNEL_PROFILE=developer_id \
+          xcodebuild \
+            -project apps/macos-ui/Helm.xcodeproj \
+            -scheme Helm \
+            -configuration Release \
+            -destination "generic/platform=macOS" \
+            -derivedDataPath "$DERIVED_DATA" \
+            ARCHS="arm64 x86_64" \
+            ONLY_ACTIVE_ARCH=NO \
+            CODE_SIGN_IDENTITY=- \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+          lipo -archs "$DERIVED_DATA/Build/Products/Release/Helm.app/Contents/MacOS/Helm"

--- a/.github/workflows/release-macos-dmg.yml
+++ b/.github/workflows/release-macos-dmg.yml
@@ -44,6 +44,8 @@ jobs:
       HELM_SPARKLE_PRIVATE_ED_KEY: ${{ secrets.HELM_SPARKLE_PRIVATE_ED_KEY }}
       TAG_NAME: ${{ inputs.tag || github.event.release.tag_name || github.event.inputs.tag }}
       VERIFY_ONLY: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.verify_only == 'true' && 'true' || 'false') || 'false' }}
+      EXPECTED_XCODE_MAJOR: "26"
+      WORKFLOW_SHA: ${{ github.workflow_sha }}
       LANG: en_US.UTF-8
       LC_ALL: en_US.UTF-8
 
@@ -93,6 +95,7 @@ jobs:
             echo "PUBLISH_FOLLOWUP_REQUIRED=no"
             echo "MAIN_METADATA_SYNCED=unknown"
             echo "PUBLISH_AUTH_MODE=unknown"
+            echo "SOURCE_TAG_SHA=unknown"
           } >> "$GITHUB_ENV"
 
       - name: Resolve release publish auth mode
@@ -111,9 +114,26 @@ jobs:
 
       - name: Checkout
         if: ${{ env.VERIFY_ONLY != 'true' }}
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.0.0
         with:
           ref: ${{ env.TAG_NAME }}
+
+      - name: Verify macOS release runtime
+        if: ${{ env.VERIFY_ONLY != 'true' }}
+        run: |
+          set -euo pipefail
+          MACOS_VERSION="$(sw_vers -productVersion)"
+          XCODE_VERSION="$(xcodebuild -version | awk '/^Xcode / {print $2; exit}')"
+          XCODE_MAJOR="${XCODE_VERSION%%.*}"
+          SOURCE_TAG_SHA="$(git rev-parse HEAD)"
+
+          if [ -z "$XCODE_VERSION" ] || [ "$XCODE_MAJOR" != "$EXPECTED_XCODE_MAJOR" ]; then
+            echo "::error::Release runner requires Xcode ${EXPECTED_XCODE_MAJOR}.x; found '${XCODE_VERSION:-unavailable}'."
+            exit 1
+          fi
+
+          echo "SOURCE_TAG_SHA=${SOURCE_TAG_SHA}" >> "$GITHUB_ENV"
+          echo "[preflight] runner=${RUNNER_OS} macOS=${MACOS_VERSION} xcode=${XCODE_VERSION} source_tag_sha=${SOURCE_TAG_SHA} workflow_sha=${WORKFLOW_SHA}"
 
       - name: Install Rust toolchain (universal targets)
         if: ${{ env.VERIFY_ONLY != 'true' }}
@@ -548,7 +568,7 @@ jobs:
 
       - name: Upload build artifacts to workflow run
         if: ${{ env.VERIFY_ONLY != 'true' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: helm-macos-dmg-${{ env.TAG_NAME }}
           path: |
@@ -576,6 +596,7 @@ jobs:
         if: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch') && env.VERIFY_ONLY != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PUBLISH_PAT != '' && secrets.RELEASE_PUBLISH_PAT || github.token }}
+          FALLBACK_GH_TOKEN: ${{ github.token }}
           PUBLISH_WITH_PAT: ${{ secrets.RELEASE_PUBLISH_PAT != '' && 'true' || 'false' }}
         run: |
           set -euo pipefail
@@ -587,7 +608,23 @@ jobs:
           PUBLISH_DIR="$RUNNER_TEMP/appcast-publish"
           PUBLISH_BRANCH="chore/publish-updates-${TAG_NAME}"
 
-          git clone --depth 1 --branch main "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$PUBLISH_DIR"
+          clone_publish_repo() {
+            git clone --depth 1 --branch main "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$PUBLISH_DIR"
+          }
+
+          if ! clone_publish_repo; then
+            if [ "$PUBLISH_WITH_PAT" != "true" ]; then
+              echo "::error::Unable to clone main with github.token for metadata publication."
+              exit 1
+            fi
+
+            echo "::warning::RELEASE_PUBLISH_PAT could not clone the repository; retrying with github.token."
+            PUBLISH_DIR="${RUNNER_TEMP}/appcast-publish-fallback"
+            GH_TOKEN="$FALLBACK_GH_TOKEN"
+            PUBLISH_WITH_PAT="false"
+            echo "PUBLISH_AUTH_MODE=github_token_fallback" >> "$GITHUB_ENV"
+            clone_publish_repo
+          fi
           mkdir -p "$PUBLISH_DIR/$(dirname "$FEED_PATH")"
           mkdir -p "$PUBLISH_DIR/$(dirname "$RELEASE_NOTES_FEED_PATH")"
           cp "$APPCAST_PATH" "$PUBLISH_DIR/$FEED_PATH"
@@ -606,7 +643,19 @@ jobs:
           git commit -m "chore(release): publish Sparkle appcast + release notes for ${TAG_NAME}"
 
           git checkout -B "$PUBLISH_BRANCH"
-          git push -u origin "$PUBLISH_BRANCH" --force-with-lease
+          if ! git push -u origin "$PUBLISH_BRANCH" --force-with-lease; then
+            if [ "$PUBLISH_WITH_PAT" != "true" ]; then
+              echo "::error::Unable to push metadata publish branch with github.token."
+              exit 1
+            fi
+
+            echo "::warning::RELEASE_PUBLISH_PAT could not push the publish branch; retrying with github.token."
+            GH_TOKEN="$FALLBACK_GH_TOKEN"
+            PUBLISH_WITH_PAT="false"
+            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+            echo "PUBLISH_AUTH_MODE=github_token_fallback" >> "$GITHUB_ENV"
+            git push -u origin "$PUBLISH_BRANCH" --force-with-lease
+          fi
 
           EXISTING_PR="$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --head "$PUBLISH_BRANCH" --state open --json number --jq '.[0].number // empty' || true)"
           if [ -n "$EXISTING_PR" ]; then
@@ -631,14 +680,26 @@ jobs:
               --head "$PUBLISH_BRANCH" \
               --title "chore(release): publish Sparkle appcast + release notes for ${TAG_NAME}" \
               --body-file "$PR_BODY_FILE" 2>&1)" || {
+              if [ "$PUBLISH_WITH_PAT" = "true" ]; then
+                echo "::warning::RELEASE_PUBLISH_PAT could not create the publish PR; retrying with github.token."
+                GH_TOKEN="$FALLBACK_GH_TOKEN"
+                PUBLISH_WITH_PAT="false"
+                echo "PUBLISH_AUTH_MODE=github_token_fallback" >> "$GITHUB_ENV"
+                PR_URL="$(gh pr create \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --base main \
+                  --head "$PUBLISH_BRANCH" \
+                  --title "chore(release): publish Sparkle appcast + release notes for ${TAG_NAME}" \
+                  --body-file "$PR_BODY_FILE" 2>&1)" && true
+              fi
+            }
+            if [ -z "${PR_URL:-}" ] || ! PR_NUMBER="$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --head "$PUBLISH_BRANCH" --state open --json number --jq '.[0].number // empty' || true)"; then
               echo "::error::Unable to create publish PR via GitHub Actions token."
               echo "::error::Fallback branch was pushed: ${PUBLISH_BRANCH}"
               echo "::error::Open manual PR: https://github.com/${GITHUB_REPOSITORY}/compare/main...${PUBLISH_BRANCH}?expand=1"
               echo "::error::gh output: ${PR_URL}"
               exit 1
-            }
-
-            PR_NUMBER="$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --head "$PUBLISH_BRANCH" --state open --json number --jq '.[0].number // empty' || true)"
+            fi
             if [ -z "$PR_NUMBER" ]; then
               echo "::error::Publish PR was created but could not be resolved to an open PR number."
               echo "::error::Open manual PR: https://github.com/${GITHUB_REPOSITORY}/compare/main...${PUBLISH_BRANCH}?expand=1"
@@ -787,6 +848,8 @@ jobs:
           publish_pr_opened="${PUBLISH_PR_OPENED:-no}"
           main_metadata_synced="${MAIN_METADATA_SYNCED:-unknown}"
           publish_auth_mode="${PUBLISH_AUTH_MODE:-unknown}"
+          workflow_sha="${WORKFLOW_SHA:-unknown}"
+          source_tag_sha="${SOURCE_TAG_SHA:-unknown}"
           publish_pr_number="${PUBLISH_PR_NUMBER:-}"
           publish_pr_url="${PUBLISH_PR_URL:-}"
           publish_followup_required="${PUBLISH_FOLLOWUP_REQUIRED:-no}"
@@ -797,6 +860,8 @@ jobs:
             echo "- Verify only run: ${VERIFY_ONLY}"
             echo "- Artifacts uploaded: ${artifacts_uploaded}"
             echo "- Publish auth mode: ${publish_auth_mode}"
+            echo "- Workflow revision: ${workflow_sha}"
+            echo "- Source tag revision: ${source_tag_sha}"
             echo "- Publish PR opened: ${publish_pr_opened}"
             echo "- Main metadata synced: ${main_metadata_synced}"
             if [ -n "${publish_pr_number}" ]; then

--- a/.github/workflows/release-publish-auth-check.yml
+++ b/.github/workflows/release-publish-auth-check.yml
@@ -1,0 +1,104 @@
+name: Release Publish Auth Check
+
+on:
+  schedule:
+    - cron: "23 14 * * 1"
+  workflow_dispatch:
+    inputs:
+      write_probe:
+        description: "Create and immediately clean up a probe branch and PR to validate write permissions"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  validate-release-publish-auth:
+    runs-on: ubuntu-latest
+    env:
+      PUBLISH_TOKEN: ${{ secrets.RELEASE_PUBLISH_PAT }}
+      WRITE_PROBE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.write_probe == 'true' && 'true' || 'false' }}
+    steps:
+      - name: Verify release publication credential
+        run: |
+          set -euo pipefail
+          if [ -z "$PUBLISH_TOKEN" ]; then
+            echo "::error::RELEASE_PUBLISH_PAT is not configured."
+            exit 1
+          fi
+
+          ACTOR="$(GH_TOKEN="$PUBLISH_TOKEN" gh api user --jq '.login')"
+          PUSH_ALLOWED="$(GH_TOKEN="$PUBLISH_TOKEN" gh api "repos/${GITHUB_REPOSITORY}" --jq '.permissions.push // false')"
+          if [ "$PUSH_ALLOWED" != "true" ]; then
+            echo "::error::RELEASE_PUBLISH_PAT does not have repository push permission."
+            exit 1
+          fi
+
+          git ls-remote --exit-code "https://x-access-token:${PUBLISH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD >/dev/null
+
+          if [ "$WRITE_PROBE" = "true" ]; then
+            BASE_BRANCH="$(GH_TOKEN="$PUBLISH_TOKEN" gh api "repos/${GITHUB_REPOSITORY}" --jq '.default_branch')"
+            BASE_SHA="$(GH_TOKEN="$PUBLISH_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BASE_BRANCH}" --jq '.object.sha')"
+            TREE_SHA="$(GH_TOKEN="$PUBLISH_TOKEN" gh api "repos/${GITHUB_REPOSITORY}/git/commits/${BASE_SHA}" --jq '.tree.sha')"
+            PROBE_BRANCH="chore/release-auth-probe-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            PROBE_PR_NUMBER=""
+            PROBE_BRANCH_CREATED="false"
+
+            cleanup() {
+              local cleanup_failed=0
+              if [ -n "$PROBE_PR_NUMBER" ]; then
+                if ! GH_TOKEN="$PUBLISH_TOKEN" gh api --method PATCH "repos/${GITHUB_REPOSITORY}/pulls/${PROBE_PR_NUMBER}" -f state=closed >/dev/null; then
+                  echo "::error::Unable to close release publication auth probe PR #${PROBE_PR_NUMBER}."
+                  cleanup_failed=1
+                fi
+              fi
+              if [ "$PROBE_BRANCH_CREATED" = "true" ]; then
+                if ! GH_TOKEN="$PUBLISH_TOKEN" gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${PROBE_BRANCH}" >/dev/null; then
+                  echo "::error::Unable to delete release publication auth probe branch ${PROBE_BRANCH}."
+                  cleanup_failed=1
+                fi
+              fi
+              return "$cleanup_failed"
+            }
+            on_exit() {
+              local original_status=$?
+              trap - EXIT
+              if ! cleanup; then
+                exit 1
+              fi
+              exit "$original_status"
+            }
+            trap on_exit EXIT
+
+            PROBE_COMMIT_SHA="$(GH_TOKEN="$PUBLISH_TOKEN" gh api --method POST "repos/${GITHUB_REPOSITORY}/git/commits" \
+              -f message="chore(release): publication auth probe" \
+              -f tree="$TREE_SHA" \
+              -f "parents[]=$BASE_SHA" \
+              --jq '.sha')"
+            GH_TOKEN="$PUBLISH_TOKEN" gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f "ref=refs/heads/${PROBE_BRANCH}" \
+              -f "sha=${PROBE_COMMIT_SHA}" >/dev/null
+            PROBE_BRANCH_CREATED="true"
+            PROBE_PR_NUMBER="$(GH_TOKEN="$PUBLISH_TOKEN" gh api --method POST "repos/${GITHUB_REPOSITORY}/pulls" \
+              -f title="chore(release): publication auth probe" \
+              -f head="$PROBE_BRANCH" \
+              -f base="$BASE_BRANCH" \
+              -f body="Automated permission probe; closed immediately." \
+              --jq '.number')"
+          fi
+
+          {
+            echo "## Release Publish Auth Check"
+            echo ""
+            echo "- Authenticated actor: ${ACTOR}"
+            echo "- Repository push permission: ${PUSH_ALLOWED}"
+            echo "- Git read authentication: verified"
+            echo "- Write/PR capability probe: ${WRITE_PROBE}"
+            if [ "$WRITE_PROBE" = "true" ]; then
+              echo "- Probe branch and PR: created and scheduled for cleanup"
+            else
+              echo "- Mutation: none"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ If behavior or policy changes, update the source-of-truth docs that changed real
 - Do not run destructive commands (for example `rm -rf`, branch deletion, cache purges) without explicit user approval.
 - Do not auto-publish releases/appcasts/website deploys.
 - Release and appcast work must remain dry-run/checklist-first unless user explicitly confirms mutation.
+- Before any release tag, publication, workflow dispatch, or release recovery, read `docs/operations/RELEASE_FLOW.md` and `docs/RELEASE_CHECKLIST.md`; run the required rehearsal and preflight gates, and obtain explicit user confirmation before a mutating step.
 
 Branch safety:
 

--- a/core/rust/crates/helm-core/tests/tokio_process_executor.rs
+++ b/core/rust/crates/helm-core/tests/tokio_process_executor.rs
@@ -153,11 +153,13 @@ async fn idle_timeout_resets_when_process_is_emitting_output() {
         ManagerId::HomebrewFormula,
         TaskType::Refresh,
         ManagerAction::Refresh,
-        CommandSpec::new("/bin/sh")
-            .args(["-c", "for i in 1 2 3 4; do echo tick; sleep 0.05; done"]),
+        CommandSpec::new("/bin/sh").args([
+            "-c",
+            "for i in 1 2 3 4 5 6 7 8; do echo tick; sleep 0.15; done",
+        ]),
     )
     .timeout(Duration::from_secs(10))
-    .idle_timeout(Duration::from_millis(120));
+    .idle_timeout(Duration::from_millis(500));
 
     let handle = spawn_validated(&executor, request).expect("spawn should succeed");
     let output = handle.wait().await.expect("wait should succeed");
@@ -175,10 +177,12 @@ async fn hard_timeout_extends_for_active_install_process() {
         ManagerId::HomebrewFormula,
         TaskType::Install,
         ManagerAction::Install,
-        CommandSpec::new("/bin/sh")
-            .args(["-c", "for i in 1 2 3 4 5 6; do echo tick; sleep 0.11; done"]),
+        CommandSpec::new("/bin/sh").args([
+            "-c",
+            "for i in 1 2 3 4 5 6 7 8 9 10; do echo tick; sleep 0.2; done",
+        ]),
     )
-    .timeout(Duration::from_millis(600))
+    .timeout(Duration::from_millis(1500))
     .idle_timeout(Duration::from_secs(5));
 
     let handle = spawn_validated(&executor, request).expect("spawn should succeed");

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -32,10 +32,14 @@ This checklist is required before creating a release tag on `main`.
 ## Release Preflight (All Releases, Mandatory Before Tagging)
 
 - [ ] Run `scripts/release/preflight.sh --tag <vX.Y.Z|vX.Y.Z-rc.N>` from a clean local clone before tag creation.
+- [ ] Read and follow `docs/operations/RELEASE_FLOW.md` before any release mutation.
+- [ ] Run `scripts/release/rehearsal_dry_run.sh --tag <vX.Y.Z|vX.Y.Z-rc.N>` and retain its passing report.
+- [ ] Confirm `Release macOS Canary` passed on `macos-26` after the latest release-workflow or toolchain change.
+- [ ] Dispatch and pass `Release Publish Auth Check` with `write_probe=true` after any release credential rotation or permission change.
 - [ ] Confirm preflight reports token scopes include `repo` and `workflow`.
 - [ ] Confirm preflight validates required release workflows are present and enabled.
 - [ ] Confirm preflight validates required DMG/signing/update secrets are present.
-- [ ] Confirm optional `RELEASE_PUBLISH_PAT` is configured (recommended) so release-generated publish PRs can receive required checks and auto-merge normally.
+- [ ] Confirm `RELEASE_PUBLISH_PAT` is configured and authenticated so release-generated publish PRs can receive required checks and auto-merge normally.
 - [ ] Confirm preflight validates `main` ruleset publish-PR bypass policy (prefer GitHub Actions app `pull_request` bypass when available; otherwise use `Repository admin` `pull_request` fallback; no `always` bypass actors).
 - [ ] Confirm preflight snapshot sanity passes for stable tags (`origin/main` appcast + `cli/latest.json` in sync and behind target tag).
 - [ ] Confirm crash/error reporting policy remains local-only for the release line and no automatic remote telemetry path was introduced (`docs/operations/CRASH_REPORTING_POLICY.md`).

--- a/docs/operations/CLI_RELEASE_AND_CI.md
+++ b/docs/operations/CLI_RELEASE_AND_CI.md
@@ -246,6 +246,8 @@ Expected outcome:
 
 If preflight fails, resolve failures before creating/pushing tags.
 
+Run the full mandatory sequence in `docs/operations/RELEASE_FLOW.md`, including the non-mutating rehearsal, `Release macOS Canary`, and `Release Publish Auth Check` before a stable tag.
+
 ### 5.1 Authenticate `gh` with Maintainer PAT
 
 Required scopes (minimum):
@@ -321,8 +323,10 @@ UI remediation path:
 ### 5.3 Set/Verify Release Secrets
 
 Existing DMG release workflow (`release-macos-dmg.yml`) still requires current Apple/signing secrets.
-Release workflows still use `github.token` for release-asset uploads, but publish-PR automation now prefers optional `RELEASE_PUBLISH_PAT`.
-If `RELEASE_PUBLISH_PAT` is missing, workflows fall back to `github.token`, which can prevent required PR checks from firing on publish branches and may require manual/admin merge follow-up.
+Release workflows use `github.token` for release-asset uploads, and stable release preflight requires `RELEASE_PUBLISH_PAT` for publish-PR automation.
+If `RELEASE_PUBLISH_PAT` is missing or cannot push/create a publish PR, workflows retry with `github.token`. The fallback can require manual/admin merge follow-up because required PR checks may not fire from a workflow-token-created PR.
+
+After setting or rotating `RELEASE_PUBLISH_PAT`, run `Release Publish Auth Check` from the Actions tab with `write_probe=true`. This explicitly creates and then cleans up an empty probe branch and PR, validating effective Git contents-write and pull-request permissions. The scheduled/default check remains read-only.
 
 To set or rotate secrets:
 
@@ -364,7 +368,7 @@ Both direct release workflows now emit a publication summary with:
 
 Outcome semantics:
 
-- hard failures are retained for build/signing/notarization/upload/PR-creation faults
+- hard failures are retained for build/signing/notarization/upload faults and when neither publication credential can create a required publish PR
 - if publication PR automation succeeds but PR merge is still pending, the run can complete with follow-up required (non-red terminal state)
 - when follow-up is required: merge the publish PR, then dispatch the same workflow with `verify_only=true` to confirm `Main metadata synced: yes` without rebuilding artifacts
 - release logs now use phase prefixes to simplify triage:

--- a/docs/operations/RELEASE_FLOW.md
+++ b/docs/operations/RELEASE_FLOW.md
@@ -1,0 +1,71 @@
+# Release Flow
+
+This is the mandatory release sequence for maintainers and agents. It supplements
+`docs/RELEASE_CHECKLIST.md`; it does not authorize a release mutation.
+
+## Authority And Safety
+
+- Only a maintainer may rotate secrets, change signing/notarization credentials, or approve a public release.
+- Agents must keep release work dry-run/checklist-first and request explicit confirmation before creating a tag, publishing a release, dispatching a publishing workflow, merging a publish PR, or deploying website metadata.
+- Release artifact source is the immutable tag. A workflow dispatch runs the workflow definition from `main`, so record both the workflow revision and source-tag revision in the run summary/provenance.
+- Do not retag or replace a published release. Recover through a PR and a `verify_only` dispatch.
+
+## Required Gates
+
+Run these from a clean, current `main` checkout before creating a tag:
+
+1. Confirm release changes and release-workflow changes have merged to `main`.
+2. Run the non-mutating rehearsal:
+
+   ```bash
+   scripts/release/rehearsal_dry_run.sh --tag vX.Y.Z
+   ```
+
+3. Run preflight:
+
+   ```bash
+   scripts/release/runbook.sh prepare --tag vX.Y.Z
+   ```
+
+4. Confirm the scheduled or manually dispatched `Release macOS Canary` is green on `macos-26` after the latest workflow/toolchain change.
+5. With explicit maintainer approval, dispatch `Release Publish Auth Check` with `write_probe=true`. Require a passing probe that creates and cleans up an empty branch/PR to validate effective Git contents-write and pull-request permissions.
+6. Resolve every error before tagging. `RELEASE_PUBLISH_PAT` is required by stable release preflight; its authentication check must pass before publication.
+
+## Mutating Sequence
+
+After explicit maintainer approval:
+
+1. Create and push the annotated tag:
+
+   ```bash
+   scripts/release/runbook.sh tag --tag vX.Y.Z
+   ```
+
+2. Create or confirm the GitHub release:
+
+   ```bash
+   scripts/release/runbook.sh publish --tag vX.Y.Z
+   ```
+
+3. Watch `Release macOS DMG` and `Release CLI Direct Installer` to completion. Do not run auxiliary variants until direct GUI and CLI artifacts have published.
+4. Read both publication summaries. Artifact upload and metadata synchronization are separate states.
+5. If either workflow opens a publish PR, wait for required checks, merge it through the protected-branch flow, then dispatch that workflow with `verify_only=true`.
+6. Run the final release verification:
+
+   ```bash
+   scripts/release/runbook.sh verify --tag vX.Y.Z
+   ```
+
+7. Confirm public `https://helmapp.dev/updates/appcast.xml` and `https://helmapp.dev/updates/cli/latest.json` reference the released version.
+
+## Recovery Rules
+
+- A failed build, signing, notarization, DMG verification, or asset upload is a hard release failure. Fix the confirmed defect and rerun the affected workflow for the existing tag.
+- If `RELEASE_PUBLISH_PAT` is invalid, workflows retry metadata branch/PR creation with `github.token`. That fallback requires a maintainer to merge the resulting publish PR and run `verify_only`.
+- If neither credential can create the publish branch/PR, retrieve the generated metadata from the workflow artifact, open the documented `chore/publish-*` PR manually, merge it, then run `verify_only`. Do not regenerate or replace release artifacts.
+- If a workflow/runtime upgrade fails the canary, update the runner label, expected Xcode major, and immutable action pin together in a dedicated workflow-maintenance PR before the next tag.
+- Record recurring friction in `TMP_RELEASE_FRICTION` and promote it to durable docs or contracts before the next release.
+
+## Credential Ownership
+
+`RELEASE_PUBLISH_PAT` is maintainer-owned. It must be authorized for the repository and have the minimum repository permissions needed to read/write contents and create pull requests. Prefer a dedicated GitHub App installation token when repository ruleset support is available. Run `Release Publish Auth Check` with `write_probe=true` after any rotation or permission change.

--- a/scripts/release/generate_provenance_manifest.sh
+++ b/scripts/release/generate_provenance_manifest.sh
@@ -120,6 +120,8 @@ payload = {
         "run_id": os.environ.get("GITHUB_RUN_ID", ""),
         "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
         "sha": os.environ.get("GITHUB_SHA", ""),
+        "workflow_sha": os.environ.get("WORKFLOW_SHA", ""),
+        "source_tag_sha": os.environ.get("SOURCE_TAG_SHA", ""),
         "ref": os.environ.get("GITHUB_REF", ""),
     },
     "release": {

--- a/scripts/release/preflight.sh
+++ b/scripts/release/preflight.sh
@@ -581,6 +581,8 @@ check_required_workflows() {
     "release-macos-dmg.yml"
     "release-cli-direct.yml"
     "release-all-variants.yml"
+    "release-macos-canary.yml"
+    "release-publish-auth-check.yml"
     "appcast-drift.yml"
     "cli-update-drift.yml"
   )
@@ -617,6 +619,10 @@ required = [
     "HELM_SPARKLE_FEED_URL",
     "HELM_SPARKLE_PUBLIC_ED_KEY",
     "HELM_SPARKLE_PRIVATE_ED_KEY",
+    "ASC_KEY_ID",
+    "ASC_ISSUER_ID",
+    "ASC_PRIVATE_KEY_BASE64",
+    "RELEASE_PUBLISH_PAT",
 ]
 
 payload = json.loads(sys.argv[1])
@@ -632,22 +638,7 @@ PY
     info "required release secrets are present"
   fi
 
-  local has_release_publish_pat
-  has_release_publish_pat="$(python3 - "$secrets_json" <<'PY'
-import json
-import sys
-
-payload = json.loads(sys.argv[1])
-present = {item["name"] for item in payload}
-print("yes" if "RELEASE_PUBLISH_PAT" in present else "no")
-PY
-)"
-
-  if [ "$has_release_publish_pat" = "yes" ]; then
-    info "optional release publish PAT secret is present (RELEASE_PUBLISH_PAT)"
-  else
-    warn "optional secret RELEASE_PUBLISH_PAT is missing; publish PR checks may not run when release workflows use github.token fallback"
-  fi
+  info "release publish PAT secret is present (RELEASE_PUBLISH_PAT)"
 }
 
 parse_args() {

--- a/scripts/release/tests/ci_toolchain_contract.sh
+++ b/scripts/release/tests/ci_toolchain_contract.sh
@@ -6,6 +6,8 @@ WORKFLOWS_DIR="${ROOT_DIR}/.github/workflows"
 EXPECTED_RUST_TOOLCHAIN="1.93.1"
 EXPECTED_SWIFTLINT_VERSION="0.59.1"
 EXPECTED_SWIFTLINT_SHA256="58f9be8a4677900c945e2c618168223f4dd620a0cc65c9ccc5ea0f70433e89c1"
+EXPECTED_CHECKOUT_SHA="fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09"
+EXPECTED_UPLOAD_ARTIFACT_SHA="330a01c490aca151604b8cf639adc76d48f6c5d4"
 
 has_pattern() {
   local pattern="$1"
@@ -62,5 +64,28 @@ has_pattern "releases/download/\\$\\{SWIFTLINT_VERSION\\}/portable_swiftlint.zip
   echo "error: swiftlint workflow must install the portable release artifact for the pinned version." >&2
   exit 1
 }
+
+for workflow in \
+  "${WORKFLOWS_DIR}/release-macos-dmg.yml" \
+  "${WORKFLOWS_DIR}/release-cli-direct.yml" \
+  "${WORKFLOWS_DIR}/release-all-variants.yml" \
+  "${WORKFLOWS_DIR}/release-contract-checks.yml" \
+  "${WORKFLOWS_DIR}/release-macos-canary.yml"; do
+  has_pattern "actions/checkout@${EXPECTED_CHECKOUT_SHA}" "${workflow}" || {
+    echo "error: ${workflow} must pin actions/checkout v5." >&2
+    exit 1
+  }
+done
+
+for workflow in \
+  "${WORKFLOWS_DIR}/release-macos-dmg.yml" \
+  "${WORKFLOWS_DIR}/release-cli-direct.yml" \
+  "${WORKFLOWS_DIR}/release-all-variants.yml" \
+  "${WORKFLOWS_DIR}/release-contract-checks.yml"; do
+  has_pattern "actions/upload-artifact@${EXPECTED_UPLOAD_ARTIFACT_SHA}" "${workflow}" || {
+    echo "error: ${workflow} must pin actions/upload-artifact v5." >&2
+    exit 1
+  }
+done
 
 echo "CI toolchain contracts validated."

--- a/scripts/release/tests/provenance_manifest_contract.sh
+++ b/scripts/release/tests/provenance_manifest_contract.sh
@@ -24,6 +24,8 @@ env \
   GITHUB_RUN_ID="123456" \
   GITHUB_RUN_ATTEMPT="2" \
   GITHUB_SHA="0123456789abcdef" \
+  WORKFLOW_SHA="1111111111111111" \
+  SOURCE_TAG_SHA="fedcba9876543210" \
   GITHUB_REF="refs/tags/v0.17.6" \
   "${SCRIPT_PATH}" \
     --output "${OUT_JSON}" \
@@ -52,6 +54,12 @@ if payload.get("schema_version") != 1:
 
 if payload.get("release", {}).get("tag") != "v0.17.6":
     raise SystemExit("release tag mismatch")
+
+builder = payload.get("builder", {})
+if builder.get("workflow_sha") != "1111111111111111":
+    raise SystemExit("workflow revision mismatch")
+if builder.get("source_tag_sha") != "fedcba9876543210":
+    raise SystemExit("source tag revision mismatch")
 
 subjects = payload.get("subjects") or []
 if len(subjects) != 2:

--- a/scripts/release/tests/release_workflow_contract.sh
+++ b/scripts/release/tests/release_workflow_contract.sh
@@ -6,6 +6,9 @@ WORKFLOWS_DIR="${ROOT_DIR}/.github/workflows"
 ALL_VARIANTS_WORKFLOW="${WORKFLOWS_DIR}/release-all-variants.yml"
 CLI_WORKFLOW="${WORKFLOWS_DIR}/release-cli-direct.yml"
 DMG_WORKFLOW="${WORKFLOWS_DIR}/release-macos-dmg.yml"
+CANARY_WORKFLOW="${WORKFLOWS_DIR}/release-macos-canary.yml"
+AUTH_CHECK_WORKFLOW="${WORKFLOWS_DIR}/release-publish-auth-check.yml"
+PREFLIGHT_SCRIPT="${ROOT_DIR}/scripts/release/preflight.sh"
 WEB_BUILD_WORKFLOW="${WORKFLOWS_DIR}/web-build.yml"
 
 fail() {
@@ -39,6 +42,25 @@ reject_pattern 'release-cli-direct\.yml' "$ALL_VARIANTS_WORKFLOW" "all-variants 
 for workflow in "$CLI_WORKFLOW" "$DMG_WORKFLOW"; do
   expect_pattern 'git push -u origin "\$PUBLISH_BRANCH" --force-with-lease' "$workflow" "metadata publication must use force-with-lease"
   reject_pattern 'git push.*--force($|[[:space:]])' "$workflow" "metadata publication must not fall back to unconditional force"
+  expect_pattern 'FALLBACK_GH_TOKEN: \$\{\{ github\.token \}\}' "$workflow" "metadata publication must retry with github.token"
+  expect_pattern 'PUBLISH_AUTH_MODE=github_token_fallback' "$workflow" "metadata publication must record fallback authentication"
+done
+
+expect_pattern 'runs-on: macos-26' "$CANARY_WORKFLOW" "release canary must use the supported macOS runner"
+expect_pattern 'EXPECTED_XCODE_MAJOR: "26"' "$CANARY_WORKFLOW" "release canary must pin the expected Xcode major"
+expect_pattern 'cargo test --workspace --manifest-path core/rust/Cargo.toml -- --test-threads=1' "$CANARY_WORKFLOW" "release canary must run the serialized Rust release gate"
+expect_pattern 'Build unsigned universal release app' "$CANARY_WORKFLOW" "release canary must build an unsigned universal app"
+
+expect_pattern 'RELEASE_PUBLISH_PAT' "$AUTH_CHECK_WORKFLOW" "release auth check must validate the publish credential"
+expect_pattern 'git ls-remote --exit-code' "$AUTH_CHECK_WORKFLOW" "release auth check must verify Git authentication"
+expect_pattern 'write_probe:' "$AUTH_CHECK_WORKFLOW" "release auth check must require explicit write-probe opt-in"
+expect_pattern 'repos/\$\{GITHUB_REPOSITORY\}/pulls' "$AUTH_CHECK_WORKFLOW" "release auth check must validate pull-request permission"
+expect_pattern 'git/refs/heads/\$\{PROBE_BRANCH\}' "$AUTH_CHECK_WORKFLOW" "release auth check must clean up its probe branch"
+expect_pattern 'GITHUB_RUN_ATTEMPT' "$AUTH_CHECK_WORKFLOW" "release auth probe branches must be unique across reruns"
+expect_pattern 'trap on_exit EXIT' "$AUTH_CHECK_WORKFLOW" "release auth check must fail when probe cleanup fails"
+
+for secret in ASC_KEY_ID ASC_ISSUER_ID ASC_PRIVATE_KEY_BASE64 RELEASE_PUBLISH_PAT; do
+  expect_pattern "\"${secret}\"" "$PREFLIGHT_SCRIPT" "release preflight must require ${secret}"
 done
 
 expect_pattern 'branches: \[web, dev, main\]' "$WEB_BUILD_WORKFLOW" "web build must cover web, dev, and main promotion branches"


### PR DESCRIPTION
## Summary

- make the release flow mandatory for agents and maintainers through root policy, checklist, and a canonical operations guide
- add macOS runtime/release canary and explicit publication-auth validation gates
- upgrade release-critical Actions to immutable Node 24-native v5 pins and lint all workflows with actionlint
- retry invalid publish PAT operations with `github.token`, record workflow/tag revisions in provenance, and relax timing-test margins

## Validation

- `cargo test --workspace --manifest-path core/rust/Cargo.toml`
- `cargo fmt --all --manifest-path core/rust/Cargo.toml -- --check`
- `xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination "platform=macOS" -configuration Debug CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO test`
- `scripts/release/rehearsal_dry_run.sh --tag v99.99.99 --report-path <temporary path>`
- release workflow/toolchain/provenance contracts and actionlint
