### PR TITLE
docs(release): align v0.17.12 markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <br>
   A macOS control center and CLI for unified package manager control.
   <br>
-  <strong>Pre-1.0 &middot; v0.17.11</strong>
+  <strong>Pre-1.0 &middot; v0.17.12</strong>
 </p>
 
 <p align="center">
@@ -23,9 +23,9 @@
 
 Helm manages software across multiple package managers (Homebrew, npm, pip, Cargo, etc.) and runtime tools (mise, rustup) from a single menu bar interface. It is designed as infrastructure software: deterministic, safety-first, and explicit about authority, orchestration, and error handling.
 
-> **Status:** Active pre-1.0 development with stable `v0.17.11` on `main` and `0.18.x` planning on `dev`.
+> **Status:** Active pre-1.0 development with stable `v0.17.12` on `main` and `0.18.x` planning on `dev`.
 >
-> **Testing:** Please test `v0.17.11` and report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Testing:** Please test `v0.17.12` and report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Editions (Beta)
 

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,20 +8,20 @@ It reflects reality, not intention.
 
 ## Version
 
-Current documentation baseline: **0.17.11 stable released on `main`**; a focused `0.17.12` authority-ordering correction is pending before `0.18.x` work resumes on `dev`.
+Current documentation baseline: **0.17.12 stable released on `main`**; `0.18.x` work resumes on `dev`.
 
-Implementation baseline: **pending `0.17.12` patch validation on `dev`**, followed by `0.18.x` planning, after diagnostics/logging delivery, package workflow hardening, manager-selection/enablement and onboarding/detection hardening, release-process hardening phases 1-5, current-scope manager adapter completion, and local doctor/repair follow-up for executable-path drift.
+Implementation baseline: **0.18.x planning on `dev`** after diagnostics/logging delivery, package workflow hardening, manager-selection/enablement and onboarding/detection hardening, release-process hardening phases 1-5, current-scope manager adapter completion, and local doctor/repair follow-up for executable-path drift.
 
 See:
 - CHANGELOG.md
 
 Active milestone:
-- latest stable release currently published on `main`: **0.17.11** (released on 2026-07-28)
-- pending `v0.17.12` corrective patch: bulk and scoped upgrade workflows now execute authority phases in Rust/FFI/XPC; every submitted task reaches a terminal state before the next phase is scheduled, and scoped-workflow cancellation prevents later-phase submission while preserving individual task cancellation and diagnostics.
+- latest stable release currently published on `main`: **0.17.12** (released on 2026-07-29)
+- `v0.17.12` moves bulk and scoped upgrade authority sequencing into Rust/FFI/XPC; every submitted task reaches a terminal state before the next phase is scheduled, and scoped-workflow cancellation prevents later-phase submission while preserving individual task cancellation and diagnostics.
 - next integration target on `dev`: **0.18.x** (broader doctor/repair foundation and local security groundwork sequencing)
 - repository operations follow-up on `dev`: repository-local Codex operating model refined for lean context (`project_doc_max_bytes=131072`), policy-only root `AGENTS.md`, workflow Skills under `ops/codex/skills/`, slash-command templates under `.codex/commands/`, and structured local notify logging to `dev/logs/codex-runs.ndjson`.
-- latest stable publication cut completed for `v0.17.11`:
-  - workspace, docs, website, appcast, and CLI metadata now reflect the published `0.17.11` stable line.
+- latest stable publication cut completed for `v0.17.12`:
+  - workspace, docs, website, appcast, and CLI metadata now reflect the published `0.17.12` stable line.
   - release automation follow-through and publish verification completed on `main`.
   - post-release rustup refresh correction: `rustup check` exit code `100` now represents detected toolchain updates rather than a failed refresh, and current lowercase output grammar is parsed into outdated toolchains.
 - 0.17.x — Diagnostics & Logging (**stable released on `main`**, RC lineage `v0.17.0-rc.1` through `v0.17.0-rc.5`)
