### PR TITLE
release: prepare v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-08-03
+
+### Added
+- SQLite-backed doctor scan generations, finding lifecycle, repair history, versioned repair knowledge, provenance, and local overrides.
+- Deterministic bundled and imported repair knowledge using RFC 8785 canonical JSON, SHA-256 integrity checks, and an allowlist of typed repair actions.
+- Internal local-only security advisory domain and cache groundwork with normalized records, deterministic identities and ordering, freshness evaluation, and pruning support.
+
+### Changed
+- CLI and FFI/XPC repair planning now resolves effective persisted knowledge, localized content keys, and deterministic recommendation rank.
+- Repair apply now revalidates active findings, records execution history, and verifies outcomes through follow-up scans.
+- Doctor scans now distinguish full, scoped, partial, failed, and cancelled coverage so only successfully evaluated scopes can resolve findings.
+
+### Security
+- Knowledge imports fail closed on forged trust, policy weakening, protected rebinding, unknown actions, equivocation, and malformed or noncanonical envelopes.
+- Repair execution rejects detached CLI work and records terminal outcomes for both CLI and FFI paths.
+- Advisory cache persistence validates canonical identities and normalized query inputs transactionally.
+
+Security advisory providers, scheduler integration, doctor advisory findings, and public advisory UI/CLI surfaces remain intentionally deferred beyond `0.18.x`.
+
 ## [0.17.12] - 2026-07-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 Helm manages software across multiple package managers (Homebrew, npm, pip, Cargo, etc.) and runtime tools (mise, rustup) from a single menu bar interface. It is designed as infrastructure software: deterministic, safety-first, and explicit about authority, orchestration, and error handling.
 
-> **Status:** Active pre-1.0 development with stable `v0.17.12` on `main` and `0.18.x` planning on `dev`.
+> **Status:** Active pre-1.0 development with stable `v0.17.12` on `main` and `v0.18.0` release validation on `dev`.
 >
 > **Testing:** Please test `v0.17.12` and report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
@@ -190,8 +190,8 @@ Or open `apps/macos-ui/Helm.xcodeproj` in Xcode and run the **Helm** scheme. The
 | 0.16.x | Self-Update & Installer Hardening — Sparkle integration, signed verification | Completed (`v0.16.0`) |
 | 0.16.1 | Documentation, Milestone Restructure & Security Staging Clarification | Completed (documentation-only) |
 | 0.16.2 | Sparkle Connectivity + Platform Baseline Alignment — network-client entitlement, feed diagnostics, macOS 11 deployment target enforcement | Completed |
-| 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel | Completed (`v0.17.x` stable, latest patch `v0.17.10`) |
-| 0.18.x | Local Security Groundwork — local vulnerability abstractions and cache plumbing (no public feature surface) | Planned |
+| 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel | Completed (`v0.17.x` stable, latest patch `v0.17.12`) |
+| 0.18.x | Doctor & Repair + Local Security Groundwork — implementation complete; `v0.18.0` release validation in progress (no public advisory feature surface) | Release validation |
 | 0.19.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit | Planned |
 | 1.0.0 | Stable Control Plane Release — production-safe execution, full feature set | Planned |
 

