### PR TITLE
fix(upgrades): centralize authority-ordered workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
 
 ## [Unreleased]
 
-Post-`v0.17.11`, `dev` is now positioned for broader `0.18.x` work.
+## [0.17.12] - 2026-07-29
+
+### Fixed
+- Bulk and scoped upgrade workflows now execute authority phases in the Rust execution boundary. Helm waits for all submitted tasks in an authoritative phase before scheduling standard or guarded manager work.
+- Cancelling a scoped upgrade workflow prevents later authority phases from being scheduled while retaining existing per-task cancellation and diagnostics.
+- Indeterminate workflow-status probes now recover local UI state after a bounded retry window without weakening backend workflow ownership.
+- Legacy external-coordinator bulk updates retain authority ordering under behavior-level regression coverage.
+
+### Changed
+- SwiftUI now submits and renders scoped upgrade workflows instead of coordinating their phase sequencing locally.
+
+`v0.17.12` is the final planned `0.17.x` patch before broader `0.18.x` work.
 
 ## [0.17.11] - 2026-07-28
 

--- a/apps/macos-ui/Helm.xcodeproj/project.pbxproj
+++ b/apps/macos-ui/Helm.xcodeproj/project.pbxproj
@@ -12,9 +12,6 @@
 		8CE1FDD22F3D2B84000A3945 /* HelmServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE1FDD12F3D2B84000A3945 /* HelmServiceProtocol.swift */; };
 		8CE1FDD32F3D2B84000A3945 /* HelmServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE1FDD12F3D2B84000A3945 /* HelmServiceProtocol.swift */; };
 		8CE1FDD82F3D2BAA000A3945 /* HelmService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE1FDD52F3D2BA9000A3945 /* HelmService.swift */; };
-		N100000000000000000000001 /* HelmCliShimCommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = N100000000000000000000002 /* HelmCliShimCommandRunner.swift */; };
-		N100000000000000000000003 /* HelmCliShimCommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = N100000000000000000000002 /* HelmCliShimCommandRunner.swift */; };
-		N100000000000000000000004 /* HelmCliShimCommandRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = N100000000000000000000005 /* HelmCliShimCommandRunnerTests.swift */; };
 		8CE1FDD92F3D2BAA000A3945 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE1FDD62F3D2BA9000A3945 /* main.swift */; };
 		8CE1FDDA2F3D2BAA000A3945 /* HelmServiceDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE1FDD72F3D2BA9000A3945 /* HelmServiceDelegate.swift */; };
 		8CE1FDDD2F3D2DA7000A3945 /* libhelm_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8CFB6D482F3D1B24002372B8 /* libhelm_ffi.a */; };
@@ -76,6 +73,9 @@
 		L200000000000000000000001 /* helm-cli in Resources */ = {isa = PBXBuildFile; fileRef = L100000000000000000000001 /* helm-cli */; };
 		M200000000000000000000001 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = M100000000000000000000002 /* main.swift */; };
 		M200000000000000000000002 /* HelmLoginHelper.app in Embed Login Items */ = {isa = PBXBuildFile; fileRef = M100000000000000000000001 /* HelmLoginHelper.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		N100000000000000000000001 /* HelmCliShimCommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = N100000000000000000000002 /* HelmCliShimCommandRunner.swift */; };