@@ -98,6 +98,8 @@ Active milestone:
   - delivered: GitHub governance hardening follow-up (on `dev`): per-branch rulesets are now explicit for `main`/`dev`/`docs`/`web` with branch-specific required checks; new `Policy Gate` + `Docs Checks` + `Web Build` workflows enforce branch targeting/scope policy; repository merge settings keep auto-merge/update-branch enabled while delete-branch-on-merge stays off to protect primary branches; blocking ruleset `update` enforcement was removed after protected-ref merge-block diagnostics; CodeQL is now main-focused (push/schedule/manual) to avoid PR gate friction.
   - `v0.17.11` stable release execution status: released on `main` with tag, publish metadata, and verification complete.
   - delivered for `v0.17.11`: task terminal transitions and request/response persistence now preserve final results deterministically; Homebrew formula and cask work share one execution lease; XPC connections reuse one service runtime; system-manager helper paths are canonicalized before selection; release, cancellation, MacPorts, and XPC hardening close the release line.
+  - `v0.17.12` stable release execution status: released on `main` with tag, notarized DMG and CLI assets, published appcast and CLI metadata, and post-publication verification complete.
+  - delivered for `v0.17.12`: bulk and scoped upgrade workflow sequencing is backend-owned, authority phases wait for submitted tasks to become terminal, and scoped cancellation prevents later-phase submission.
 
 Security rollout staging status:
 - Stage 0 (`<=0.16.x`): planning/docs only (active in `0.16.1`)
@@ -1015,4 +1017,4 @@ Helm is a **functional control plane for 28 implemented managers** with:
 
 The core architecture is in place. The Rust core passed a full audit with no critical issues.
 
-0.13.x through 0.17.11 stable checkpoints are complete on `main`; `v0.17.0-rc.1` through `v0.17.0-rc.5` served as the completed RC validation path into stable `0.17.0`, followed by stable patch releases `v0.17.1`, `v0.17.2`, `v0.17.3`, `v0.17.4`, `v0.17.5`, `v0.17.6`, `v0.17.7`, `v0.17.8`, `v0.17.9`, `v0.17.10`, and `v0.17.11`.
+0.13.x through 0.17.12 stable checkpoints are complete on `main`; `v0.17.0-rc.1` through `v0.17.0-rc.5` served as the completed RC validation path into stable `0.17.0`, followed by stable patch releases `v0.17.1`, `v0.17.2`, `v0.17.3`, `v0.17.4`, `v0.17.5`, `v0.17.6`, `v0.17.7`, `v0.17.8`, `v0.17.9`, `v0.17.10`, `v0.17.11`, and `v0.17.12`.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -721,7 +721,7 @@ Initial implemented scope:
 **Decision:**
 Bulk and scoped upgrade workflows are owned by the Rust execution boundary. SwiftUI sends scoped intent and presents state; it does not schedule authority phases, use UI task projections to determine completion, or decide when downstream manager work may start.
 
-Implemented in the pending `v0.17.12` patch:
+Implemented in the released `v0.17.12` patch:
 
 - bulk and scoped workflows derive the current safe upgrade plan in Rust/FFI;
 - managers are scheduled by canonical authority phase;

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -11,24 +11,23 @@ It is intentionally tactical.
 Helm is in:
 
 ```
-v0.17.12 patch validation on `dev`, then 0.18.x planning (post-v0.17.11 stable release)
+0.18.x planning on `dev` (post-v0.17.12 stable release)
 ```
 
 Focus:
-- complete the focused `v0.17.12` corrective patch: retain bulk/scoped upgrade authority sequencing, workflow cancellation, and task visibility in Rust/FFI/XPC rather than SwiftUI
-- keep `main`/`dev`/`docs`/`web` release-state docs and version markers aligned now that `v0.17.11` is published
+- keep `main`/`dev`/`docs`/`web` release-state docs and version markers aligned now that `v0.17.12` is published
 - maintain release-process hardening guardrails now that phases 1-5 are complete (preflight, publish verification, drift prevention)
 - preserve manager-specific expected nonzero update-check outcomes as completed refreshes with actionable outdated state, starting with rustup's exit code `100`
 - continue doctor/repair subsystem foundation in core + FFI + service surfaces without widening into online knowledge lookup yet
 - keep repair knowledge lookup local/embedded for now, with explicit TODO seams for future online fingerprint lookup
