### PR TITLE
fix(rustup): treat update checks as refresh results

### DIFF
--- a/core/rust/crates/helm-core/src/adapters/process_utils.rs
+++ b/core/rust/crates/helm-core/src/adapters/process_utils.rs
@@ -39,6 +39,14 @@ pub(crate) fn run_and_collect_stdout(
     executor: &dyn ProcessExecutor,
     request: ProcessSpawnRequest,
 ) -> AdapterResult<String> {
+    run_and_collect_stdout_accepting_exit_codes(executor, request, &[])
+}
+
+pub(crate) fn run_and_collect_stdout_accepting_exit_codes(
+    executor: &dyn ProcessExecutor,
+    request: ProcessSpawnRequest,
+    allowed_exit_codes: &[i32],
+) -> AdapterResult<String> {
     let manager = request.manager;
     let task_type = request.task_type;
     let action = request.action;
@@ -49,7 +57,9 @@ pub(crate) fn run_and_collect_stdout(
     let output: ProcessOutput = handle.block_on(process.wait())?;
 
     match output.status {
-        ProcessExitStatus::ExitCode(0) => Ok(String::from_utf8_lossy(&output.stdout).to_string()),
+        ProcessExitStatus::ExitCode(code) if code == 0 || allowed_exit_codes.contains(&code) => {
+            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        }
         ProcessExitStatus::ExitCode(code) => {
             let stderr = String::from_utf8_lossy(&output.stderr);
             Err(CoreError {
@@ -81,7 +91,7 @@ mod tests {
     };
     use crate::models::{CoreErrorKind, ManagerAction, ManagerId, TaskType};
 
-    use super::run_and_collect_stdout;
+    use super::{run_and_collect_stdout, run_and_collect_stdout_accepting_exit_codes};
 
     #[derive(Clone)]
     struct StaticExecutor {
@@ -180,5 +190,30 @@ mod tests {
         assert_eq!(error.manager, Some(ManagerId::Npm));
         assert_eq!(error.task, Some(TaskType::Refresh));
         assert_eq!(error.action, Some(ManagerAction::ListInstalled));
+    }
+
+    #[test]
+    fn run_and_collect_stdout_accepts_explicit_expected_exit_code() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime should build");
+        let _guard = runtime.enter();
+
+        let now = SystemTime::now();
+        let executor = Arc::new(StaticExecutor {
+            output: ProcessOutput {
+                status: ProcessExitStatus::ExitCode(100),
+                stdout: b"updates available\n".to_vec(),
+                stderr: Vec::new(),
+                started_at: now,
+                finished_at: now,
+            },
+        });
+
+        let stdout =
+            run_and_collect_stdout_accepting_exit_codes(executor.as_ref(), make_request(), &[100])
+                .expect("expected exit code should be accepted");
+        assert_eq!(stdout, "updates available\n");
     }
 }

--- a/core/rust/crates/helm-core/src/adapters/rustup.rs
+++ b/core/rust/crates/helm-core/src/adapters/rustup.rs
@@ -1615,14 +1615,25 @@ fn parse_rustup_check(output: &str) -> AdapterResult<Vec<OutdatedPackage>> {
         .map(str::trim)
         .filter(|line| !line.is_empty())
     {
-        // Skip rustup self-check line: "rustup - Up to date : ..."
-        if line.starts_with("rustup -") || line.starts_with("rustup -") {
+        // Skip rustup self-check lines; Helm tracks toolchain updates, not rustup self-updates.
+        if line.starts_with("rustup -") {
             continue;
         }
 
-        // Only process "Update available" lines
-        // Format: "stable-x86_64-apple-darwin - Update available : 1.82.0 -> 1.93.0"
-        let Some((toolchain_part, update_part)) = line.split_once(" - Update available : ") else {
+        let Some((toolchain_part, status_part)) = line.split_once(" - ") else {
+            continue;
+        };
+
+        let status_part = status_part.trim();
+        let update_marker = "update available";
+        let Some(version_part) = status_part
+            .get(..update_marker.len())
+            .filter(|prefix| prefix.eq_ignore_ascii_case(update_marker))
+            .and_then(|_| status_part.get(update_marker.len()..))
+            .map(str::trim_start)
+            .and_then(|remainder| remainder.strip_prefix(':'))
+            .map(str::trim)
+        else {
             continue;
         };
 
@@ -1631,8 +1642,7 @@ fn parse_rustup_check(output: &str) -> AdapterResult<Vec<OutdatedPackage>> {
             continue;
         }
 
-        // Parse "1.82.0 -> 1.93.0"
-        let Some((old_version, new_version)) = update_part.split_once(" -> ") else {
+        let Some((old_version, new_version)) = version_part.split_once(" -> ") else {
             continue;
         };
 
@@ -1964,6 +1974,23 @@ wasm32-unknown-unknown\n";
         assert_eq!(packages[0].installed_version.as_deref(), Some("1.82.0"));
         assert_eq!(packages[0].candidate_version, "1.93.0");
         assert!(packages[0].runtime_state.is_empty());
+    }
+
+    #[test]
+    fn parses_current_rustup_check_output() {
+        let output = "stable-aarch64-apple-darwin - update available: 1.96.0 (ac68faa20 2026-05-25) -> 1.97.1 (8bab26f4f 2026-07-14)\nrustup - up to date : 1.29.0\n";
+        let packages = parse_rustup_check(output).unwrap();
+
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].package.name, "stable-aarch64-apple-darwin");
+        assert_eq!(
+            packages[0].installed_version.as_deref(),
+            Some("1.96.0 (ac68faa20 2026-05-25)")
+        );
+        assert_eq!(
+            packages[0].candidate_version,
+            "1.97.1 (8bab26f4f 2026-07-14)"
+        );
     }
 
     #[test]

--- a/core/rust/crates/helm-core/src/adapters/rustup_process.rs
+++ b/core/rust/crates/helm-core/src/adapters/rustup_process.rs
@@ -5,7 +5,10 @@ use std::time::Duration;
 
 use crate::adapters::detect_utils::which_executable;
 use crate::adapters::manager::AdapterResult;
-use crate::adapters::process_utils::{run_and_collect_stdout, run_and_collect_version_output};
+use crate::adapters::process_utils::{
+    run_and_collect_stdout, run_and_collect_stdout_accepting_exit_codes,
+    run_and_collect_version_output,
+};
 use crate::adapters::rustup::{
     RustupDetectOutput, RustupInstallSource, RustupSource, RustupToolchainDetail,
     rustup_add_component_request, rustup_add_target_request, rustup_check_request,
@@ -171,7 +174,8 @@ impl RustupSource for ProcessRustupSource {
 
     fn check(&self) -> AdapterResult<String> {
         let request = self.configure_request(rustup_check_request(None));
-        run_and_collect_stdout(self.executor.as_ref(), request)
+        // rustup exits 100 when updates are available, which is a successful outdated-state result.
+        run_and_collect_stdout_accepting_exit_codes(self.executor.as_ref(), request, &[100])
     }
 
     fn install_self(&self, source: RustupInstallSource) -> AdapterResult<String> {

--- a/core/rust/crates/helm-core/tests/end_to_end_rustup.rs
+++ b/core/rust/crates/helm-core/tests/end_to_end_rustup.rs
@@ -117,9 +117,18 @@ impl ProcessExecutor for RustupFakeExecutor {
             Vec::new()
         };
 
+        let status = if program == "rustup" || program.ends_with("/rustup") {
+            match args.as_slice() {
+                [command] if command == "check" => ProcessExitStatus::ExitCode(100),
+                _ => ProcessExitStatus::ExitCode(0),
+            }
+        } else {
+            ProcessExitStatus::ExitCode(0)
+        };
+
         Ok(Box::new(FakeProcess {
             output: ProcessOutput {
-                status: ProcessExitStatus::ExitCode(0),
+                status,
                 stdout,
                 stderr: Vec::new(),
                 started_at: now,

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -22,6 +22,7 @@ Active milestone:
 - latest stable publication cut completed for `v0.17.11`:
   - workspace, docs, website, appcast, and CLI metadata now reflect the published `0.17.11` stable line.
   - release automation follow-through and publish verification completed on `main`.
+  - post-release rustup refresh correction: `rustup check` exit code `100` now represents detected toolchain updates rather than a failed refresh, and current lowercase output grammar is parsed into outdated toolchains.
 - 0.17.x — Diagnostics & Logging (**stable released on `main`**, RC lineage `v0.17.0-rc.1` through `v0.17.0-rc.5`)
   - delivered: `feat/v0.17-log-foundation` (SQLite-backed task lifecycle logs + retrieval plumbing)
   - delivered: `feat/v0.17-task-log-viewer` (inspector diagnostics logs tab with level/status filters + load-more pagination)

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -17,6 +17,7 @@ Helm is in:
 Focus:
 - keep `main`/`dev`/`docs`/`web` release-state docs and version markers aligned now that `v0.17.11` is published
 - maintain release-process hardening guardrails now that phases 1-5 are complete (preflight, publish verification, drift prevention)
+- preserve manager-specific expected nonzero update-check outcomes as completed refreshes with actionable outdated state, starting with rustup's exit code `100`
 - continue doctor/repair subsystem foundation in core + FFI + service surfaces without widening into online knowledge lookup yet
 - keep repair knowledge lookup local/embedded for now, with explicit TODO seams for future online fingerprint lookup
 - sequence `0.18.x` local security groundwork now that the `0.17.11` hardening slice has landed


### PR DESCRIPTION
## Summary

- treat rustup `check` exit code `100` as the expected updates-available result
- parse current lowercase rustup update output while retaining legacy output support
- preserve failures for all other rustup process exit codes

## Validation

- `cargo test --workspace --manifest-path core/rust/Cargo.toml`
- `cargo clippy --workspace --manifest-path core/rust/Cargo.toml -- -D warnings`
- `cargo fmt --all --manifest-path core/rust/Cargo.toml -- --check`