--- a/core/rust/Cargo.lock
+++ b/core/rust/Cargo.lock
@@ -650,7 +650,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helm-cli"
-version = "0.17.12"
+version = "0.18.0"
 dependencies = [
  "crossterm 0.28.1",
  "helm-core",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "helm-core"
-version = "0.17.12"
+version = "0.18.0"
 dependencies = [
  "libc",
  "rusqlite",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "helm-ffi"
-version = "0.17.12"
+version = "0.18.0"
 dependencies = [
  "cbindgen",
  "helm-core",

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -3,4 +3,4 @@ members = ["crates/helm-core", "crates/helm-ffi", "crates/helm-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.12"
+version = "0.18.0"

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,15 +8,16 @@ It reflects reality, not intention.
 
 ## Version
 
-Current documentation baseline: **0.17.12 stable released on `main`**; the internal `0.18.x` groundwork is implemented on `dev` and remains unreleased.
+Current documentation baseline: **0.17.12 stable released on `main`**; `v0.18.0` implementation is complete on `dev` and is in release validation.
 
-Implementation baseline: **0.18.x local groundwork implemented on `dev`** after diagnostics/logging delivery, package workflow hardening, manager-selection/enablement and onboarding/detection hardening, release-process hardening phases 1-5, current-scope manager adapter completion, and local doctor/repair follow-up for executable-path drift.
+Implementation baseline: **0.18.x doctor/repair and local security groundwork implemented on `dev`** after diagnostics/logging delivery, package workflow hardening, manager-selection/enablement and onboarding/detection hardening, release-process hardening phases 1-5, current-scope manager adapter completion, and local doctor/repair follow-up for executable-path drift.
 
 See:
 - CHANGELOG.md
 
 Active milestone:
 - latest stable release currently published on `main`: **0.17.12** (released on 2026-07-29)
+- `v0.18.0` stable release preparation is in progress on `dev`; public update metadata remains pinned to `v0.17.12` until release publication succeeds.
 - `v0.17.12` moves bulk and scoped upgrade authority sequencing into Rust/FFI/XPC; every submitted task reaches a terminal state before the next phase is scheduled, and scoped-workflow cancellation prevents later-phase submission while preserving individual task cancellation and diagnostics.
 - delivered on `dev` for **0.18.x**: SQLite-backed doctor finding lifecycle and repair knowledge, deterministic cross-installation fingerprints, guarded bundled/imported knowledge, repair verification history, and the local security-advisory domain/cache groundwork; provider fetchers and user-facing advisory features remain deferred to the staged advisory release.
 - repository operations follow-up on `dev`: agent-agnostic operating model with policy-only root `AGENTS.md`, isolated agent task worktrees under `.worktrees/` with the `agent-worktree-isolation` Skill, workflow Skills under `.opencode/skills/`, inactive prompt drafts under `.opencode/templates/`, and structured local notify logging to `dev/logs/agent-runs.ndjson`.

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -11,11 +11,11 @@ It is intentionally tactical.
 Helm is in:
 
 ```
-0.18.x consolidation on `dev` (post-v0.17.12 stable release)
+v0.18.0 release validation on `dev` (post-v0.17.12 stable release)
 ```
 
 Focus:
-- keep `main`/`dev` release-state docs and version markers aligned now that `v0.17.12` is published
+- complete the `v0.18.0` release rehearsal, quality gates, fresh macOS canary, publish-auth probe, and explicit approval checkpoints before tagging
 - maintain release-process hardening guardrails now that phases 1-5 are complete (preflight, publish verification, drift prevention)
 - preserve manager-specific expected nonzero update-check outcomes as completed refreshes with actionable outdated state, starting with rustup's exit code `100`
 - consolidate and review the delivered SQLite doctor/repair lifecycle, bundled knowledge bootstrap, import/export hardening, and repair verification path without widening into online knowledge lookup
@@ -375,7 +375,7 @@ Current checkpoint:
 - `v0.14.0` distribution/licensing architecture planning docs aligned (future-state, no implementation changes)
 
 Next release targets:
-- `v0.18.x` — Local security groundwork (internal-only implementation complete; release integration pending)
+- `v0.18.x` — Doctor/repair and local security groundwork (implementation complete; `v0.18.0` release validation in progress)
 - `v0.19.x` — Stability & Pre-1.0 hardening
 
 ## Historical v0.17.x Delivery Tracker (0.17.3 Checkpoint)

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -62,6 +62,27 @@ This checklist is required before creating a release tag on `main`.
   - `CLI Update Metadata Drift Guard`
 - [ ] Review `TMP_RELEASE_FRICTION`; promote recurring friction items into durable docs (`docs/DECISIONS.md`, `docs/operations/CLI_RELEASE_AND_CI.md`) and keep temporary notes uncommitted.
 
+## v0.18.0 (Stable Release Gate, Pending)
+
+### Scope
+
+- [x] SQLite is canonical for doctor scan generations, finding lifecycle, repair knowledge, local overrides, provenance, and repair history.
+- [x] Bundled and imported knowledge uses canonical integrity validation and maps only to allowlisted typed repair actions.
+- [x] CLI and FFI/XPC doctor and repair paths persist scans, resolve effective knowledge, record execution history, and verify repair outcomes.
+- [x] Internal security advisory records and cache persistence provide deterministic normalization, validation, ordering, freshness, and pruning without a public feature surface.
+- [x] Provider fetchers, scheduler wiring, doctor advisory findings, and public advisory CLI/GUI surfaces remain explicitly deferred beyond `0.18.x`.
+
+### Required Validation
+
+- [x] Doctor/repair and advisory persistence suites cover deterministic lifecycle, hostile imports, stale completion, normalization, and transactional rejection behavior.
+- [x] Run the full repository quality gate, documentation sync, Sparkle checklist, and non-mutating release rehearsal from the release-preparation branch.
+- [ ] Merge release preparation through `dev` and the protected `dev` to `main` path.
+- [ ] Run rehearsal and preflight from a clean, current `main` checkout.
+- [ ] Run a fresh successful `Release macOS Canary` on `macos-26` after the final release changes.
+- [ ] Dispatch and pass `Release Publish Auth Check` with `write_probe=true` after explicit maintainer approval.
+- [ ] Obtain explicit maintainer approval before tag creation and publication.
+- [ ] Complete release publication and post-publication metadata verification.
+
 ## v0.17.12 (Stable Patch Release Gate, Completed)
 
 ### Scope

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -559,7 +559,9 @@ Exit Criteria:
 
 ---
 
-## 0.18.x — Doctor & Repair Foundation (rc) - Completed on `dev`
+## 0.18.x — Doctor & Repair Foundation - Completed on `dev`
+
+Release status: included in the `v0.18.0` stable release validation.
 
 Goal:
 
@@ -624,7 +626,9 @@ Stage 3 (`1.4.x`) — Shared Brain:
 
 ---
 
-## 0.18.x — Local Security Groundwork (rc, second slice) - Completed on `dev`
+## 0.18.x — Local Security Groundwork (second slice) - Completed on `dev`
+
+Release status: included in the `v0.18.0` stable release validation.
 
 Goal:
 

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -45,7 +45,7 @@ Key features:
 - **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, `ja`, and `hu` with locale override in Settings
 - **Upgrade transparency** — dedicated upgrade preview surface with scoped execution and failure-attribution visibility
 
-> **Current Track:** `v0.17.12` is the latest stable release on `main`; `0.18.x` local security groundwork is next. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.17.12` is the latest stable release on `main`; `v0.18.0` implementation is complete on `dev` and is in release validation. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## How it works
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -33,13 +33,13 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 | 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification (`v0.16.x` stable, latest patch `v0.16.2`) |
 | 0.17.x | Diagnostics & Logging + Release Hardening — task log viewer, structured diagnostics export, manager-detection diagnostics, onboarding/detection hardening, manager-selection controls, and stable release follow-up fixes (`v0.17.0` stable, latest patch `v0.17.12`) |
 
-> **Current Track:** `v0.17.12` is stable on `main`; `0.18.x` local security groundwork is next. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.17.12` is stable on `main`; `v0.18.0` implementation is complete on `dev` and is in release validation. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Planned
 
 | Version | Milestone |
 |---|---|
-| 0.18.x | Local Security Groundwork — local vulnerability abstractions and cache plumbing (internal only) |
+| 0.18.x | Doctor & Repair + Local Security Groundwork — implementation complete; `v0.18.0` release validation in progress (advisory surface remains internal only) |
 | 0.19.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit |
 | 1.0.0 | Stable Control Plane Release — production-safe execution, full feature set |
 


### PR DESCRIPTION
## Summary

- bump the Rust workspace and lockfile package versions to `0.18.0`
- add the stable `0.18.0` changelog entry for doctor/repair and internal advisory groundwork
- align repository and website status docs with `v0.18.0` release validation
- add the pending stable release gate while preserving explicit approval checkpoints

## Validation

- `.opencode/skills/run-quality-gate/scripts/run-quality-gate.sh all`
- `.opencode/skills/docs-sync/scripts/docs-sync-check.sh`
- `.opencode/skills/sparkle-appcast-checklist/scripts/run-checklist.sh v0.18.0`
- `scripts/release/rehearsal_dry_run.sh --tag v0.18.0`
- generated CLI reports `0.18.0`

The full gate passed Rust tests, formatting, strict Clippy, locale parity, 49 macOS tests, release workflow contracts, and branch-safe preflight. The rehearsal report recorded all three non-mutating phases as passed.

## Publication Boundary

This PR intentionally leaves `docs/contracts/release-line.json`, the Sparkle appcast, CLI update metadata, website release banner, and other public latest-stable claims at `v0.17.12`. Those change only through the release publication flow after the release-preparation PR reaches `main`, a fresh macOS canary passes, the write auth probe passes with approval, and the maintainer explicitly approves tag creation and publication.