-- sequence `0.18.x` local security groundwork now that the `0.17.11` hardening slice has landed
+- sequence `0.18.x` local security groundwork now that the `0.17.12` hardening slice has landed
 - keep launch-at-login scoped to GUI only (no CLI/TUI parity target)
 - track post-mise lifecycle follow-ups: plugin-as-package modeling evaluation and managed-environment install-source policy controls
 - keep the repository-local Codex operating model current (lean `AGENTS`, `ops/codex/skills/`, `.codex/commands/`, notify logging, and `ops/codex/docs/` workflows) so recurring AI workflows remain deterministic and low-friction
 
 Current checkpoint:
-- `v0.17.11` is the current stable release on `main`; current-scope manager adapter completion, final stable-line hardening, and package workflow hardening are now published:
-  - pending `v0.17.12` correction moves bulk and scoped upgrade phase coordination out of SwiftUI. The backend derives the current safe plan, schedules authority phases, waits for each phase to reach terminal state, and stops later-phase scheduling on scoped-workflow cancellation; individual tasks remain the live execution and diagnostics surface.
+- `v0.17.12` is the current stable release on `main`; current-scope manager adapter completion, final stable-line hardening, and package workflow hardening are now published:
+  - bulk and scoped upgrade phase coordination now resides in Rust/FFI/XPC. The backend derives the current safe plan, schedules authority phases, waits for each phase to reach terminal state, and stops later-phase scheduling on scoped-workflow cancellation; individual tasks remain the live execution and diagnostics surface.
   - all current manager adapters are considered complete for Helm's intended scope
   - intentionally narrower manager scopes remain explicit (`nix_darwin` detect/refresh-only; detection-only adapters such as `sparkle`, `setapp`, and `parallels_desktop`; guarded/status adapters such as `docker_desktop`, `podman`, `colima`, `rosetta2`, `firmware_updates`, and `xcode_command_line_tools`)
   - no additional manager-adapter implementation gaps remain beyond those intentional product boundaries
@@ -356,7 +355,7 @@ Current checkpoint:
     - audit-remediation follow-up delivered: stable CLI update metadata now points to published `v0.17.2` CLI release assets with real checksums (no placeholder zeros), and auto-check last-checked timestamps now update only after eligible direct self-managed check attempts instead of policy-gated skips
     - audit-remediation follow-up delivered: distribution profile contract is now centralized in `docs/contracts/distribution-profiles.json` and consumed by shared build orchestration (`scripts/build.sh`, `scripts/release/build_unsigned_variant.sh`, matrix-based `release-all-variants.yml` auxiliary jobs); Swift update-authority mapping now has one source (`AppUpdateConfiguration`), targeted updater policy tests pass on macOS, and GUI checksum-publication symmetry is explicitly documented as deferred while Sparkle remains canonical GUI integrity authority
     - trust-chain future work is now explicitly tracked: detached signatures + signing-key rotation for CLI update artifacts (`docs/roadmap/CLI_DISTRIBUTION_CI_MILESTONES.md`, milestone M5)
-- latest stable release on `main`: `v0.17.11`
+- latest stable release on `main`: `v0.17.12`
 - validation gates are green through the stable cut (`cargo test`, macOS `xcodebuild` tests, locale integrity/length audits, release workflow smoke across `v0.17.0-rc.1` through `v0.17.0-rc.5`)
 - `v0.15.0` released on `main` (tag `v0.15.0`)
 - `v0.14.0` released (merged to `main`, tagged, manager rollout + docs/version alignment complete)
