### PR TITLE
fix: migrate CodeQL to Node 24

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,10 +34,10 @@ jobs:
             os: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -59,4 +59,4 @@ jobs:
             build
 
       - name: Analyze
-        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3


### PR DESCRIPTION
## Summary

- migrate CodeQL Advanced Setup from v3 to the current Node 24-based v4 release
- migrate checkout from the Node 20-based v4 line to the current Node 24-based v7 release
- preserve immutable full-SHA action pins and the verified four-language workflow behavior

## Verification

- `actionlint .github/workflows/codeql.yml`
- `git diff --check`
- `scripts/release/tests/ci_toolchain_contract.sh`
- verified checkout `v7.0.1` resolves to `3d3c42e5aac5ba805825da76410c181273ba90b1`
- verified CodeQL `v4.37.3` resolves to `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`
- verified both action manifests declare the Node 24 runtime

## Context

The repaired CodeQL workflow passed all four language jobs on PR #292 and on the resulting `main` push. Those runs exposed GitHub migration warnings for CodeQL Action v3 and Node 20 action manifests; this follow-up removes both warnings.