+		N100000000000000000000003 /* HelmCliShimCommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = N100000000000000000000002 /* HelmCliShimCommandRunner.swift */; };
+		N100000000000000000000004 /* HelmCliShimCommandRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = N100000000000000000000005 /* HelmCliShimCommandRunnerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -125,8 +125,6 @@
 		8CE1FDD52F3D2BA9000A3945 /* HelmService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HelmService.swift; sourceTree = "<group>"; };
 		8CE1FDD62F3D2BA9000A3945 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		8CE1FDD72F3D2BA9000A3945 /* HelmServiceDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HelmServiceDelegate.swift; sourceTree = "<group>"; };
-		N100000000000000000000002 /* HelmCliShimCommandRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelmCliShimCommandRunner.swift; sourceTree = "<group>"; };
-		N100000000000000000000005 /* HelmCliShimCommandRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelmCliShimCommandRunnerTests.swift; sourceTree = "<group>"; };
 		8CE1FDDE2F3D3249000A3945 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../../../service/macos-service/Info.plist"; sourceTree = "<group>"; };
 		8CE1FDE02F3D3410000A3945 /* HelmService-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "HelmService-Bridging-Header.h"; path = "../../../service/macos-service/HelmService-Bridging-Header.h"; sourceTree = "<group>"; };
 		8CFB6D482F3D1B24002372B8 /* libhelm_ffi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libhelm_ffi.a; path = Generated/libhelm_ffi.a; sourceTree = "<group>"; };
@@ -192,6 +190,8 @@
 		M100000000000000000000002 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		M100000000000000000000003 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		M100000000000000000000004 /* HelmLoginHelper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HelmLoginHelper.entitlements; sourceTree = "<group>"; };
+		N100000000000000000000002 /* HelmCliShimCommandRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelmCliShimCommandRunner.swift; sourceTree = "<group>"; };
+		N100000000000000000000005 /* HelmCliShimCommandRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelmCliShimCommandRunnerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -997,6 +997,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.jasoncavinder.Helm;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};

--- a/apps/macos-ui/Helm/Core/HelmCore+Actions.swift
+++ b/apps/macos-ui/Helm/Core/HelmCore+Actions.swift
@@ -6,7 +6,6 @@ import os.log
 private let logger = Logger(subsystem: "com.jasoncavinder.Helm", category: "core.actions")
 
 extension HelmCore {
-    private static let scopedUpgradePlanPhaseTimeoutSeconds: TimeInterval = 300
 
     func cancelTask(_ task: TaskItem) {
         guard task.isRunning, let taskId = Int64(task.id) else { return }
@@ -190,43 +189,84 @@ extension HelmCore {
             managerScopeId: managerScopeId,
             packageFilter: packageFilter
         )
-        let runCandidateSteps = scopedSteps.filter { step in
-            let status = projectedUpgradePlanStatus(for: step)
-            let hasProjectedTask = upgradePlanTaskProjectionByStepId[step.id] != nil
-            return UpgradePreviewPlanner.shouldRunScopedStep(
-                status: status,
-                hasProjectedTask: hasProjectedTask,
-                managerId: step.managerId,
-                safeModeEnabled: safeModeEnabled
-            )
-        }
+        guard !scopedSteps.isEmpty else { return }
 
-        guard !runCandidateSteps.isEmpty else { return }
-
-        let runToken = UUID()
-        scopedUpgradePlanRunToken = runToken
-        scopedUpgradePlanRunInProgress = true
-
-        let phasesByRank = Dictionary(grouping: runCandidateSteps) { step in
-            HelmCore.authorityRank(for: step.authority)
-        }
-        let orderedPhaseRanks = phasesByRank.keys.sorted()
-        guard !orderedPhaseRanks.isEmpty else {
-            finishScopedUpgradePlanRun(runToken: runToken, invalidateToken: true)
-            return
-        }
-
-        runScopedUpgradePlanPhases(
-            phaseRanks: orderedPhaseRanks,
-            phasesByRank: phasesByRank,
-            phaseIndex: 0,
-            runToken: runToken
+        startScopedUpgradeWorkflow(
+            includePinned: upgradePlanIncludePinned,
+            allowOsUpdates: upgradePlanAllowOsUpdates,
+            managerScopeId: managerScopeId,
+            packageFilter: packageFilter,
+            source: "core.actions",
+            action: "runUpgradePlanScoped"
         )
     }
 
+    func startScopedUpgradeWorkflow(
+        includePinned: Bool,
+        allowOsUpdates: Bool,
+        managerScopeId: String,
+        packageFilter: String,
+        source: String,
+        action: String
+    ) {
+        guard scopedUpgradeWorkflowId == nil,
+              !scopedUpgradeWorkflowStartState.isInFlight,
+              !scopedUpgradePlanRunInProgress else { return }
+        guard let service = service() else {
+            recordLastError(
+                source: source,
+                action: "\(action).service_unavailable",
+                taskType: "upgrade"
+            )
+            return
+        }
+
+        let workflowId = "upgrade-workflow-\(UUID().uuidString.lowercased())"
+        scopedUpgradeWorkflowId = workflowId
+        scopedUpgradePlanRunInProgress = true
+        scopedUpgradeWorkflowStartState.begin(workflowId: workflowId)
+        scopedUpgradeWorkflowStatusReconciliationState.reset()
+        withTimeout(
+            30,
+            source: source,
+            action: "\(action).start",
+            taskType: "upgrade",
+            operation: { completion in
+                service.startScopedUpgradeWorkflowWithId(
+                    workflowId: workflowId,
+                    includePinned: includePinned,
+                    allowOsUpdates: allowOsUpdates,
+                    managerScopeId: managerScopeId,
+                    packageFilter: packageFilter
+                ) { completion($0) }
+            },
+            fallback: false
+        ) { [weak self] accepted in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                let cancellationPending = self.scopedUpgradeWorkflowStartState.finish(workflowId: workflowId)
+                guard self.scopedUpgradeWorkflowId == workflowId else { return }
+                guard accepted == true else {
+                    self.recordLastError(source: source, action: action, taskType: "upgrade")
+                    // The service may have accepted the request after this XPC reply timed out.
+                    // Keep the caller-generated ID until the backend query resolves ownership.
+                    self.refreshScopedUpgradeWorkflowStatus()
+                    return
+                }
+                if cancellationPending {
+                    self.cancelScopedUpgradeWorkflow(workflowId)
+                } else {
+                    self.refreshScopedUpgradeWorkflowStatus()
+                }
+            }
+        }
+    }
+
     func cancelRemainingUpgradePlanSteps(managerScopeId: String, packageFilter: String) {
-        scopedUpgradePlanRunToken = UUID()
-        scopedUpgradePlanRunInProgress = false
+        scopedUpgradeWorkflowStartState.requestCancellation()
+        if let workflowId = scopedUpgradeWorkflowId {
+            cancelScopedUpgradeWorkflow(workflowId)
+        }
 
         let scopedStepIds = Set(
             HelmCore.scopedUpgradePlanSteps(
@@ -275,111 +315,17 @@ extension HelmCore {
         }
     }
 
-    private func runScopedUpgradePlanPhases(
-        phaseRanks: [Int],
-        phasesByRank: [Int: [CoreUpgradePlanStep]],
-        phaseIndex: Int,
-        runToken: UUID
-    ) {
-        guard runToken == scopedUpgradePlanRunToken else {
-            return
-        }
-
-        guard phaseIndex < phaseRanks.count else {
-            finishScopedUpgradePlanRun(runToken: runToken, invalidateToken: true)
-            return
-        }
-
-        let phaseRank = phaseRanks[phaseIndex]
-        let phaseSteps = phasesByRank[phaseRank] ?? []
-        guard !phaseSteps.isEmpty else {
-            runScopedUpgradePlanPhases(
-                phaseRanks: phaseRanks,
-                phasesByRank: phasesByRank,
-                phaseIndex: phaseIndex + 1,
-                runToken: runToken
-            )
-            return
-        }
-
-        let dispatchGroup = DispatchGroup()
-        for step in phaseSteps {
-            dispatchGroup.enter()
-            retryUpgradePlanStep(step) { _ in
-                dispatchGroup.leave()
+    private func cancelScopedUpgradeWorkflow(_ workflowId: String) {
+        service()?.cancelUpgradeWorkflow(workflowId: workflowId) { [weak self] success in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                guard self.scopedUpgradeWorkflowId == workflowId else { return }
+                if !success {
+                    logger.warning("cancelUpgradeWorkflow(\(workflowId)) returned false")
+                }
+                self.refreshScopedUpgradeWorkflowStatus()
             }
         }
-
-        dispatchGroup.notify(queue: .main) { [weak self] in
-            self?.waitForScopedUpgradePlanPhaseCompletion(stepIds: Set(phaseSteps.map(\.id)), runToken: runToken) {
-                self?.runScopedUpgradePlanPhases(
-                    phaseRanks: phaseRanks,
-                    phasesByRank: phasesByRank,
-                    phaseIndex: phaseIndex + 1,
-                    runToken: runToken
-                )
-            }
-        }
-    }
-
-    private func waitForScopedUpgradePlanPhaseCompletion(
-        stepIds: Set<String>,
-        runToken: UUID,
-        startedAt: Date = Date(),
-        completion: @escaping () -> Void
-    ) {
-        guard !stepIds.isEmpty else {
-            completion()
-            return
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
-            guard let self = self else { return }
-            guard runToken == self.scopedUpgradePlanRunToken else {
-                return
-            }
-            if Date().timeIntervalSince(startedAt) > Self.scopedUpgradePlanPhaseTimeoutSeconds {
-                logger.warning(
-                    "Scoped upgrade phase timed out after \(Self.scopedUpgradePlanPhaseTimeoutSeconds)s; cancelling scoped run token"
-                )
-                self.recordLastError(
-                    source: "core.actions",
-                    action: "runUpgradePlanScoped.phase_timeout",
-                    taskType: "upgrade"
-                )
-                self.finishScopedUpgradePlanRun(runToken: runToken, invalidateToken: true)
-                return
-            }
-
-            let inFlight = self.upgradePlanSteps.contains { step in
-                guard stepIds.contains(step.id) else { return false }
-                let status = self.projectedUpgradePlanStatus(for: step)
-                let hasProjectedTask = self.upgradePlanTaskProjectionByStepId[step.id] != nil
-                return UpgradePreviewPlanner.isInFlightStatus(
-                    status: status,
-                    hasProjectedTask: hasProjectedTask
-                )
-            }
-
-            if inFlight {
-                self.waitForScopedUpgradePlanPhaseCompletion(
-                    stepIds: stepIds,
-                    runToken: runToken,
-                    startedAt: startedAt,
-                    completion: completion
-                )
-            } else {
-                completion()
-            }
-        }
-    }
-
-    private func finishScopedUpgradePlanRun(runToken: UUID, invalidateToken: Bool) {
-        guard runToken == scopedUpgradePlanRunToken else { return }
-        if invalidateToken {
-            scopedUpgradePlanRunToken = UUID()
-        }
-        scopedUpgradePlanRunInProgress = false
     }
 
     private func retryUpgradePlanStep(_ step: CoreUpgradePlanStep, completion: ((Bool) -> Void)? = nil) {

--- a/apps/macos-ui/Helm/Core/HelmCore+Dashboard.swift
+++ b/apps/macos-ui/Helm/Core/HelmCore+Dashboard.swift
@@ -294,12 +294,14 @@ extension HelmCore {
     }
 
     func upgradeAllPackages(forManagerId managerId: String) {
-        let packages = outdatedPackages.filter {
-            $0.managerId == managerId && !$0.pinned && canUpgradeIndividually($0)
-        }
-        for package in packages {
-            upgradePackage(package)
-        }
+        startScopedUpgradeWorkflow(
+            includePinned: false,
+            allowOsUpdates: false,
+            managerScopeId: managerId,
+            packageFilter: "",
+            source: "core.dashboard",
+            action: "upgradeAllPackages"
+        )
     }
 
     func health(forManagerId managerId: String) -> OperationalHealth {
@@ -939,6 +941,7 @@ extension HelmCore {
             if !upgradePlanFailureGroups.isEmpty {
                 upgradePlanFailureGroups = []
             }
+            refreshScopedUpgradeWorkflowStatus()
             return
         }
 
@@ -975,6 +978,57 @@ extension HelmCore {
 
         upgradePlanTaskProjectionByStepId = projection
         rebuildUpgradePlanFailureGroups()
+        refreshScopedUpgradeWorkflowStatus()
+    }
+
+    func refreshScopedUpgradeWorkflowStatus() {
+        guard let workflowId = scopedUpgradeWorkflowId,
+              !scopedUpgradeWorkflowStatusCheckInFlight,
+              let service = service() else { return }
+        scopedUpgradeWorkflowStatusCheckInFlight = true
+        withTimeout(
+            30,
+            source: "core.dashboard",
+            action: "isUpgradeWorkflowActive",
+            taskType: "upgrade",
+            operation: { completion in
+                service.isUpgradeWorkflowActive(workflowId: workflowId) { completion($0) }
+            },
+            fallback: nil
+        ) { [weak self] isActive in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.scopedUpgradeWorkflowStatusCheckInFlight = false
+                guard self.scopedUpgradeWorkflowId == workflowId else { return }
+                let resolvedIsActive: Bool?
+                switch isActive {
+                case let .some(value):
+                    resolvedIsActive = value
+                case .none:
+                    resolvedIsActive = nil
+                }
+                switch self.scopedUpgradeWorkflowStatusReconciliationState.reconcile(isActive: resolvedIsActive) {
+                case .keepLocalState:
+                    break
+                case .clearLocalState:
+                    self.scopedUpgradeWorkflowId = nil
+                    self.scopedUpgradePlanRunInProgress = false
+                    self.scopedUpgradeWorkflowStartState.clear(workflowId: workflowId)
+                case .recoverLocalState:
+                    taskSyncLogger.warning(
+                        "Upgrade workflow status remained indeterminate; clearing local workflow UI state (workflow_id=\(workflowId), retries=\(UpgradeWorkflowStatusReconciliationState.maximumIndeterminateResults), budget_seconds=\(Int(UpgradeWorkflowStatusReconciliationState.recoveryBudget)))"
+                    )
+                    self.scopedUpgradeWorkflowId = nil
+                    self.scopedUpgradePlanRunInProgress = false
+                    self.scopedUpgradeWorkflowStartState.clear(workflowId: workflowId)
+                    self.recordLastError(
+                        source: "core.dashboard",
+                        action: "isUpgradeWorkflowActive.indeterminate_recovery",
+                        taskType: "upgrade"
+                    )
+                }
+            }
+        }
     }
 
     func rebuildUpgradePlanFailureGroups() {

--- a/apps/macos-ui/Helm/Core/HelmCore+Settings.swift
+++ b/apps/macos-ui/Helm/Core/HelmCore+Settings.swift
@@ -738,6 +738,9 @@ extension HelmCore {
     // MARK: - Upgrade All
 
     func upgradeAll(includePinned: Bool = false, allowOsUpdates: Bool = false) {
+        guard scopedUpgradeWorkflowId == nil,
+              !scopedUpgradeWorkflowStartState.isInFlight,
+              !scopedUpgradePlanRunInProgress else { return }
         DispatchQueue.main.async {
             self.upgradePlanIncludePinned = includePinned
             self.upgradePlanAllowOsUpdates = allowOsUpdates
@@ -746,24 +749,14 @@ extension HelmCore {
             }
             self.rebuildUpgradePlanFailureGroups()
         }
-        guard let service = service() else {
-            recordLastError(
-                source: "core.settings",
-                action: "upgradeAll.service_unavailable",
-                taskType: "upgrade"
-            )
-            return
-        }
-        service.upgradeAll(includePinned: includePinned, allowOsUpdates: allowOsUpdates) { success in
-            if !success {
-                logger.error("upgradeAll(includePinned: \(includePinned), allowOsUpdates: \(allowOsUpdates)) failed")
-                self.recordLastError(
-                    source: "core.settings",
-                    action: "upgradeAll",
-                    taskType: "upgrade"
-                )
-            }
-        }
+        startScopedUpgradeWorkflow(
+            includePinned: includePinned,
+            allowOsUpdates: allowOsUpdates,
+            managerScopeId: Self.allManagersScopeId,
+            packageFilter: "",
+            source: "core.settings",
+            action: "upgradeAll"
+        )
     }
 
     func refreshUpgradePlan(includePinned: Bool = false, allowOsUpdates: Bool = false) {

--- a/apps/macos-ui/Helm/Core/HelmCore.swift
+++ b/apps/macos-ui/Helm/Core/HelmCore.swift
@@ -784,7 +784,10 @@ final class HelmCore: ObservableObject {
     var latestCoreTasksSnapshot: [CoreTaskRecord] = []
     var previousFailedTaskCount: Int = 0
     var previousRefreshState: Bool = false
-    var scopedUpgradePlanRunToken = UUID()
+    var scopedUpgradeWorkflowId: String?
+    var scopedUpgradeWorkflowStartState = UpgradeWorkflowStartState()
+    var scopedUpgradeWorkflowStatusReconciliationState = UpgradeWorkflowStatusReconciliationState()
+    var scopedUpgradeWorkflowStatusCheckInFlight = false
     private var reconnectAttempt: Int = 0
     private var lastTaskSnapshotRefreshAt: Date = .distantPast
     private var lastFullSnapshotRefreshAt: Date = .distantPast

--- a/apps/macos-ui/Helm/Core/UpgradePreviewPlanner.swift
+++ b/apps/macos-ui/Helm/Core/UpgradePreviewPlanner.swift
@@ -214,6 +214,82 @@ struct UpgradePreviewPlanner {
     }
 }
 
+struct UpgradeWorkflowStartState {
+    private(set) var isInFlight = false
+    private(set) var cancellationPending = false
+    private(set) var workflowId: String?
+
+    mutating func begin(workflowId: String) {
+        isInFlight = true
+        cancellationPending = false
+        self.workflowId = workflowId
+    }
+
+    mutating func requestCancellation() {
+        guard isInFlight else { return }
+        cancellationPending = true
+    }
+
+    mutating func finish(workflowId: String) -> Bool {
+        guard self.workflowId == workflowId else { return false }
+        isInFlight = false
+        defer { cancellationPending = false }
+        return cancellationPending
+    }
+
+    mutating func clear(workflowId: String) {
+        guard self.workflowId == workflowId else { return }
+        isInFlight = false
+        cancellationPending = false
+        self.workflowId = nil
+    }
+}
+
+enum UpgradeWorkflowStatusReconciliationDecision: Equatable {
+    case keepLocalState
+    case clearLocalState
+    case recoverLocalState
+}
+
+struct UpgradeWorkflowStatusReconciliationState {
+    static let maximumIndeterminateResults = 3
+    static let recoveryBudget: TimeInterval = 90
+
+    private(set) var indeterminateResultCount = 0
+    private(set) var firstIndeterminateResultAt: Date?
+
+    mutating func reconcile(
+        isActive: Bool?,
+        now: Date = Date()
+    ) -> UpgradeWorkflowStatusReconciliationDecision {
+        switch isActive {
+        case false:
+            reset()
+            return .clearLocalState
+        case true:
+            reset()
+            return .keepLocalState
+        case nil:
+            indeterminateResultCount += 1
+            if firstIndeterminateResultAt == nil {
+                firstIndeterminateResultAt = now
+            }
+            guard indeterminateResultCount >= Self.maximumIndeterminateResults,
+                  let firstIndeterminateResultAt,
+                  now.timeIntervalSince(firstIndeterminateResultAt) >= Self.recoveryBudget else {
+                return .keepLocalState
+            }
+            reset()
+            return .recoverLocalState
+        }
+    }
+
+    mutating func reset() {
+        indeterminateResultCount = 0
+        firstIndeterminateResultAt = nil
+    }
+}
+
 struct PackageConsolidationPolicy {
     static func statusRank(_ rawStatus: String) -> Int {
         switch rawStatus.lowercased() {

--- a/apps/macos-ui/Helm/Shared/HelmServiceProtocol.swift
+++ b/apps/macos-ui/Helm/Shared/HelmServiceProtocol.swift
@@ -41,6 +41,23 @@ import Foundation
     func setPackageManagerPreference(packageFamilyKey: String, managerId: String?, withReply reply: @escaping (Bool) -> Void)
     func previewUpgradePlan(includePinned: Bool, allowOsUpdates: Bool, withReply reply: @escaping (String?) -> Void)
     func upgradeAll(includePinned: Bool, allowOsUpdates: Bool, withReply reply: @escaping (Bool) -> Void)
+    func startScopedUpgradeWorkflow(
+        includePinned: Bool,
+        allowOsUpdates: Bool,
+        managerScopeId: String,
+        packageFilter: String,
+        withReply reply: @escaping (String?) -> Void
+    )
+    func startScopedUpgradeWorkflowWithId(
+        workflowId: String,
+        includePinned: Bool,
+        allowOsUpdates: Bool,
+        managerScopeId: String,
+        packageFilter: String,
+        withReply reply: @escaping (Bool) -> Void
+    )
+    func cancelUpgradeWorkflow(workflowId: String, withReply reply: @escaping (Bool) -> Void)
+    func isUpgradeWorkflowActive(workflowId: String, withReply reply: @escaping (Bool) -> Void)
     func upgradePackage(managerId: String, packageName: String, packageTargetName: String?, version: String?, withReply reply: @escaping (Int64) -> Void)
     func installPackage(managerId: String, packageName: String, packageTargetName: String?, version: String?, withReply reply: @escaping (Int64) -> Void)
     func uninstallPackage(managerId: String, packageName: String, packageTargetName: String?, version: String?, withReply reply: @escaping (Int64) -> Void)

--- a/apps/macos-ui/HelmService/Sources/HelmService.swift
+++ b/apps/macos-ui/HelmService/Sources/HelmService.swift
@@ -479,6 +479,63 @@ class HelmService: NSObject, HelmServiceProtocol {
         reply(result)
     }
 
+    func startScopedUpgradeWorkflow(
+        includePinned: Bool,
+        allowOsUpdates: Bool,
+        managerScopeId: String,
+        packageFilter: String,
+        withReply reply: @escaping (String?) -> Void
+    ) {
+        let workflowId = managerScopeId.withCString { scope in
+            packageFilter.withCString { filter in
+                helm_start_scoped_upgrade_workflow(includePinned, allowOsUpdates, scope, filter)
+            }
+        }
+        guard let workflowId else {
+            logger.warning("helm_start_scoped_upgrade_workflow returned nil")
+            reply(nil)
+            return
+        }
+        defer { helm_free_string(workflowId) }
+        reply(String(cString: workflowId))
+    }
+
+    func startScopedUpgradeWorkflowWithId(
+        workflowId: String,
+        includePinned: Bool,
+        allowOsUpdates: Bool,
+        managerScopeId: String,
+        packageFilter: String,
+        withReply reply: @escaping (Bool) -> Void
+    ) {
+        let result = workflowId.withCString { workflow in
+            managerScopeId.withCString { scope in
+                packageFilter.withCString { filter in
+                    helm_start_scoped_upgrade_workflow_with_id(
+                        workflow,
+                        includePinned,
+                        allowOsUpdates,
+                        scope,
+                        filter
+                    )
+                }
+            }
+        }
+        if !result {
+            logger.warning("helm_start_scoped_upgrade_workflow_with_id returned false")
+        }
+        reply(result)
+    }
+
+    func cancelUpgradeWorkflow(workflowId: String, withReply reply: @escaping (Bool) -> Void) {
+        let result = workflowId.withCString(helm_cancel_upgrade_workflow)
+        reply(result)
+    }
+
+    func isUpgradeWorkflowActive(workflowId: String, withReply reply: @escaping (Bool) -> Void) {
+        reply(workflowId.withCString(helm_is_upgrade_workflow_active))
+    }
+
     func upgradePackage(
         managerId: String,
         packageName: String,

--- a/apps/macos-ui/HelmTests/UpgradePreviewPlannerTests.swift
+++ b/apps/macos-ui/HelmTests/UpgradePreviewPlannerTests.swift
@@ -231,6 +231,68 @@ final class UpgradePreviewPlannerTests: XCTestCase {
         XCTAssertEqual(taskIds, Set<Int64>([101, 202]))
     }
 
+    func testWorkflowStartKnowsItsIdBeforeTheBackendReply() {
+        var state = UpgradeWorkflowStartState()
+        state.begin(workflowId: "upgrade-workflow-request-1")
+        state.requestCancellation()
+
+        XCTAssertEqual(state.workflowId, "upgrade-workflow-request-1")
+        XCTAssertTrue(state.finish(workflowId: "upgrade-workflow-request-1"))
+        XCTAssertFalse(state.isInFlight)
+        XCTAssertFalse(state.cancellationPending)
+    }
+
+    func testWorkflowStartCompletionWithoutCancellationDoesNotRequestCancellation() {
+        var state = UpgradeWorkflowStartState()
+        state.begin(workflowId: "upgrade-workflow-request-2")
+
+        XCTAssertFalse(state.finish(workflowId: "upgrade-workflow-request-2"))
+        XCTAssertFalse(state.isInFlight)
+    }
+
+    func testWorkflowStatusReconciliationClearsImmediatelyWhenInactive() {
+        var state = UpgradeWorkflowStatusReconciliationState()
+
+        XCTAssertEqual(state.reconcile(isActive: false), .clearLocalState)
+        XCTAssertEqual(state.indeterminateResultCount, 0)
+    }
+
+    func testWorkflowStatusReconciliationRecoversOnlyAfterRetryAndTimeBudget() {
+        var state = UpgradeWorkflowStatusReconciliationState()
+        let start = Date(timeIntervalSince1970: 1_000)
+
+        XCTAssertEqual(state.reconcile(isActive: nil, now: start), .keepLocalState)
+        XCTAssertEqual(
+            state.reconcile(isActive: nil, now: start.addingTimeInterval(30)),
+            .keepLocalState
+        )
+        XCTAssertEqual(
+            state.reconcile(isActive: nil, now: start.addingTimeInterval(89)),
+            .keepLocalState
+        )
+        XCTAssertEqual(
+            state.reconcile(isActive: nil, now: start.addingTimeInterval(90)),
+            .recoverLocalState
+        )
+        XCTAssertEqual(state.indeterminateResultCount, 0)
+    }
+
+    func testWorkflowStatusReconciliationResetsAfterActiveResult() {
+        var state = UpgradeWorkflowStatusReconciliationState()
+        let start = Date(timeIntervalSince1970: 1_000)
+
+        _ = state.reconcile(isActive: nil, now: start)
+        XCTAssertEqual(
+            state.reconcile(isActive: true, now: start.addingTimeInterval(30)),
+            .keepLocalState
+        )
+        XCTAssertEqual(state.indeterminateResultCount, 0)
+        XCTAssertEqual(
+            state.reconcile(isActive: nil, now: start.addingTimeInterval(120)),
+            .keepLocalState
+        )
+    }
+
     private func step(
         id: String,
         order: UInt64,

--- a/core/rust/Cargo.lock
+++ b/core/rust/Cargo.lock
@@ -650,7 +650,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helm-cli"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "crossterm 0.28.1",
  "helm-core",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "helm-core"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "libc",
  "rusqlite",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "helm-ffi"
-version = "0.17.11"
+version = "0.17.12"
 dependencies = [
  "cbindgen",
  "helm-core",

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -3,4 +3,4 @@ members = ["crates/helm-core", "crates/helm-ffi", "crates/helm-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.11"
+version = "0.17.12"

--- a/core/rust/crates/helm-cli/src/main.rs
+++ b/core/rust/crates/helm-cli/src/main.rs
@@ -641,6 +641,7 @@ enum CoordinatorWorkflowRequest {
     UpdatesRun {
         include_pinned: bool,
         allow_os_updates: bool,
+        #[serde(default)]
         manager_id: Option<String>,
     },
 }
@@ -16305,12 +16306,12 @@ fn print_completion_help() {
 #[cfg(test)]
 mod tests {
     use super::{
-        CLI_LICENSE_TERMS_VERSION, Command, CoordinatorClientTransport, ExecutionMode,
-        GlobalOptions, HomebrewKegPolicy, InstallChannel, ManagerId, RustupPackagesCommand,
-        SelfUpdateErrorKind, UpdatePolicy, UpgradeExecutionStep,
-        acquire_coordinator_bootstrap_lock, apply_manager_enablement_self_heal,
-        build_json_payload_lines, classify_failure_class, cmd_updates_run,
-        command_bypasses_cli_onboarding, command_help_topic_exists,
+        CLI_LICENSE_TERMS_VERSION, Command, CoordinatorClientTransport, CoordinatorRequest,
+        CoordinatorWorkflowRequest, ExecutionMode, GlobalOptions, HomebrewKegPolicy,
+        InstallChannel, ManagerId, RustupPackagesCommand, SelfUpdateErrorKind, UpdatePolicy,
+        UpgradeExecutionStep, acquire_coordinator_bootstrap_lock,
+        apply_manager_enablement_self_heal, build_json_payload_lines, classify_failure_class,
+        cmd_updates_run, command_bypasses_cli_onboarding, command_help_topic_exists,
         coordinator_transport_for_cancel, coordinator_transport_for_submit,
         coordinator_transport_for_workflow, count_upgrade_step_failures,
         ensure_cli_onboarding_completed, exit_code_for_error, failure_class_hint, list_managers,
@@ -18034,6 +18035,25 @@ mod tests {
         )
         .expect_err("duplicate --manager should fail");
         assert!(error.contains("specified multiple times"));
+    }
+
+    #[test]
+    fn coordinator_updates_run_accepts_legacy_request_without_manager_id() {
+        let request: CoordinatorRequest = serde_json::from_str(
+            r#"{"kind":"start_workflow","workflow":{"kind":"updates_run","include_pinned":false,"allow_os_updates":true}}"#,
+        )
+        .expect("legacy updates workflow request should deserialize");
+
+        assert!(matches!(
+            request,
+            CoordinatorRequest::StartWorkflow {
+                workflow: CoordinatorWorkflowRequest::UpdatesRun {
+                    include_pinned: false,
+                    allow_os_updates: true,
+                    manager_id: None,
+                },
+            }
+        ));
     }
 
     #[test]

--- a/core/rust/crates/helm-ffi/include/helm.h
+++ b/core/rust/crates/helm-ffi/include/helm.h
@@ -221,6 +221,56 @@ bool helm_set_package_manager_preference(const char *package_family_key, const c
 char *helm_preview_upgrade_plan(bool include_pinned, bool allow_os_updates);
 
 /**
+ * Start a manager/package-scoped bulk upgrade workflow and return its identifier.
+ *
+ * The workflow submits individual package tasks in canonical authority phases and does not
+ * schedule a later phase until every submitted task in the current phase is terminal.
+ *
+ * # Safety
+ *
+ * `manager_scope_id` and `package_filter` must be valid, non-null UTF-8 C strings.
+ */
+char *helm_start_scoped_upgrade_workflow(bool include_pinned,
+                                         bool allow_os_updates,
+                                         const char *manager_scope_id,
+                                         const char *package_filter);
+
+/**
+ * Start a scoped bulk upgrade workflow using a caller-supplied stable identifier.
+ *
+ * Repeating the same request ID is idempotent while the workflow is active. A cancellation
+ * received before its matching start request is retained and prevents task submission.
+ *
+ * # Safety
+ *
+ * All string arguments must be valid, non-null UTF-8 C strings.
+ */
+bool helm_start_scoped_upgrade_workflow_with_id(const char *workflow_id,
+                                                bool include_pinned,
+                                                bool allow_os_updates,
+                                                const char *manager_scope_id,
+                                                const char *package_filter);
+
+/**
+ * Stop a bulk upgrade workflow before it schedules another authority phase.
+ * Existing individual tasks remain cancellable through `helm_cancel_task`.
+ *
+ * # Safety
+ *
+ * `workflow_id` must be a valid, non-null UTF-8 C string.
+ */
+bool helm_cancel_upgrade_workflow(const char *workflow_id);
+
+/**
+ * Return whether a bulk upgrade workflow is still scheduling or waiting for a phase.
+ *
+ * # Safety
+ *
+ * `workflow_id` must be a valid, non-null UTF-8 C string.
+ */
+bool helm_is_upgrade_workflow_active(const char *workflow_id);
+
+/**
  * Queue upgrade tasks for supported managers using cached outdated snapshot.
  *
  * - `include_pinned`: if false, pinned packages are excluded.

--- a/core/rust/crates/helm-ffi/src/lib.rs
+++ b/core/rust/crates/helm-ffi/src/lib.rs
@@ -55,6 +55,9 @@
 //! | `helm_set_package_manager_preference` | Package manager preferences |
 //! | `helm_preview_upgrade_plan` | Upgrade |
 //! | `helm_upgrade_all` | Upgrade |
+//! | `helm_start_scoped_upgrade_workflow` | Upgrade |
+//! | `helm_start_scoped_upgrade_workflow_with_id` | Upgrade |
+//! | `helm_cancel_upgrade_workflow` | Upgrade |
 //! | `helm_upgrade_package` | Upgrade |
 //! | `helm_list_pins` | Pinning |
 //! | `helm_pin_package` | Pinning |
@@ -193,11 +196,75 @@ struct TaskLabel {
     args: std::collections::BTreeMap<String, String>,
 }
 
+struct UpgradeWorkflowControl {
+    cancelled: AtomicBool,
+    started: AtomicBool,
+    task_ids: Mutex<Vec<TaskId>>,
+    cancellation_reservation_expires_at: Option<Instant>,
+}
+
+impl UpgradeWorkflowControl {
+    fn new() -> Self {
+        Self {
+            cancelled: AtomicBool::new(false),
+            started: AtomicBool::new(false),
+            task_ids: Mutex::new(Vec::new()),
+            cancellation_reservation_expires_at: None,
+        }
+    }
+
+    fn cancelled_reservation(expires_at: Instant) -> Self {
+        Self {
+            cancelled: AtomicBool::new(true),
+            started: AtomicBool::new(false),
+            task_ids: Mutex::new(Vec::new()),
+            cancellation_reservation_expires_at: Some(expires_at),
+        }
+    }
+
+    // Exactly one request with an ID may start the workflow; later retries are harmless.
+    fn start_once(&self) -> bool {
+        self.started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    // Returning false tells the caller to cancel a task that raced with workflow cancellation.
+    fn admit_task(&self, task_id: TaskId) -> bool {
+        let mut task_ids = lock_or_recover(&self.task_ids, "upgrade_workflow_tasks");
+        if self.cancelled.load(Ordering::Acquire) {
+            return false;
+        }
+        task_ids.push(task_id);
+        true
+    }
+
+    fn cancel(&self) -> Vec<TaskId> {
+        self.cancelled.store(true, Ordering::Release);
+        lock_or_recover(&self.task_ids, "upgrade_workflow_tasks").clone()
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+
+    fn is_expired_cancellation_reservation(&self, now: Instant) -> bool {
+        !self.started.load(Ordering::Acquire)
+            && self
+                .cancellation_reservation_expires_at
+                .is_some_and(|expires_at| now >= expires_at)
+    }
+}
+
 lazy_static! {
     static ref STATE: Mutex<Option<HelmState>> = Mutex::new(None);
     static ref TASK_LABELS: Mutex<std::collections::HashMap<u64, TaskLabel>> =
         Mutex::new(std::collections::HashMap::new());
     static ref LAST_ERROR_KEY: Mutex<Option<String>> = Mutex::new(None);
+    static ref UPGRADE_WORKFLOWS: Mutex<std::collections::HashMap<String, Arc<UpgradeWorkflowControl>>> =
+        Mutex::new(std::collections::HashMap::new());
+    static ref COMPLETED_UPGRADE_WORKFLOWS: Mutex<std::collections::VecDeque<String>> =
+        Mutex::new(std::collections::VecDeque::new());
 }
 
 const LOCK_POISONED_ERROR_KEY: &str = "error.ffi.lock_poisoned";
@@ -734,6 +801,7 @@ static MANAGER_AUTOMATION_POLICY_CONTEXT: OnceLock<ManagerAutomationPolicyContex
 static COORDINATOR_REQUEST_COUNTER: AtomicU64 = AtomicU64::new(1);
 static COORDINATOR_SERVER_STARTED: AtomicBool = AtomicBool::new(false);
 static AUTO_CHECK_TICKER_STARTED: AtomicBool = AtomicBool::new(false);
+static UPGRADE_WORKFLOW_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 const COORDINATOR_REQUEST_TIMEOUT_SECS: u64 = 30;
 const COORDINATOR_POLL_SLEEP_MS: u64 = 25;
@@ -749,6 +817,8 @@ const AUTO_CHECK_ALLOW_INSECURE_ENV: &str = "HELM_CLI_ALLOW_INSECURE_UPDATE_URLS
 const AUTO_CHECK_HTTP_CONNECT_TIMEOUT_SECS: u64 = 10;
 const AUTO_CHECK_HTTP_READ_TIMEOUT_SECS: u64 = 30;
 const AUTO_CHECK_HTTP_WRITE_TIMEOUT_SECS: u64 = 30;
+const COMPLETED_UPGRADE_WORKFLOW_ID_LIMIT: usize = 64;
+const UPGRADE_WORKFLOW_CANCELLATION_RESERVATION_SECS: u64 = 30;
 const AUTO_CHECK_ALLOWED_HOSTS: [&str; 5] = [
     "helmapp.dev",
     "github.com",
@@ -928,6 +998,8 @@ enum CoordinatorWorkflowRequest {
     UpdatesRun {
         include_pinned: bool,
         allow_os_updates: bool,
+        #[serde(default)]
+        manager_id: Option<String>,
     },
 }
 
@@ -3338,7 +3410,7 @@ struct UpgradeAllTargets {
     softwareupdate_outdated: bool,
 }
 
-#[derive(serde::Serialize, Clone, Debug, Eq, PartialEq)]
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 struct FfiUpgradePlanStep {
     step_id: String,
@@ -4645,9 +4717,30 @@ fn handle_local_coordinator_request(
         }
         CoordinatorRequest::StartWorkflow { workflow } => {
             let job_id = next_coordinator_request_id();
+            let upgrade_workflow_id = match &workflow {
+                CoordinatorWorkflowRequest::UpdatesRun { .. } => {
+                    let workflow_id = next_upgrade_workflow_id();
+                    match register_upgrade_workflow(workflow_id.clone()) {
+                        Ok(Some(_)) | Ok(None) => Some(workflow_id),
+                        Err(error) => {
+                            return CoordinatorResponse {
+                                ok: false,
+                                task_id: None,
+                                job_id: Some(job_id),
+                                payload: None,
+                                error: Some(error.to_string()),
+                            };
+                        }
+                    }
+                }
+                _ => None,
+            };
             let workflow_runtime = runtime.clone();
             let store = Arc::new(SqliteStore::new(store.database_path().to_path_buf()));
             if let Err(error) = store.migrate_to_latest() {
+                if let Some(workflow_id) = upgrade_workflow_id.as_deref() {
+                    finish_upgrade_workflow(workflow_id);
+                }
                 return CoordinatorResponse {
                     ok: false,
                     task_id: None,
@@ -4666,6 +4759,9 @@ fn handle_local_coordinator_request(
                     &rt_handle,
                     workflow,
                 );
+                if let Some(workflow_id) = upgrade_workflow_id {
+                    finish_upgrade_workflow(&workflow_id);
+                }
             });
             CoordinatorResponse {
                 ok: true,
@@ -4745,7 +4841,15 @@ fn run_coordinator_workflow(
         CoordinatorWorkflowRequest::UpdatesRun {
             include_pinned,
             allow_os_updates,
-        } => run_updates_workflow(runtime, store, rt_handle, include_pinned, allow_os_updates),
+            manager_id,
+        } => run_updates_workflow(
+            runtime,
+            store,
+            rt_handle,
+            include_pinned,
+            allow_os_updates,
+            manager_id.as_deref(),
+        ),
     }
 }
 
@@ -4883,115 +4987,32 @@ fn run_updates_workflow(
     rt_handle: &tokio::runtime::Handle,
     include_pinned: bool,
     allow_os_updates: bool,
+    manager_id: Option<&str>,
 ) -> Result<(), String> {
-    let outdated = store
-        .list_outdated()
-        .map_err(|error| format!("failed to list outdated packages: {error}"))?;
-    let targets = collect_upgrade_all_targets(&outdated, include_pinned);
-
-    if runtime.is_manager_enabled(ManagerId::Asdf) {
-        for package_name in targets.asdf {
-            let request = AdapterRequest::Upgrade(UpgradeRequest {
-                package: Some(PackageRef {
-                    manager: ManagerId::Asdf,
-                    name: package_name,
-                }),
-                target_name: None,
-                version: None,
-            });
-            let _ = submit_request_wait(runtime, rt_handle, ManagerId::Asdf, request)?;
-        }
-    }
-
-    if runtime.is_manager_enabled(ManagerId::HomebrewFormula) {
-        for package_name in targets.homebrew {
-            let policy = effective_homebrew_keg_policy(store, &package_name);
-            let cleanup_old_kegs = policy == HomebrewKegPolicy::Cleanup;
-            let target_name = encode_homebrew_upgrade_target(&package_name, cleanup_old_kegs);
-            let request = AdapterRequest::Upgrade(UpgradeRequest {
-                package: Some(PackageRef {
-                    manager: ManagerId::HomebrewFormula,
-                    name: target_name,
-                }),
-                target_name: None,
-                version: None,
-            });
-            let _ = submit_request_wait(runtime, rt_handle, ManagerId::HomebrewFormula, request)?;
-        }
-    }
-
-    if runtime.is_manager_enabled(ManagerId::HomebrewCask) {
-        for package_name in targets.homebrew_cask {
-            let request = AdapterRequest::Upgrade(UpgradeRequest {
-                package: Some(PackageRef {
-                    manager: ManagerId::HomebrewCask,
-                    name: package_name,
-                }),
-                target_name: None,
-                version: None,
-            });
-            let _ = submit_request_wait(runtime, rt_handle, ManagerId::HomebrewCask, request)?;
-        }
-    }
-
-    if runtime.is_manager_enabled(ManagerId::Mas) {
-        for package_name in targets.mas {
-            let request = AdapterRequest::Upgrade(UpgradeRequest {
-                package: Some(PackageRef {
-                    manager: ManagerId::Mas,
-                    name: package_name,
-                }),
-                target_name: None,
-                version: None,
-            });
-            let _ = submit_request_wait(runtime, rt_handle, ManagerId::Mas, request)?;
-        }
-    }
-
-    for (manager, packages) in [
-        (ManagerId::Mise, targets.mise),
-        (ManagerId::Npm, targets.npm),
-        (ManagerId::Pnpm, targets.pnpm),
-        (ManagerId::Yarn, targets.yarn),
-        (ManagerId::Cargo, targets.cargo),
-        (ManagerId::CargoBinstall, targets.cargo_binstall),
-        (ManagerId::Pip, targets.pip),
-        (ManagerId::Pipx, targets.pipx),
-        (ManagerId::Poetry, targets.poetry),
-        (ManagerId::RubyGems, targets.rubygems),
-        (ManagerId::Bundler, targets.bundler),
-        (ManagerId::Rustup, targets.rustup),
-    ] {
-        if !runtime.is_manager_enabled(manager) {
-            continue;
-        }
-        for package_name in packages {
-            let request = AdapterRequest::Upgrade(UpgradeRequest {
-                package: Some(PackageRef {
-                    manager,
-                    name: package_name,
-                }),
-                target_name: None,
-                version: None,
-            });
-            let _ = submit_request_wait(runtime, rt_handle, manager, request)?;
-        }
-    }
-
-    if allow_os_updates
-        && targets.softwareupdate_outdated
-        && runtime.is_manager_enabled(ManagerId::SoftwareUpdate)
-        && !runtime.is_safe_mode()
+    let manager_scope_id = manager_id.unwrap_or(ALL_MANAGERS_UPGRADE_SCOPE);
+    if manager_scope_id != ALL_MANAGERS_UPGRADE_SCOPE
+        && manager_scope_id.parse::<ManagerId>().is_err()
     {
-        let request = AdapterRequest::Upgrade(UpgradeRequest {
-            package: Some(PackageRef {
-                manager: ManagerId::SoftwareUpdate,
-                name: "__confirm_os_updates__".to_string(),
-            }),
-            target_name: None,
-            version: None,
-        });
-        let _ = submit_request_wait(runtime, rt_handle, ManagerId::SoftwareUpdate, request)?;
+        return Err(format!("unknown manager id '{manager_scope_id}'"));
+    }
+    let steps =
+        preview_upgrade_workflow_steps(include_pinned, allow_os_updates, manager_scope_id, "")
+            .map_err(str::to_string)?;
+    run_external_updates_workflow_steps(runtime, store, rt_handle, steps)
+}
+
+fn run_external_updates_workflow_steps(
+    runtime: &AdapterRuntime,
+    store: &SqliteStore,
+    rt_handle: &tokio::runtime::Handle,
+    steps: Vec<FfiUpgradePlanStep>,
+) -> Result<(), String> {
+    for step in steps {
+        let (manager, request, _) = upgrade_workflow_request(store, &step)
+            .ok_or_else(|| format!("invalid upgrade workflow step '{}'", step.step_id))?;
+        // The external coordinator retains the legacy synchronous transport, so execute its
+        // authority-ordered plan sequentially and wait for each task before the next step.
+        let _ = submit_request_wait(runtime, rt_handle, manager, request)?;
     }
 
     Ok(())
@@ -7346,6 +7367,393 @@ pub extern "C" fn helm_preview_upgrade_plan(
     }
 }
 
+const ALL_MANAGERS_UPGRADE_SCOPE: &str = "__all_managers__";
+
+fn upgrade_authority_rank(authority: &str) -> u8 {
+    match authority {
+        "authoritative" => 0,
+        "standard" => 1,
+        "guarded" => 2,
+        "detection_only" => 3,
+        _ => 4,
+    }
+}
+
+fn scoped_upgrade_workflow_steps(
+    mut steps: Vec<FfiUpgradePlanStep>,
+    manager_scope_id: &str,
+    package_filter: &str,
+) -> Vec<FfiUpgradePlanStep> {
+    let package_filter = package_filter.trim().to_ascii_lowercase();
+    steps.retain(|step| {
+        (manager_scope_id == ALL_MANAGERS_UPGRADE_SCOPE || manager_scope_id == step.manager_id)
+            && (package_filter.is_empty()
+                || step
+                    .package_name
+                    .to_ascii_lowercase()
+                    .contains(&package_filter)
+                || step
+                    .reason_label_key
+                    .to_ascii_lowercase()
+                    .contains(&package_filter))
+    });
+    steps.sort_by(|left, right| {
+        upgrade_authority_rank(&left.authority)
+            .cmp(&upgrade_authority_rank(&right.authority))
+            .then_with(|| left.order_index.cmp(&right.order_index))
+            .then_with(|| left.manager_id.cmp(&right.manager_id))
+            .then_with(|| left.package_name.cmp(&right.package_name))
+    });
+    steps
+}
+
+fn prune_expired_upgrade_workflow_reservations(
+    workflows: &mut std::collections::HashMap<String, Arc<UpgradeWorkflowControl>>,
+    now: Instant,
+) {
+    workflows.retain(|_, control| !control.is_expired_cancellation_reservation(now));
+}
+
+fn next_upgrade_workflow_id() -> String {
+    format!(
+        "upgrade-workflow-{}",
+        UPGRADE_WORKFLOW_COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn register_upgrade_workflow(
+    workflow_id: String,
+) -> Result<Option<Arc<UpgradeWorkflowControl>>, &'static str> {
+    let mut workflows = lock_or_recover(&UPGRADE_WORKFLOWS, "upgrade_workflows");
+    prune_expired_upgrade_workflow_reservations(&mut workflows, Instant::now());
+    let completed = lock_or_recover(&COMPLETED_UPGRADE_WORKFLOWS, "completed_upgrade_workflows");
+    if let Some(control) = workflows.get(&workflow_id).cloned() {
+        return Ok(control.start_once().then_some(control));
+    }
+    if completed
+        .iter()
+        .any(|completed_id| completed_id == &workflow_id)
+    {
+        return Ok(None);
+    }
+    if !workflows.is_empty() {
+        return Err(SERVICE_ERROR_UNSUPPORTED_CAPABILITY);
+    }
+    let control = Arc::new(UpgradeWorkflowControl::new());
+    debug_assert!(control.start_once());
+    workflows.insert(workflow_id, control.clone());
+    Ok(Some(control))
+}
+
+fn finish_upgrade_workflow(workflow_id: &str) {
+    let mut workflows = lock_or_recover(&UPGRADE_WORKFLOWS, "upgrade_workflows");
+    let mut completed =
+        lock_or_recover(&COMPLETED_UPGRADE_WORKFLOWS, "completed_upgrade_workflows");
+    if workflows.remove(workflow_id).is_none() {
+        return;
+    }
+    completed.retain(|completed_id| completed_id != workflow_id);
+    completed.push_back(workflow_id.to_string());
+    while completed.len() > COMPLETED_UPGRADE_WORKFLOW_ID_LIMIT {
+        completed.pop_front();
+    }
+}
+
+fn preview_upgrade_workflow_steps(
+    include_pinned: bool,
+    allow_os_updates: bool,
+    manager_scope_id: &str,
+    package_filter: &str,
+) -> Result<Vec<FfiUpgradePlanStep>, &'static str> {
+    let plan = helm_preview_upgrade_plan(include_pinned, allow_os_updates);
+    if plan.is_null() {
+        return Err(SERVICE_ERROR_PROCESS_FAILURE);
+    }
+    let json = unsafe { CString::from_raw(plan) }
+        .into_string()
+        .map_err(|_| SERVICE_ERROR_PROCESS_FAILURE)?;
+    let steps = serde_json::from_str(&json).map_err(|_| SERVICE_ERROR_PROCESS_FAILURE)?;
+    Ok(scoped_upgrade_workflow_steps(
+        steps,
+        manager_scope_id,
+        package_filter,
+    ))
+}
+
+fn upgrade_workflow_request(
+    store: &SqliteStore,
+    step: &FfiUpgradePlanStep,
+) -> Option<(ManagerId, AdapterRequest, bool)> {
+    let manager = step.manager_id.parse::<ManagerId>().ok()?;
+    let cleanup_old_kegs = manager == ManagerId::HomebrewFormula
+        && effective_homebrew_keg_policy(store, &step.package_name) == HomebrewKegPolicy::Cleanup;
+    let package_name = if manager == ManagerId::HomebrewFormula {
+        encode_homebrew_upgrade_target(&step.package_name, cleanup_old_kegs)
+    } else {
+        step.package_name.clone()
+    };
+    Some((
+        manager,
+        AdapterRequest::Upgrade(UpgradeRequest {
+            package: Some(PackageRef {
+                manager,
+                name: package_name,
+            }),
+            target_name: None,
+            version: None,
+        }),
+        cleanup_old_kegs,
+    ))
+}
+
+async fn submit_upgrade_workflow_step(
+    runtime: &AdapterRuntime,
+    store: &SqliteStore,
+    step: &FfiUpgradePlanStep,
+    control: &UpgradeWorkflowControl,
+) -> Option<helm_core::models::TaskId> {
+    let (manager, request, cleanup_old_kegs) = upgrade_workflow_request(store, step)?;
+    match runtime.submit(manager, request).await {
+        Ok(task_id) => {
+            let (label_key, label_args) =
+                upgrade_task_label_for(manager, &step.package_name, cleanup_old_kegs);
+            set_task_label(task_id, label_key, &label_args);
+            if !control.admit_task(task_id) {
+                let _ = runtime.cancel(task_id, CancellationMode::Immediate).await;
+            }
+            Some(task_id)
+        }
+        Err(error) => {
+            eprintln!(
+                "scoped_upgrade_workflow: failed to queue {} upgrade '{}': {error}",
+                step.manager_id, step.package_name
+            );
+            None
+        }
+    }
+}
+
+fn start_scoped_upgrade_workflow(
+    include_pinned: bool,
+    allow_os_updates: bool,
+    workflow_id: String,
+    manager_scope_id: String,
+    package_filter: String,
+) -> Result<(), &'static str> {
+    if manager_scope_id != ALL_MANAGERS_UPGRADE_SCOPE
+        && manager_scope_id.parse::<ManagerId>().is_err()
+    {
+        return Err(SERVICE_ERROR_INVALID_INPUT);
+    }
+
+    let steps = preview_upgrade_workflow_steps(
+        include_pinned,
+        allow_os_updates,
+        &manager_scope_id,
+        &package_filter,
+    )?;
+    let (store, runtime, rt_handle) = {
+        let guard = lock_or_recover(&STATE, "state");
+        let state = guard.as_ref().ok_or(SERVICE_ERROR_INTERNAL)?;
+        (
+            state.store.clone(),
+            state.runtime.clone(),
+            state.rt_handle.clone(),
+        )
+    };
+    let Some(control) = register_upgrade_workflow(workflow_id.clone())? else {
+        return Ok(());
+    };
+    let finished_workflow_id = workflow_id.clone();
+
+    rt_handle.spawn(async move {
+        for authority_rank in 0..=4 {
+            if control.is_cancelled() {
+                break;
+            }
+            let phase_steps = steps
+                .iter()
+                .filter(|step| upgrade_authority_rank(&step.authority) == authority_rank);
+            let mut task_ids = Vec::new();
+            for step in phase_steps {
+                if control.is_cancelled() {
+                    break;
+                }
+                if let Some(task_id) =
+                    submit_upgrade_workflow_step(&runtime, &store, step, &control).await
+                {
+                    task_ids.push(task_id);
+                }
+            }
+            // Every submitted task reaches a terminal state before the next authority phase.
+            for task_id in task_ids {
+                let _ = runtime.wait_for_terminal(task_id, None).await;
+            }
+        }
+        finish_upgrade_workflow(&finished_workflow_id);
+    });
+
+    Ok(())
+}
+
+/// Start a manager/package-scoped bulk upgrade workflow and return its identifier.
+///
+/// The workflow submits individual package tasks in canonical authority phases and does not
+/// schedule a later phase until every submitted task in the current phase is terminal.
+///
+/// # Safety
+///
+/// `manager_scope_id` and `package_filter` must be valid, non-null UTF-8 C strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn helm_start_scoped_upgrade_workflow(
+    include_pinned: bool,
+    allow_os_updates: bool,
+    manager_scope_id: *const c_char,
+    package_filter: *const c_char,
+) -> *mut c_char {
+    clear_last_error_key();
+    let manager_scope_id = match unsafe { parse_required_cstr_arg(manager_scope_id) } {
+        Ok(value) => value,
+        Err(error) => return return_error_ptr(error),
+    };
+    let package_filter = if package_filter.is_null() {
+        return return_error_ptr(SERVICE_ERROR_INVALID_INPUT);
+    } else {
+        match unsafe { CStr::from_ptr(package_filter) }.to_str() {
+            Ok(value) => value.to_string(),
+            Err(_) => return return_error_ptr(SERVICE_ERROR_INVALID_INPUT),
+        }
+    };
+    let workflow_id = next_upgrade_workflow_id();
+    match start_scoped_upgrade_workflow(
+        include_pinned,
+        allow_os_updates,
+        workflow_id.clone(),
+        manager_scope_id,
+        package_filter,
+    ) {
+        Ok(()) => CString::new(workflow_id)
+            .map(CString::into_raw)
+            .unwrap_or_else(|_| return_error_ptr(SERVICE_ERROR_PROCESS_FAILURE)),
+        Err(error) => return_error_ptr(error),
+    }
+}
+
+/// Start a scoped bulk upgrade workflow using a caller-supplied stable identifier.
+///
+/// Repeating the same request ID is idempotent while the workflow is active. A cancellation
+/// received before its matching start request is retained and prevents task submission.
+///
+/// # Safety
+///
+/// All string arguments must be valid, non-null UTF-8 C strings.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn helm_start_scoped_upgrade_workflow_with_id(
+    workflow_id: *const c_char,
+    include_pinned: bool,
+    allow_os_updates: bool,
+    manager_scope_id: *const c_char,
+    package_filter: *const c_char,
+) -> bool {
+    clear_last_error_key();
+    let workflow_id = match unsafe { parse_required_cstr_arg(workflow_id) } {
+        Ok(value) => value,
+        Err(error) => return return_error_bool(error),
+    };
+    let manager_scope_id = match unsafe { parse_required_cstr_arg(manager_scope_id) } {
+        Ok(value) => value,
+        Err(error) => return return_error_bool(error),
+    };
+    let package_filter = if package_filter.is_null() {
+        return return_error_bool(SERVICE_ERROR_INVALID_INPUT);
+    } else {
+        match unsafe { CStr::from_ptr(package_filter) }.to_str() {
+            Ok(value) => value.to_string(),
+            Err(_) => return return_error_bool(SERVICE_ERROR_INVALID_INPUT),
+        }
+    };
+    start_scoped_upgrade_workflow(
+        include_pinned,
+        allow_os_updates,
+        workflow_id,
+        manager_scope_id,
+        package_filter,
+    )
+    .is_ok()
+}
+
+/// Stop a bulk upgrade workflow before it schedules another authority phase.
+/// Existing individual tasks remain cancellable through `helm_cancel_task`.
+///
+/// # Safety
+///
+/// `workflow_id` must be a valid, non-null UTF-8 C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn helm_cancel_upgrade_workflow(workflow_id: *const c_char) -> bool {
+    clear_last_error_key();
+    let workflow_id = match unsafe { parse_required_cstr_arg(workflow_id) } {
+        Ok(value) => value,
+        Err(error) => return return_error_bool(error),
+    };
+    let control = {
+        let mut workflows = lock_or_recover(&UPGRADE_WORKFLOWS, "upgrade_workflows");
+        prune_expired_upgrade_workflow_reservations(&mut workflows, Instant::now());
+        let completed =
+            lock_or_recover(&COMPLETED_UPGRADE_WORKFLOWS, "completed_upgrade_workflows");
+        if let Some(control) = workflows.get(&workflow_id).cloned() {
+            control
+        } else if completed
+            .iter()
+            .any(|completed_id| completed_id == &workflow_id)
+        {
+            return true;
+        } else {
+            // Retain an early cancellation briefly so a delayed start reply cannot lose control.
+            if !workflows.is_empty() {
+                return return_error_bool(SERVICE_ERROR_UNSUPPORTED_CAPABILITY);
+            }
+            let control = Arc::new(UpgradeWorkflowControl::cancelled_reservation(
+                Instant::now()
+                    + Duration::from_secs(UPGRADE_WORKFLOW_CANCELLATION_RESERVATION_SECS),
+            ));
+            workflows.insert(workflow_id, control.clone());
+            control
+        }
+    };
+    let task_ids = control.cancel();
+    if !task_ids.is_empty() {
+        let (runtime, rt_handle) = {
+            let guard = lock_or_recover(&STATE, "state");
+            let Some(state) = guard.as_ref() else {
+                return return_error_bool(SERVICE_ERROR_INTERNAL);
+            };
+            (state.runtime.clone(), state.rt_handle.clone())
+        };
+        rt_handle.spawn(async move {
+            for task_id in task_ids {
+                let _ = runtime.cancel(task_id, CancellationMode::Immediate).await;
+            }
+        });
+    }
+    true
+}
+
+/// Return whether a bulk upgrade workflow is still scheduling or waiting for a phase.
+///
+/// # Safety
+///
+/// `workflow_id` must be a valid, non-null UTF-8 C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn helm_is_upgrade_workflow_active(workflow_id: *const c_char) -> bool {
+    let workflow_id = match unsafe { parse_required_cstr_arg(workflow_id) } {
+        Ok(value) => value,
+        Err(_) => return false,
+    };
+    let mut workflows = lock_or_recover(&UPGRADE_WORKFLOWS, "upgrade_workflows");
+    prune_expired_upgrade_workflow_reservations(&mut workflows, Instant::now());
+    workflows.contains_key(&workflow_id)
+}
+
 /// Queue upgrade tasks for supported managers using cached outdated snapshot.
 ///
 /// - `include_pinned`: if false, pinned packages are excluded.
@@ -7354,9 +7762,25 @@ pub extern "C" fn helm_preview_upgrade_plan(
 pub extern "C" fn helm_upgrade_all(include_pinned: bool, allow_os_updates: bool) -> bool {
     clear_last_error_key();
     if external_coordinator_state_dir().is_some() {
+        return legacy_upgrade_all(include_pinned, allow_os_updates);
+    }
+    start_scoped_upgrade_workflow(
+        include_pinned,
+        allow_os_updates,
+        next_upgrade_workflow_id(),
+        ALL_MANAGERS_UPGRADE_SCOPE.to_string(),
+        String::new(),
+    )
+    .is_ok()
+}
+
+fn legacy_upgrade_all(include_pinned: bool, allow_os_updates: bool) -> bool {
+    clear_last_error_key();
+    if external_coordinator_state_dir().is_some() {
         return coordinator_start_workflow_external(CoordinatorWorkflowRequest::UpdatesRun {
             include_pinned,
             allow_os_updates,
+            manager_id: None,
         })
         .is_ok();
     }
@@ -10794,26 +11218,31 @@ pub unsafe extern "C" fn helm_free_string(s: *mut c_char) {
 #[cfg(test)]
 mod tests {
     use super::{
-        FfiUpgradePlanStep, SERVICE_ERROR_UNSUPPORTED_CAPABILITY, build_manager_statuses,
-        build_manager_uninstall_plan, build_manager_uninstall_preview, build_visible_tasks,
-        collect_upgrade_all_targets, homebrew_probe_candidates,
+        ALL_MANAGERS_UPGRADE_SCOPE, CoordinatorRequest, CoordinatorWorkflowRequest,
+        FfiUpgradePlanStep, SERVICE_ERROR_UNSUPPORTED_CAPABILITY, UpgradeWorkflowControl,
+        build_manager_statuses, build_manager_uninstall_plan, build_manager_uninstall_preview,
+        build_visible_tasks, collect_upgrade_all_targets, homebrew_probe_candidates,
         manager_allows_individual_package_install, manager_allows_individual_package_uninstall,
         manager_authority_key, manager_participates_in_catalog_sync,
         manager_participates_in_package_search, manager_uninstall_label_for_route,
-        parse_homebrew_config_version, push_upgrade_plan_step,
-        resolve_homebrew_manager_update_strategy, resolve_rustup_uninstall_strategy,
-        rustup_probe_candidates, search_label_args, search_label_key_for_query,
-        search_task_type_for_query, upgrade_plan_step_id, upgrade_reason_label_for,
-        upgrade_task_label_for,
+        parse_homebrew_config_version, prune_expired_upgrade_workflow_reservations,
+        push_upgrade_plan_step, resolve_homebrew_manager_update_strategy,
+        resolve_rustup_uninstall_strategy, run_external_updates_workflow_steps,
+        rustup_probe_candidates, scoped_upgrade_workflow_steps, search_label_args,
+        search_label_key_for_query, search_task_type_for_query, upgrade_plan_step_id,
+        upgrade_reason_label_for, upgrade_task_label_for,
     };
-    use helm_core::adapters::{AdapterRequest, ManagerAdapter, UninstallRequest};
+    use helm_core::adapters::{
+        AdapterRequest, AdapterResponse, ManagerAdapter, MutationResult, UninstallRequest,
+    };
     use helm_core::manager_policy::{
         PIP_SYSTEM_UNMANAGED_REASON_CODE, RUBYGEMS_SYSTEM_UNMANAGED_REASON_CODE,
     };
     use helm_core::models::{
-        AutomationLevel, DetectionInfo, InstallProvenance, InstalledPackage, ManagerId,
-        ManagerInstallInstance, OutdatedPackage, PackageRef, StrategyKind, TaskId, TaskLogRecord,
-        TaskRecord, TaskStatus, TaskType,
+        ActionSafety, AutomationLevel, Capability, DetectionInfo, InstallProvenance,
+        InstalledPackage, ManagerAction, ManagerAuthority, ManagerCategory, ManagerDescriptor,
+        ManagerId, ManagerInstallInstance, OutdatedPackage, PackageRef, StrategyKind, TaskId,
+        TaskLogRecord, TaskRecord, TaskStatus, TaskType,
     };
     use helm_core::orchestration::adapter_runtime::AdapterRuntime;
     use helm_core::persistence::{DetectionStore, ManagerPreference, PackageStore, TaskStore};
@@ -10828,7 +11257,7 @@ mod tests {
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
     use std::path::Path;
     use std::sync::{Arc, Mutex, OnceLock};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     #[cfg(unix)]
     fn unix_mode(path: &Path) -> u32 {
@@ -10974,6 +11403,59 @@ mod tests {
             .expect("clock should be after epoch")
             .as_nanos();
         std::env::temp_dir().join(format!("helm-ffi-{name}-{nanos}"))
+    }
+
+    const RECORDING_UPGRADE_CAPABILITIES: &[Capability] = &[Capability::Upgrade];
+
+    struct RecordingUpgradeAdapter {
+        descriptor: ManagerDescriptor,
+        executed_steps: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl RecordingUpgradeAdapter {
+        fn new(manager: ManagerId, executed_steps: Arc<Mutex<Vec<String>>>) -> Self {
+            Self {
+                descriptor: ManagerDescriptor {
+                    id: manager,
+                    display_name: "Recording Upgrade Adapter",
+                    category: ManagerCategory::Language,
+                    authority: ManagerAuthority::Standard,
+                    capabilities: RECORDING_UPGRADE_CAPABILITIES,
+                },
+                executed_steps,
+            }
+        }
+    }
+
+    impl ManagerAdapter for RecordingUpgradeAdapter {
+        fn descriptor(&self) -> &ManagerDescriptor {
+            &self.descriptor
+        }
+
+        fn action_safety(&self, action: ManagerAction) -> ActionSafety {
+            action.safety()
+        }
+
+        fn execute(
+            &self,
+            request: AdapterRequest,
+        ) -> helm_core::adapters::AdapterResult<AdapterResponse> {
+            let AdapterRequest::Upgrade(request) = request else {
+                panic!("recording adapter only accepts upgrade requests");
+            };
+            let package = request.package.expect("legacy workflow targets a package");
+            self.executed_steps
+                .lock()
+                .expect("recording lock should not be poisoned")
+                .push(format!("{}:{}", package.manager.as_str(), package.name));
+            Ok(AdapterResponse::Mutation(MutationResult {
+                package,
+                package_identifier: None,
+                action: ManagerAction::Upgrade,
+                before_version: Some("1.0.0".to_string()),
+                after_version: Some("2.0.0".to_string()),
+            }))
+        }
     }
 
     #[test]
@@ -12094,6 +12576,264 @@ mod tests {
         assert_eq!(steps[0].authority, manager_authority_key(ManagerId::Npm));
         assert_eq!(steps[1].step_id, "softwareupdate:__confirm_os_updates__");
         assert_eq!(steps[1].order_index, 1);
+    }
+
+    #[test]
+    fn scoped_upgrade_workflow_uses_authority_order_and_raw_package_filter() {
+        let mut steps = Vec::new();
+        let mut order_index = 0;
+        push_upgrade_plan_step(
+            &mut steps,
+            ManagerId::HomebrewFormula,
+            "git".to_string(),
+            false,
+            &mut order_index,
+        );
+        push_upgrade_plan_step(
+            &mut steps,
+            ManagerId::Npm,
+            "typescript".to_string(),
+            false,
+            &mut order_index,
+        );
+        push_upgrade_plan_step(
+            &mut steps,
+            ManagerId::Rustup,
+            "stable".to_string(),
+            false,
+            &mut order_index,
+        );
+
+        let ordered = scoped_upgrade_workflow_steps(steps.clone(), ALL_MANAGERS_UPGRADE_SCOPE, "");
+        assert_eq!(
+            ordered
+                .into_iter()
+                .map(|step| step.manager_id)
+                .collect::<Vec<_>>(),
+            vec!["rustup", "npm", "homebrew_formula"]
+        );
+
+        let filtered = scoped_upgrade_workflow_steps(steps, ALL_MANAGERS_UPGRADE_SCOPE, "SCRIPT");
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].step_id, "npm:typescript");
+    }
+
+    #[test]
+    fn scoped_upgrade_workflow_honors_manager_scope() {
+        let mut steps = Vec::new();
+        let mut order_index = 0;
+        push_upgrade_plan_step(
+            &mut steps,
+            ManagerId::Rustup,
+            "stable".to_string(),
+            false,
+            &mut order_index,
+        );
+        push_upgrade_plan_step(
+            &mut steps,
+            ManagerId::Npm,
+            "typescript".to_string(),
+            false,
+            &mut order_index,
+        );
+
+        let scoped = scoped_upgrade_workflow_steps(steps, "npm", "");
+        assert_eq!(scoped.len(), 1);
+        assert_eq!(scoped[0].step_id, "npm:typescript");
+    }
+
+    #[test]
+    fn expired_upgrade_workflow_cancellation_reservation_is_pruned() {
+        let mut workflows = HashMap::new();
+        let now = Instant::now();
+        workflows.insert(
+            "never-started".to_string(),
+            Arc::new(UpgradeWorkflowControl::cancelled_reservation(now)),
+        );
+
+        prune_expired_upgrade_workflow_reservations(&mut workflows, now);
+
+        assert!(workflows.is_empty());
+    }
+
+    #[test]
+    fn unexpired_upgrade_workflow_cancellation_reservation_cancels_delayed_start() {
+        let now = Instant::now();
+        let control = UpgradeWorkflowControl::cancelled_reservation(now + Duration::from_secs(1));
+
+        assert!(!control.is_expired_cancellation_reservation(now));
+        assert!(control.start_once());
+        assert!(control.is_cancelled());
+    }
+
+    #[test]
+    fn cancelled_upgrade_workflow_rejects_late_task_admission() {
+        let control = UpgradeWorkflowControl::new();
+        assert!(control.admit_task(TaskId(41)));
+        assert_eq!(control.cancel(), vec![TaskId(41)]);
+        assert!(!control.admit_task(TaskId(42)));
+    }
+
+    #[test]
+    fn supplied_upgrade_workflow_id_is_idempotent_after_early_cancellation() {
+        let control = UpgradeWorkflowControl::new();
+        assert!(control.cancel().is_empty());
+        assert!(control.start_once());
+        assert!(!control.start_once());
+        assert!(control.is_cancelled());
+    }
+
+    #[test]
+    fn external_updates_run_request_deserializes_with_cli_wire_contract() {
+        #[derive(serde::Deserialize)]
+        #[serde(tag = "kind", rename_all = "snake_case")]
+        enum CliCoordinatorRequest {
+            StartWorkflow {
+                workflow: CliCoordinatorWorkflowRequest,
+            },
+        }
+
+        #[derive(serde::Deserialize)]
+        #[serde(tag = "kind", rename_all = "snake_case")]
+        enum CliCoordinatorWorkflowRequest {
+            UpdatesRun {
+                include_pinned: bool,
+                allow_os_updates: bool,
+                manager_id: Option<String>,
+            },
+        }
+
+        let request = CoordinatorRequest::StartWorkflow {
+            workflow: CoordinatorWorkflowRequest::UpdatesRun {
+                include_pinned: true,
+                allow_os_updates: false,
+                manager_id: None,
+            },
+        };
+        let encoded = serde_json::to_string(&request).expect("FFI request should serialize");
+        let decoded: CliCoordinatorRequest =
+            serde_json::from_str(&encoded).expect("CLI should deserialize FFI request");
+
+        match decoded {
+            CliCoordinatorRequest::StartWorkflow {
+                workflow:
+                    CliCoordinatorWorkflowRequest::UpdatesRun {
+                        include_pinned,
+                        allow_os_updates,
+                        manager_id,
+                    },
+            } => {
+                assert!(include_pinned);
+                assert!(!allow_os_updates);
+                assert_eq!(manager_id, None);
+            }
+        }
+    }
+
+    #[test]
+    fn external_updates_run_request_preserves_manager_scope() {
+        #[derive(serde::Deserialize)]
+        #[serde(tag = "kind", rename_all = "snake_case")]
+        enum CliCoordinatorRequest {
+            StartWorkflow {
+                workflow: CliCoordinatorWorkflowRequest,
+            },
+        }
+
+        #[derive(serde::Deserialize)]
+        #[serde(tag = "kind", rename_all = "snake_case")]
+        enum CliCoordinatorWorkflowRequest {
+            UpdatesRun { manager_id: Option<String> },
+        }
+
+        let request = CoordinatorRequest::StartWorkflow {
+            workflow: CoordinatorWorkflowRequest::UpdatesRun {
+                include_pinned: false,
+                allow_os_updates: false,
+                manager_id: Some("npm".to_string()),
+            },
+        };
+        let encoded = serde_json::to_string(&request).expect("FFI request should serialize");
+        let decoded: CliCoordinatorRequest =
+            serde_json::from_str(&encoded).expect("CLI should deserialize FFI request");
+
+        match decoded {
+            CliCoordinatorRequest::StartWorkflow {
+                workflow: CliCoordinatorWorkflowRequest::UpdatesRun { manager_id },
+            } => assert_eq!(manager_id.as_deref(), Some("npm")),
+        }
+    }
+
+    #[test]
+    fn external_updates_workflow_executes_authority_ordered_steps() {
+        let store = temp_sqlite_store("external-updates-authority-order");
+        store
+            .migrate_to_latest()
+            .expect("sqlite migrations should apply");
+        let executed_steps = Arc::new(Mutex::new(Vec::new()));
+        let runtime = AdapterRuntime::new(vec![
+            Arc::new(RecordingUpgradeAdapter::new(
+                ManagerId::Rustup,
+                executed_steps.clone(),
+            )) as Arc<dyn ManagerAdapter>,
+            Arc::new(RecordingUpgradeAdapter::new(
+                ManagerId::Npm,
+                executed_steps.clone(),
+            )) as Arc<dyn ManagerAdapter>,
+            Arc::new(RecordingUpgradeAdapter::new(
+                ManagerId::HomebrewFormula,
+                executed_steps.clone(),
+            )) as Arc<dyn ManagerAdapter>,
+        ])
+        .expect("recording adapter runtime should initialize");
+        let tokio_runtime =
+            tokio::runtime::Runtime::new().expect("tokio runtime should initialize");
+
+        let mut unsorted_steps = Vec::new();
+        let mut order_index = 0;
+        push_upgrade_plan_step(
+            &mut unsorted_steps,
+            ManagerId::HomebrewFormula,
+            "git".to_string(),
+            false,
+            &mut order_index,
+        );
+        push_upgrade_plan_step(
+            &mut unsorted_steps,
+            ManagerId::Npm,
+            "typescript".to_string(),
+            false,
+            &mut order_index,
+        );
+        push_upgrade_plan_step(
+            &mut unsorted_steps,
+            ManagerId::Rustup,
+            "stable".to_string(),
+            false,
+            &mut order_index,
+        );
+
+        let authority_ordered_steps =
+            scoped_upgrade_workflow_steps(unsorted_steps, ALL_MANAGERS_UPGRADE_SCOPE, "");
+        run_external_updates_workflow_steps(
+            &runtime,
+            &store,
+            tokio_runtime.handle(),
+            authority_ordered_steps,
+        )
+        .expect("external updates workflow should execute every step");
+
+        assert_eq!(
+            *executed_steps
+                .lock()
+                .expect("recording lock should not be poisoned"),
+            vec![
+                "rustup:stable".to_string(),
+                "npm:typescript".to_string(),
+                "homebrew_formula:git".to_string(),
+            ]
+        );
+        let _ = fs::remove_file(store.database_path());
     }
 
     #[test]

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,15 +8,16 @@ It reflects reality, not intention.
 
 ## Version
 
-Current documentation baseline: **0.17.11 stable released on `main`** with `0.18.x` planning active on `dev`.
+Current documentation baseline: **0.17.11 stable released on `main`**; a focused `0.17.12` authority-ordering correction is pending before `0.18.x` work resumes on `dev`.
 
-Implementation baseline: **0.18.x planning on `dev`** after diagnostics/logging delivery, package workflow hardening, manager-selection/enablement and onboarding/detection hardening, release-process hardening phases 1-5, post-`v0.17.5` refresh reliability/diagnostics hardening, complete current-scope manager adapter coverage, and local doctor/repair follow-up for executable-path drift.
+Implementation baseline: **pending `0.17.12` patch validation on `dev`**, followed by `0.18.x` planning, after diagnostics/logging delivery, package workflow hardening, manager-selection/enablement and onboarding/detection hardening, release-process hardening phases 1-5, current-scope manager adapter completion, and local doctor/repair follow-up for executable-path drift.
 
 See:
 - CHANGELOG.md
 
 Active milestone:
 - latest stable release currently published on `main`: **0.17.11** (released on 2026-07-28)
+- pending `v0.17.12` corrective patch: bulk and scoped upgrade workflows now execute authority phases in Rust/FFI/XPC; every submitted task reaches a terminal state before the next phase is scheduled, and scoped-workflow cancellation prevents later-phase submission while preserving individual task cancellation and diagnostics.
 - next integration target on `dev`: **0.18.x** (broader doctor/repair foundation and local security groundwork sequencing)
 - repository operations follow-up on `dev`: repository-local Codex operating model refined for lean context (`project_doc_max_bytes=131072`), policy-only root `AGENTS.md`, workflow Skills under `ops/codex/skills/`, slash-command templates under `.codex/commands/`, and structured local notify logging to `dev/logs/codex-runs.ndjson`.
 - latest stable publication cut completed for `v0.17.11`:

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -716,6 +716,32 @@ Initial implemented scope:
 - Avoiding native lockfile deletion preserves Homebrew's ownership and locking guarantees.
 
 ---
+## Decision 038 — Backend-Owned Upgrade Workflows and Deferred Transport Refinement
+
+**Decision:**
+Bulk and scoped upgrade workflows are owned by the Rust execution boundary. SwiftUI sends scoped intent and presents state; it does not schedule authority phases, use UI task projections to determine completion, or decide when downstream manager work may start.
+
+Implemented in the pending `v0.17.12` patch:
+
+- bulk and scoped workflows derive the current safe upgrade plan in Rust/FFI;
+- managers are scheduled by canonical authority phase;
+- all submitted tasks in one phase become terminal before the next phase is scheduled;
+- scoped-workflow cancellation prevents future phase submission while per-task cancellation remains process-backed and observable; pre-start caller-supplied cancellation IDs reserve cancellation only for a bounded window so abandoned IDs cannot block future workflows.
+
+Deferred architecture work:
+
+- `0.19.x`: add revision-aware snapshots and evaluate narrowly scoped event delivery, with reconnect/replay/ordering/backpressure tests before reducing polling;
+- `0.19.x`: consolidate related XPC operations through additive versioned contracts, without a disruptive boundary rewrite;
+- `1.1.x` reassessment: consider incremental SwiftUI state-container/reducer extraction only if post-1.0 operational evidence justifies it;
+- runtime-loadable manager adapters remain out of scope through 1.0. Static registry registration remains the safety and reviewability baseline.
+
+**Rationale:**
+
+- Authority ordering and cancellation are execution policy and must be consistent across GUI, CLI, TUI, and direct FFI callers.
+- Adaptive polling is acceptable until a transport design proves it can preserve service-reconnection and state-consistency guarantees.
+- A pre-1.0 state-management rewrite or plugin architecture would add broad risk without resolving a demonstrated correctness defect.
+
+---
 ## Summary
 
 Helm prioritizes:

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -66,6 +66,8 @@ The XPC layer must support, at minimum:
 - Manager self-update (where supported)
 - Cancel task (best-effort + process-level where possible)
 
+Bulk upgrade workflows are backend-owned. UI may provide manager/package scope as an intent and render workflow/task state, but it must not sequence authority phases or infer task completion to schedule downstream managers. The service returns individual task handles and may return a workflow handle for scoped cancellation; individual task logs and terminal output remain the source of execution transparency.
+
 ### 2.3 Versioning
 
 - If the XPC protocol changes materially, record it in `docs/DECISIONS.md`.
@@ -109,6 +111,7 @@ FFI must expose functions sufficient for:
 - get/set language override
 - get/set manager enablement
 - upgrade-all confirmation token flow (see §6)
+- start/cancel/query scoped upgrade workflows without exposing UI-owned phase state
 
 ### 3.3 Data Encoding
 

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -11,10 +11,11 @@ It is intentionally tactical.
 Helm is in:
 
 ```
-0.18.x planning on `dev` (post-v0.17.11 stable release)
+v0.17.12 patch validation on `dev`, then 0.18.x planning (post-v0.17.11 stable release)
 ```
 
 Focus:
+- complete the focused `v0.17.12` corrective patch: retain bulk/scoped upgrade authority sequencing, workflow cancellation, and task visibility in Rust/FFI/XPC rather than SwiftUI
 - keep `main`/`dev`/`docs`/`web` release-state docs and version markers aligned now that `v0.17.11` is published
 - maintain release-process hardening guardrails now that phases 1-5 are complete (preflight, publish verification, drift prevention)
 - preserve manager-specific expected nonzero update-check outcomes as completed refreshes with actionable outdated state, starting with rustup's exit code `100`
@@ -27,6 +28,7 @@ Focus:
 
 Current checkpoint:
 - `v0.17.11` is the current stable release on `main`; current-scope manager adapter completion, final stable-line hardening, and package workflow hardening are now published:
+  - pending `v0.17.12` correction moves bulk and scoped upgrade phase coordination out of SwiftUI. The backend derives the current safe plan, schedules authority phases, waits for each phase to reach terminal state, and stops later-phase scheduling on scoped-workflow cancellation; individual tasks remain the live execution and diagnostics surface.
   - all current manager adapters are considered complete for Helm's intended scope
   - intentionally narrower manager scopes remain explicit (`nix_darwin` detect/refresh-only; detection-only adapters such as `sparkle`, `setapp`, and `parallels_desktop`; guarded/status adapters such as `docker_desktop`, `podman`, `colima`, `rosetta2`, `firmware_updates`, and `xcode_command_line_tools`)
   - no additional manager-adapter implementation gaps remain beyond those intentional product boundaries

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -58,6 +58,21 @@ This checklist is required before creating a release tag on `main`.
   - `CLI Update Metadata Drift Guard`
 - [ ] Review `TMP_RELEASE_FRICTION`; promote recurring friction items into durable docs (`docs/DECISIONS.md`, `docs/operations/CLI_RELEASE_AND_CI.md`) and keep temporary notes uncommitted.
 
+## v0.17.12 (Stable Patch Release Gate, Pending)
+
+### Scope
+
+- [x] Bulk and scoped upgrade authority sequencing is backend-owned through Rust/FFI/XPC rather than SwiftUI polling.
+- [x] Individual upgrade task records, `plan_step_id` labels, terminal output, and per-task cancellation remain visible through existing diagnostics surfaces.
+- [x] Scoped-workflow cancellation blocks future authority-phase submission.
+- [x] Website current-version markers are aligned to the published `v0.17.11` baseline and identify `v0.17.12` as pending validation.
+
+### Required Validation
+
+- [ ] Verify authoritative tasks reach terminal state before standard or guarded bulk-upgrade tasks are submitted.
+- [ ] Verify scoped-workflow cancellation prevents later-phase scheduling and individual in-flight tasks remain cancellable.
+- [ ] Run the required preflight, rehearsal, canary, and publish-auth gates from `docs/operations/RELEASE_FLOW.md` before tag creation.
+
 ## v0.17.10 (Stable Patch Release Gate, Completed)
 
 - Published on `main` on 2026-03-11 with tag, release metadata, and post-publication verification complete.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -543,6 +543,22 @@ Exit Criteria:
 
 ---
 
+## v0.17.12 — Upgrade Workflow Authority Correction (pending patch)
+
+Goal:
+
+- Move bulk and scoped upgrade phase sequencing from SwiftUI into the Rust execution boundary.
+- Preserve individual task records, `plan_step_id` labels, cancellation, and diagnostics visibility.
+- Ensure authoritative manager work reaches terminal state before standard or guarded work is scheduled.
+
+Exit Criteria:
+
+- GUI bulk, scoped, and manager-scoped upgrades use the same backend workflow path.
+- Workflow cancellation prevents future authority-phase submission and retains existing in-flight task cancellation.
+- Regression coverage verifies phase ordering and scoped package filtering.
+
+---
+
 ## 0.18.x — Doctor & Repair Foundation (rc)
 
 Goal:
@@ -637,6 +653,8 @@ Goal:
 - Logging refinement
 - Crash recovery validation
 - No known race conditions
+- Introduce revision-aware snapshot transport and evaluate event delivery only where it reduces polling without weakening reconnect, ordering, replay, or backpressure guarantees.
+- Consolidate related XPC reads/actions behind additive, versioned request/response contracts; retain compatibility until all surfaces migrate.
 - Memory safety audit
 - i18n validation:
   - key parity across locales
@@ -655,6 +673,7 @@ Exit Criteria:
 - No unhandled panics
 - Stable FFI boundary
 - Deterministic execution verified
+- Snapshot revision/reconnect behavior and consolidated XPC contracts are covered by integration tests.
 
 ---
 
@@ -682,6 +701,7 @@ Goal:
 - Localization coverage for all UI surfaces
 - Website localization
 - Documentation localization (partial)
+- Reassess SwiftUI state ownership after 1.0 operational data is available. A reducer/store rewrite is not a pre-1.0 goal; any change must be incremental and preserve the presentation-only boundary.
 
 Exit Criteria:
 

--- a/docs/ui/SWIFTUI_ARCHITECTURE.md
+++ b/docs/ui/SWIFTUI_ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 This document describes the current SwiftUI architecture of the Helm macOS app.
 
-It reflects the actual implementation as of v0.14.0.
+It reflects the implementation pending `v0.17.12` patch validation.
 
 ---
 
@@ -51,7 +51,7 @@ Helm uses **shared singleton `ObservableObject` instances** — not view models 
 
 | Instance | Type | Access Pattern | Role |
 |----------|------|---------------|------|
-| `HelmCore.shared` | `ObservableObject` | `@ObservedObject` / `@StateObject` | All data, XPC communication, business logic |
+| `HelmCore.shared` | `ObservableObject` | `@ObservedObject` / `@StateObject` | UI state, XPC communication, intent dispatch, and presentation projections |
 | `ControlCenterContext()` | `ObservableObject` | `@EnvironmentObject` | UI navigation, selection, overlay routing |
 | `WalkthroughManager.shared` | `ObservableObject` | `@ObservedObject` | Onboarding walkthrough orchestration |
 | `LocalizationManager.shared` | `ObservableObject` | `@ObservedObject` | Locale loading and string resolution |
@@ -67,6 +67,8 @@ Helm uses **shared singleton `ObservableObject` instances** — not view models 
 | `Core/HelmCore+Actions.swift` | Mutation methods: `upgradePackage()`, `cancelTask()`, `togglePackagePin()`, manager operations |
 | `Core/HelmCore+Fetching.swift` | XPC data fetching: `fetchPackages()`, `fetchTasks()`, `fetchManagerStatus()`, `fetchSearchResults()` |
 | `Core/HelmCore+Settings.swift` | Settings: safe mode, keg cleanup, keg policies, manager enable/disable |
+
+`HelmCore` is a presentation coordinator, not an execution orchestrator. In particular, bulk and scoped upgrade intents are sent to the XPC/Rust workflow path; SwiftUI renders task and workflow state but does not sequence authority phases or poll for phase completion to schedule subsequent managers.
 
 ### ControlCenterContext
 

--- a/scripts/release/rehearsal_dry_run.sh
+++ b/scripts/release/rehearsal_dry_run.sh
@@ -163,8 +163,9 @@ prepare_paths() {
     REPORT_PATH="${ROOT_DIR}/${REPORT_PATH}"
   fi
 
-  REPORT_DIR="$(cd "$(dirname "$REPORT_PATH")" && pwd)"
+  REPORT_DIR="$(dirname "$REPORT_PATH")"
   mkdir -p "$REPORT_DIR"
+  REPORT_DIR="$(cd "$REPORT_DIR" && pwd)"
 
   LOG_DIR="${REPORT_DIR}/logs-${tag_slug}-${stamp}"
   mkdir -p "$LOG_DIR"

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -17,7 +17,7 @@ Helm is planned as two product lifecycles: **Helm (Consumer)** and **Helm Busine
 
 ## What it does today
 
-Helm `v0.17.10` supports twenty-eight managers:
+Helm `v0.17.11` supports twenty-eight managers:
 
 | Category | Managers |
 |---------|----------|
@@ -45,7 +45,7 @@ Key features:
 - **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, `ja`, and `hu` with locale override in Settings
 - **Upgrade transparency** — dedicated upgrade preview surface with scoped execution and failure-attribution visibility
 
-> **Current Track:** `v0.17.10` is the latest stable release on `main`; `0.18.x` planning is in progress. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.17.11` is the latest stable release on `main`; a focused `v0.17.12` corrective patch is in validation before `0.18.x` work resumes. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## How it works
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -31,9 +31,9 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 | 0.14.x | Platform, Detection & Optional Managers — Docker, Xcode, Rosetta, Sparkle, Setapp, Homebrew casks, optional managers (`v0.14.x` stable, latest patch `v0.14.1`) |
 | 0.15.x | Advanced Upgrade Transparency — richer execution-plan visibility, failure isolation, and operator controls (`v0.15.0` released) |
 | 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification (`v0.16.x` stable, latest patch `v0.16.2`) |
-| 0.17.x | Diagnostics & Logging + Release Hardening — task log viewer, structured diagnostics export, manager-detection diagnostics, onboarding/detection hardening, manager-selection controls, and stable release follow-up fixes (`v0.17.0` stable, latest patch `v0.17.10`) |
+| 0.17.x | Diagnostics & Logging + Release Hardening — task log viewer, structured diagnostics export, manager-detection diagnostics, onboarding/detection hardening, manager-selection controls, and stable release follow-up fixes (`v0.17.0` stable, latest patch `v0.17.11`) |
 
-> **Current Track:** `v0.17.10` is stable on `main`; planning is shifting to `0.18.x` local security groundwork. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.17.11` is stable on `main`; a focused `v0.17.12` authority-ordering correction is in validation before `0.18.x` local security groundwork. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Planned
 


### PR DESCRIPTION
## Summary

- Move bulk and scoped upgrade authority sequencing into the Rust/FFI/XPC execution boundary.
- Preserve task-level cancellation, diagnostics, and manager/package-scoped workflows.
- Prepare the final `0.17.x` patch as version `0.17.12`, including release documentation and a rehearsal report-path fix.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- macOS Xcode test suite and signed universal Release build
- `codesign --verify --deep --strict --verbose=2 Helm.app`
- `scripts/release/rehearsal_dry_run.sh --tag v0.17.12`
- `scripts/release/check_release_line_copy.sh`

Public appcast and CLI update metadata intentionally remain at the published `0.17.11` baseline until the `v0.17.12` tag is created and publication is explicitly approved.