@@ -1269,4 +1268,4 @@ Delivered:
 - 0.14 stable release alignment for `v0.14.0` is complete (README/website + version artifacts).
 - Distribution/licensing future-state planning documentation is aligned for 0.14 release notes and roadmap planning (no implementation yet).
 - 0.14.x and 0.15.x release execution are complete on `main` (`v0.14.1` and `v0.15.0`).
-- 0.17.11 release execution is complete on `main`; 0.17.x diagnostics/logging delivery and post-`0.17.x` follow-up stabilization are now closed with stable lineage `v0.17.0`, `v0.17.1`, `v0.17.2`, `v0.17.3`, `v0.17.4`, `v0.17.5`, `v0.17.6`, `v0.17.7`, `v0.17.8`, `v0.17.9`, `v0.17.10`, and `v0.17.11`.
+- 0.17.12 release execution is complete on `main`; 0.17.x diagnostics/logging delivery and post-`0.17.x` follow-up stabilization are now closed with stable lineage `v0.17.0`, `v0.17.1`, `v0.17.2`, `v0.17.3`, `v0.17.4`, `v0.17.5`, `v0.17.6`, `v0.17.7`, `v0.17.8`, `v0.17.9`, `v0.17.10`, `v0.17.11`, and `v0.17.12`.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -58,20 +58,20 @@ This checklist is required before creating a release tag on `main`.
   - `CLI Update Metadata Drift Guard`
 - [ ] Review `TMP_RELEASE_FRICTION`; promote recurring friction items into durable docs (`docs/DECISIONS.md`, `docs/operations/CLI_RELEASE_AND_CI.md`) and keep temporary notes uncommitted.
 
-## v0.17.12 (Stable Patch Release Gate, Pending)
+## v0.17.12 (Stable Patch Release Gate, Completed)
 
 ### Scope
 
 - [x] Bulk and scoped upgrade authority sequencing is backend-owned through Rust/FFI/XPC rather than SwiftUI polling.
 - [x] Individual upgrade task records, `plan_step_id` labels, terminal output, and per-task cancellation remain visible through existing diagnostics surfaces.
 - [x] Scoped-workflow cancellation blocks future authority-phase submission.
-- [x] Website current-version markers are aligned to the published `v0.17.11` baseline and identify `v0.17.12` as pending validation.
+- [x] Website, appcast, and CLI update metadata identify the published `v0.17.12` stable release.
 
 ### Required Validation
 
-- [ ] Verify authoritative tasks reach terminal state before standard or guarded bulk-upgrade tasks are submitted.
-- [ ] Verify scoped-workflow cancellation prevents later-phase scheduling and individual in-flight tasks remain cancellable.
-- [ ] Run the required preflight, rehearsal, canary, and publish-auth gates from `docs/operations/RELEASE_FLOW.md` before tag creation.
+- [x] Verify authoritative tasks reach terminal state before standard or guarded bulk-upgrade tasks are submitted.
+- [x] Verify scoped-workflow cancellation prevents later-phase scheduling and individual in-flight tasks remain cancellable.
+- [x] Run the required preflight, rehearsal, canary, publish-auth, publication, and post-publication verification gates from `docs/operations/RELEASE_FLOW.md`.
 
 ## v0.17.10 (Stable Patch Release Gate, Completed)
 

--- a/docs/contracts/release-line.json
+++ b/docs/contracts/release-line.json
@@ -1,3 +1,3 @@
 {
-  "stable_version": "0.17.11"
+  "stable_version": "0.17.12"
 }

--- a/docs/ui/SWIFTUI_ARCHITECTURE.md
+++ b/docs/ui/SWIFTUI_ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 This document describes the current SwiftUI architecture of the Helm macOS app.
 
-It reflects the implementation pending `v0.17.12` patch validation.
+It reflects the implementation released in `v0.17.12`.
 
 ---
 

--- a/web/src/components/starlight/Banner.astro
+++ b/web/src/components/starlight/Banner.astro
@@ -1,5 +1,5 @@
 ---
