### PR TITLE
fix(release): avoid Xcode runtime probe broken pipe

### DIFF
--- a/.github/workflows/release-macos-dmg.yml
+++ b/.github/workflows/release-macos-dmg.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           set -euo pipefail
           MACOS_VERSION="$(sw_vers -productVersion)"
-          XCODE_VERSION="$(xcodebuild -version | awk '/^Xcode / {print $2; exit}')"
+          XCODE_VERSION="$(xcodebuild -version | awk '/^Xcode / {print $2}')"
           XCODE_MAJOR="${XCODE_VERSION%%.*}"
           SOURCE_TAG_SHA="$(git rev-parse HEAD)"
 


### PR DESCRIPTION
## Summary

- Fix the `macos-26` release runtime probe to avoid an Xcode 26 broken-pipe abort.
- Preserve the immutable `v0.17.12` tag; after merge, rerun the affected DMG workflow for that tag.

## Validation

- `scripts/release/tests/release_workflow_contract.sh`
- `xcodebuild -version | awk '/^Xcode / {print $2}'`

The first DMG workflow run failed before building or uploading artifacts. The direct CLI workflow already uploaded its artifacts and opened its normal metadata publish PR.
