### PR TITLE
hotfix: require approval for guarded OpenCode commands

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -9,7 +9,7 @@
 
   "permission": {
     // Do not let agents wander outside the Helm repository.
-    "external_directory": "deny",
+    "external_directory": "ask",
 
     // Require approval before changing files.
     "edit": "ask",
@@ -25,12 +25,12 @@
       "git branch*": "allow",
       "git rev-parse*": "allow",
 
-      "git commit*": "deny",
-      "git push*": "deny",
-      "git reset --hard*": "deny",
-      "git clean*": "deny",
-      "rm *": "deny",
-      "sudo *": "deny"
+      "git commit*": "ask",
+      "git push*": "ask",
+      "git reset --hard*": "ask",
+      "git clean*": "ask",
+      "rm *": "ask",
+      "sudo *": "ask"
     },
 
     // Interrupt identical repeating tool calls.


### PR DESCRIPTION
## Summary

- change project OpenCode external-directory access from deny to approval-required
- change commit, push, destructive Git, file removal, and sudo commands from deny to approval-required
- retain allowlisted read-only Git inspection commands and default approval prompts

## Verification

- preserve the OpenCode JSON schema declaration
- validate the resolved project configuration with OpenCode tooling

## Operational Note

OpenCode loads configuration at startup; restart OpenCode after this change is merged.