-const globalBanner = `<strong>Helm v0.17.11 is live.</strong> Install the latest release and report issues on <a href="https://github.com/jasoncavinder/Helm/issues/new/choose" target="_blank" rel="noreferrer">GitHub</a>.`;
+const globalBanner = `<strong>Helm v0.17.12 is live.</strong> Install the latest release and report issues on <a href="https://github.com/jasoncavinder/Helm/issues/new/choose" target="_blank" rel="noreferrer">GitHub</a>.`;
 const pageBanner = Astro.locals.starlightRoute.entry.data.banner?.content;
 const banners = [globalBanner, pageBanner].filter(Boolean);
 ---

--- a/web/src/content/docs/changelog.md
+++ b/web/src/content/docs/changelog.md
@@ -11,6 +11,18 @@ For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncav
 
 ---
 
+## 0.17.12 — 2026-07-29
+
+Patch `0.17.12` moves bulk and scoped upgrade workflow sequencing into the Rust execution boundary.
+
+### Fixed
+- Authority phases now wait for every submitted task to become terminal before standard or guarded manager work is scheduled.
+- Scoped-workflow cancellation prevents later phase submission while preserving individual task cancellation and diagnostics.
+- Indeterminate workflow-status probes recover UI state after a bounded retry window without moving execution ownership into SwiftUI.
+
+### Changed
+- SwiftUI submits and renders scoped upgrade workflows while Rust/FFI/XPC owns their sequencing.
+
 ## 0.17.11 — 2026-07-28
 
 Patch `0.17.11` ships manager lifecycle, release-process, and execution-safety hardening.

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -17,7 +17,7 @@ Helm is planned as two product lifecycles: **Helm (Consumer)** and **Helm Busine
 
 ## What it does today
 
-Helm `v0.17.11` supports twenty-eight managers:
+Helm `v0.17.12` supports twenty-eight managers:
 
 | Category | Managers |
 |---------|----------|
@@ -45,7 +45,7 @@ Key features:
 - **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, `ja`, and `hu` with locale override in Settings
 - **Upgrade transparency** — dedicated upgrade preview surface with scoped execution and failure-attribution visibility
 
-> **Current Track:** `v0.17.11` is the latest stable release on `main`; a focused `v0.17.12` corrective patch is in validation before `0.18.x` work resumes. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.17.12` is the latest stable release on `main`; `0.18.x` local security groundwork is next. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## How it works
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -31,9 +31,9 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 | 0.14.x | Platform, Detection & Optional Managers — Docker, Xcode, Rosetta, Sparkle, Setapp, Homebrew casks, optional managers (`v0.14.x` stable, latest patch `v0.14.1`) |
 | 0.15.x | Advanced Upgrade Transparency — richer execution-plan visibility, failure isolation, and operator controls (`v0.15.0` released) |
 | 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification (`v0.16.x` stable, latest patch `v0.16.2`) |
-| 0.17.x | Diagnostics & Logging + Release Hardening — task log viewer, structured diagnostics export, manager-detection diagnostics, onboarding/detection hardening, manager-selection controls, and stable release follow-up fixes (`v0.17.0` stable, latest patch `v0.17.11`) |
+| 0.17.x | Diagnostics & Logging + Release Hardening — task log viewer, structured diagnostics export, manager-detection diagnostics, onboarding/detection hardening, manager-selection controls, and stable release follow-up fixes (`v0.17.0` stable, latest patch `v0.17.12`) |
 
-> **Current Track:** `v0.17.11` is stable on `main`; a focused `v0.17.12` authority-ordering correction is in validation before `0.18.x` local security groundwork. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.17.12` is stable on `main`; `0.18.x` local security groundwork is next. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Planned
 


### PR DESCRIPTION
## Summary

- Align README, current-state docs, release contract, checklist, and website release markers to published `v0.17.12`.
- Add the `0.17.12` website changelog entry and update the global website banner.
- Preserve historical `v0.17.11` release notes and screenshot references.

## Validation

- `scripts/release/check_release_line_copy.sh`
- `ops/codex/skills/docs-sync/scripts/docs-sync-check.sh`
- `npm run check:content-ids`
- `npm run build`
