### PR TITLE
fix(ci): prevent false-green hardcoded string scan

### DIFF
--- a/.github/workflows/i18n-lint.yml
+++ b/.github/workflows/i18n-lint.yml
@@ -30,10 +30,4 @@ jobs:
         run: apps/macos-ui/scripts/check_locale_lengths.sh
 
       - name: Block Hardcoded UI Strings
-        run: |
-          set -euo pipefail
-          PATTERN='Text\("[A-Za-z]|Button\("[A-Za-z]|Toggle\("[A-Za-z]|TextField\("[A-Za-z]|\.alert\("[A-Za-z]|\.help\("[A-Za-z]'
-          if rg -n "$PATTERN" apps/macos-ui/Helm; then
-            echo "Found hardcoded UI strings; use L10n keys instead."
-            exit 1
-          fi
+        run: apps/macos-ui/scripts/check_hardcoded_ui_strings.sh

--- a/apps/macos-ui/scripts/check_hardcoded_ui_strings.sh
+++ b/apps/macos-ui/scripts/check_hardcoded_ui_strings.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCAN_DIR="${ROOT_DIR}/apps/macos-ui/Helm"
+
+# Matches SwiftUI views/helpers that take a literal string argument.
+# Lines containing ".localized" are excluded because they use L10n keys.
+PATTERN='Text\("[A-Za-z]|Button\("[A-Za-z]|Toggle\("[A-Za-z]|TextField\("[A-Za-z]|\.alert\("[A-Za-z]|\.help\("[A-Za-z]'
+
+if ! command -v grep >/dev/null 2>&1; then
+  echo "::error::grep is required for the hardcoded UI string check" >&2
+  exit 2
+fi
+
+# Temporarily disable errexit so we can capture grep's exit code.
+set +e
+MATCHES="$(grep -Ern -- "$PATTERN" "${SCAN_DIR}" | grep -v '.localized')"
+GREP_EXIT=$?
+set -e
+
+if [[ ${GREP_EXIT} -eq 0 ]]; then
+  echo "Found hardcoded UI strings; use L10n keys instead."
+  echo ""
+  echo "${MATCHES}"
+  exit 1
+elif [[ ${GREP_EXIT} -eq 1 ]]; then
+  echo "No hardcoded UI strings found."
+  exit 0
+else
+  echo "::error::scanner exited with unexpected status ${GREP_EXIT}" >&2
+  exit 2
+fi

--- a/apps/macos-ui/scripts/check_hardcoded_ui_strings.sh
+++ b/apps/macos-ui/scripts/check_hardcoded_ui_strings.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-SCAN_DIR="${ROOT_DIR}/apps/macos-ui/Helm"
+SCAN_DIR="${SCAN_DIR:-${ROOT_DIR}/apps/macos-ui/Helm}"
 
 # Matches SwiftUI views/helpers that take a literal string argument.
 # Lines containing ".localized" are excluded because they use L10n keys.
@@ -13,21 +13,52 @@ if ! command -v grep >/dev/null 2>&1; then
   exit 2
 fi
 
-# Temporarily disable errexit so we can capture grep's exit code.
+RAW_MATCHES_FILE="$(mktemp)"
+trap 'rm -f "${RAW_MATCHES_FILE}"' EXIT
+
+# Run the primary scan separately so its exit status cannot be hidden
+# by the subsequent .localized filtering step.
 set +e
-MATCHES="$(grep -Ern -- "$PATTERN" "${SCAN_DIR}" | grep -v '.localized')"
-GREP_EXIT=$?
+grep -Ern -- "${PATTERN}" "${SCAN_DIR}" >"${RAW_MATCHES_FILE}"
+SCAN_EXIT=$?
 set -e
 
-if [[ ${GREP_EXIT} -eq 0 ]]; then
-  echo "Found hardcoded UI strings; use L10n keys instead."
-  echo ""
-  echo "${MATCHES}"
-  exit 1
-elif [[ ${GREP_EXIT} -eq 1 ]]; then
-  echo "No hardcoded UI strings found."
-  exit 0
-else
-  echo "::error::scanner exited with unexpected status ${GREP_EXIT}" >&2
-  exit 2
-fi
+case "${SCAN_EXIT}" in
+  0)
+    # The scanner found candidate matches. Filter legitimate localized uses
+    # and independently validate the filter's exit status.
+    set +e
+    MATCHES="$(grep -vF '.localized' "${RAW_MATCHES_FILE}")"
+    FILTER_EXIT=$?
+    set -e
+
+    case "${FILTER_EXIT}" in
+      0)
+        echo "Found hardcoded UI strings; use L10n keys instead."
+        echo
+        printf '%s\n' "${MATCHES}"
+        exit 1
+        ;;
+
+      1)
+        echo "No hardcoded UI strings found."
+        exit 0
+        ;;
+
+      *)
+        echo "::error::hardcoded UI string result filtering failed with status ${FILTER_EXIT}" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+
+  1)
+    echo "No hardcoded UI strings found."
+    exit 0
+    ;;
+
+  *)
+    echo "::error::hardcoded UI string scan failed with status ${SCAN_EXIT}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Problem

The i18n workflow contained a hardcoded-UI-string check that invoked `rg`, but the GitHub Actions runner does not have `rg` installed. The command appeared inside an `if` condition:

```bash
if rg -n "$PATTERN" apps/macos-ui/Helm; then
  echo "Found hardcoded UI strings"
  exit 1
fi
```

When `rg` is not found, Bash does **not** terminate the step despite `set -e` — commands in `if` conditions are exempt from `set -e`. The `if` condition simply evaluated to false, the body was skipped, and the step passed. This produced a false-green CI result: the scan never ran, but the workflow reported success.

## Fix

1. **Replace `rg` with `grep -E`** — `grep` is available on all GitHub Actions runners. The regex pattern is valid ERE, and `grep -E` has compatible exit codes (0 = match, 1 = no match, 2 = error).

2. **Move scan logic into `check_hardcoded_ui_strings.sh`** — follows the existing convention (e.g., `check_locale_integrity.sh`, `check_locale_lengths.sh`) and allows local testing.

3. **Proper exit code handling** — the script distinguishes three cases:
   - Exit 0: no prohibited strings found (pass)
   - Exit 1: prohibited strings found (fail, prints matches)
   - Exit 2: scanner error or dependency unavailable (fail with error message)

4. **Filter `.localized` lines** — excludes L10n key usage from matches to avoid false positives on properly localized strings.

## Verification

- ShellCheck: 0 findings
- Syntax check: pass
- Current repo state: no prohibited strings detected (exit 0)
- Known-bad fixture: correctly detected and failed (exit 1)
- L10n key fixture: correctly filtered (exit 0)
- Scanner unavailable: correctly failed with error (exit 2)
- Existing i18n checks: locale sync, integrity, and length checks all pass
