### PR TITLE
chore(release): close v0.18.0 publication

### DIFF
--- a/.github/workflows/release-contract-checks.yml
+++ b/.github/workflows/release-contract-checks.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Validate release workflow safety contracts
         run: scripts/release/tests/release_workflow_contract.sh
 
+      - name: Validate post-publication preflight contract
+        run: scripts/release/tests/preflight_post_publish_contract.sh
+
       - name: Validate release provenance manifest contracts
         run: scripts/release/tests/provenance_manifest_contract.sh
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <br>
   A macOS control center and CLI for unified package manager control.
   <br>
-  <strong>Pre-1.0 &middot; v0.17.12</strong>
+  <strong>Pre-1.0 &middot; v0.18.0</strong>
 </p>
 
 <p align="center">
@@ -23,9 +23,9 @@
 
 Helm manages software across multiple package managers (Homebrew, npm, pip, Cargo, etc.) and runtime tools (mise, rustup) from a single menu bar interface. It is designed as infrastructure software: deterministic, safety-first, and explicit about authority, orchestration, and error handling.
 
-> **Status:** Active pre-1.0 development with stable `v0.17.12` on `main` and `v0.18.0` release validation on `dev`.
+> **Status:** Active pre-1.0 development with stable `v0.18.0` on `main` and `v0.19.x` stability and pre-1.0 hardening next.
 >
-> **Testing:** Please test `v0.17.12` and report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Testing:** Please test `v0.18.0` and report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Editions (Beta)
 
@@ -191,8 +191,8 @@ Or open `apps/macos-ui/Helm.xcodeproj` in Xcode and run the **Helm** scheme. The
 | 0.16.1 | Documentation, Milestone Restructure & Security Staging Clarification | Completed (documentation-only) |
 | 0.16.2 | Sparkle Connectivity + Platform Baseline Alignment — network-client entitlement, feed diagnostics, macOS 11 deployment target enforcement | Completed |
 | 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel | Completed (`v0.17.x` stable, latest patch `v0.17.12`) |
-| 0.18.x | Doctor & Repair + Local Security Groundwork — implementation complete; `v0.18.0` release validation in progress (no public advisory feature surface) | Release validation |
-| 0.19.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit | Planned |
+| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge and internal advisory cache foundation (no public advisory feature surface) | Completed (`v0.18.0`) |
+| 0.19.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit | Next |
 | 1.0.0 | Stable Control Plane Release — production-safe execution, full feature set | Planned |
 
 See [`docs/ROADMAP.md`](docs/ROADMAP.md) for the full roadmap through 1.x.

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,23 +8,23 @@ It reflects reality, not intention.
 
 ## Version
 
-Current documentation baseline: **0.17.12 stable released on `main`**; `v0.18.0` implementation is complete on `dev` and is in release validation.
+Current documentation baseline: **0.18.0 stable released on `main`**; `v0.19.x` stability and pre-1.0 hardening is the next milestone.
 
-Implementation baseline: **0.18.x doctor/repair and local security groundwork implemented on `dev`** after diagnostics/logging delivery, package workflow hardening, manager-selection/enablement and onboarding/detection hardening, release-process hardening phases 1-5, current-scope manager adapter completion, and local doctor/repair follow-up for executable-path drift.
+Implementation baseline: **0.18.x doctor/repair and local security groundwork released on `main`** after diagnostics/logging delivery, package workflow hardening, manager-selection/enablement and onboarding/detection hardening, release-process hardening phases 1-5, current-scope manager adapter completion, and local doctor/repair follow-up for executable-path drift.
 
 See:
 - CHANGELOG.md
 
 Active milestone:
-- latest stable release currently published on `main`: **0.17.12** (released on 2026-07-29)
-- `v0.18.0` stable release preparation is in progress on `dev`; public update metadata remains pinned to `v0.17.12` until release publication succeeds.
+- latest stable release currently published on `main`: **0.18.0** (released on 2026-08-03)
+- `v0.18.0` is published with notarized universal DMG, direct CLI binaries, appcast, CLI update metadata, release notes, checksums, and provenance.
 - `v0.17.12` moves bulk and scoped upgrade authority sequencing into Rust/FFI/XPC; every submitted task reaches a terminal state before the next phase is scheduled, and scoped-workflow cancellation prevents later-phase submission while preserving individual task cancellation and diagnostics.
-- delivered on `dev` for **0.18.x**: SQLite-backed doctor finding lifecycle and repair knowledge, deterministic cross-installation fingerprints, guarded bundled/imported knowledge, repair verification history, and the local security-advisory domain/cache groundwork; provider fetchers and user-facing advisory features remain deferred to the staged advisory release.
-- repository operations follow-up on `dev`: agent-agnostic operating model with policy-only root `AGENTS.md`, isolated agent task worktrees under `.worktrees/` with the `agent-worktree-isolation` Skill, workflow Skills under `.opencode/skills/`, inactive prompt drafts under `.opencode/templates/`, and structured local notify logging to `dev/logs/agent-runs.ndjson`.
-- latest stable publication cut completed for `v0.17.12`:
-  - workspace, docs, website, appcast, and CLI metadata now reflect the published `0.17.12` stable line.
-  - release automation follow-through and publish verification completed on `main`.
-  - post-release rustup refresh correction: `rustup check` exit code `100` now represents detected toolchain updates rather than a failed refresh, and current lowercase output grammar is parsed into outdated toolchains.
+- delivered on `main` for **0.18.x**: SQLite-backed doctor finding lifecycle and repair knowledge, deterministic cross-installation fingerprints, guarded bundled/imported knowledge, repair verification history, and the local security-advisory domain/cache groundwork; provider fetchers and user-facing advisory features remain deferred to the staged advisory release.
+- repository operations follow-up on `main`: agent-agnostic operating model with policy-only root `AGENTS.md`, isolated agent task worktrees under `.worktrees/` with the `agent-worktree-isolation` Skill, workflow Skills under `.opencode/skills/`, inactive prompt drafts under `.opencode/templates/`, and structured local notify logging to `dev/logs/agent-runs.ndjson`.
+- latest stable publication cut completed for `v0.18.0`:
+  - workspace, website, appcast, CLI metadata, and release notes reflect the published `0.18.0` stable line.
+  - signed/notarized DMG and direct CLI artifacts passed release canary, publish-auth, provenance, metadata convergence, and drift-guard verification.
+  - release-process follow-up now keeps post-publication verification distinct from strict pre-tag metadata ordering checks.
 - 0.17.x — Diagnostics & Logging (**stable released on `main`**, RC lineage `v0.17.0-rc.1` through `v0.17.0-rc.5`)
   - delivered: `feat/v0.17-log-foundation` (SQLite-backed task lifecycle logs + retrieval plumbing)
   - delivered: `feat/v0.17-task-log-viewer` (inspector diagnostics logs tab with level/status filters + load-more pagination)
@@ -101,10 +101,12 @@ Active milestone:
   - delivered for `v0.17.11`: task terminal transitions and request/response persistence now preserve final results deterministically; Homebrew formula and cask work share one execution lease; XPC connections reuse one service runtime; system-manager helper paths are canonicalized before selection; release, cancellation, MacPorts, and XPC hardening close the release line.
   - `v0.17.12` stable release execution status: released on `main` with tag, notarized DMG and CLI assets, published appcast and CLI metadata, and post-publication verification complete.
   - delivered for `v0.17.12`: bulk and scoped upgrade workflow sequencing is backend-owned, authority phases wait for submitted tasks to become terminal, and scoped cancellation prevents later-phase submission.
+  - `v0.18.0` stable release execution status: released on `main` with tag, notarized DMG and CLI assets, published appcast and CLI metadata, provenance, and post-publication verification complete.
+  - delivered for `v0.18.0`: persisted doctor/repair lifecycle, guarded repair knowledge, repair verification history, and deterministic local security-advisory cache groundwork without a public advisory surface.
 
 Security rollout staging status:
 - Stage 0 (`<=0.16.x`): planning/docs only (active in `0.16.1`)
-- Stage 1 (`0.18.x`): local security groundwork implemented on `dev` (normalized advisory domain records and queries, canonical cache identity validation, control-character hardening, deterministic order, freshness contracts, task hooks, and migration 18 SQLite cache persistence)
+- Stage 1 (`0.18.x`): local security groundwork released on `main` (normalized advisory domain records and queries, canonical cache identity validation, control-character hardening, deterministic order, freshness contracts, task hooks, and migration 18 SQLite cache persistence)
 - Stage 2 (`1.3.x`): Security Advisory System (Pro, planned)
 - Stage 3 (`1.4.x`): Shared Brain infrastructure (planned)
 - Current behavior: no package/fingerprint data is sent to any Helm-operated shared backend; the `0.18.x` advisory groundwork has no network provider or user-facing feature path.
@@ -1018,4 +1020,4 @@ Helm is a **functional control plane for 28 implemented managers** with:
 
 The core architecture is in place. The Rust core passed a full audit with no critical issues.
 
-0.13.x through 0.17.12 stable checkpoints are complete on `main`; `v0.17.0-rc.1` through `v0.17.0-rc.5` served as the completed RC validation path into stable `0.17.0`, followed by stable patch releases `v0.17.1`, `v0.17.2`, `v0.17.3`, `v0.17.4`, `v0.17.5`, `v0.17.6`, `v0.17.7`, `v0.17.8`, `v0.17.9`, `v0.17.10`, `v0.17.11`, and `v0.17.12`.
+0.13.x through 0.18.0 stable checkpoints are complete on `main`; the completed 0.17.x RC and patch lineage led into `v0.18.0`, which publishes the doctor/repair and local-security groundwork milestone.

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -11,14 +11,14 @@ It is intentionally tactical.
 Helm is in:
 
 ```
-v0.18.0 release validation on `dev` (post-v0.17.12 stable release)
+v0.19.x stability and pre-1.0 hardening (post-v0.18.0 stable release)
 ```
 
 Focus:
-- complete the `v0.18.0` release rehearsal, quality gates, fresh macOS canary, publish-auth probe, and explicit approval checkpoints before tagging
-- maintain release-process hardening guardrails now that phases 1-5 are complete (preflight, publish verification, drift prevention)
+- begin the `v0.19.x` stability and pre-1.0 hardening track with stress, crash-recovery, and memory audits
+- maintain release-process hardening guardrails now that `v0.18.0` publication is complete (preflight, publish verification, drift prevention)
 - preserve manager-specific expected nonzero update-check outcomes as completed refreshes with actionable outdated state, starting with rustup's exit code `100`
-- consolidate and review the delivered SQLite doctor/repair lifecycle, bundled knowledge bootstrap, import/export hardening, and repair verification path without widening into online knowledge lookup
+- preserve the released SQLite doctor/repair lifecycle, bundled knowledge bootstrap, import/export hardening, and repair verification path without widening into online knowledge lookup
 - preserve the compiled typed-action registry as the immutable execution boundary; knowledge remains declarative and cannot carry commands, arguments, scripts, plugins, or arbitrary executable content
 - retain deterministic `v2` finding identity while keeping sensitive local evidence outside shared fingerprint inputs
 - preserve the internal-only `0.18.x` advisory domain/cache foundation; provider fetchers, task-scheduler wiring, doctor advisory findings, and public CLI/GUI surfaces remain post-`0.18.x`
@@ -27,8 +27,8 @@ Focus:
 - keep the agent-agnostic operating model current (lean `AGENTS`, isolated task worktrees under `.worktrees/` via `agent-worktree-isolation`, `.opencode/skills/`, inactive prompt drafts under `.opencode/templates/`, notify logging to `dev/logs/agent-runs.ndjson`, and `scripts/agents/` workflows) so recurring AI workflows remain deterministic and low-friction
 
 Current checkpoint:
-- `0.18.x` internal groundwork is implemented on `dev`: migrations 17-19 persist doctor/repair, ranked repair knowledge, and advisory cache state; strict canonical knowledge envelopes seed and resolve bundled typed repairs; CLI and FFI doctor scans persist scoped generations; CLI and FFI repair tasks record verification outcomes; advisory records have deterministic normalization, validation, ordering, freshness, and transactional SQLite cache behavior.
-- `v0.17.12` is the current stable release on `main`; current-scope manager adapter completion, final stable-line hardening, and package workflow hardening are now published:
+- `0.18.x` internal groundwork is released on `main`: migrations 17-19 persist doctor/repair, ranked repair knowledge, and advisory cache state; strict canonical knowledge envelopes seed and resolve bundled typed repairs; CLI and FFI doctor scans persist scoped generations; CLI and FFI repair tasks record verification outcomes; advisory records have deterministic normalization, validation, ordering, freshness, and transactional SQLite cache behavior.
+- `v0.18.0` is the current stable release on `main`; current-scope manager adapter completion, doctor/repair delivery, local security groundwork, and package workflow hardening are now published:
   - bulk and scoped upgrade phase coordination now resides in Rust/FFI/XPC. The backend derives the current safe plan, schedules authority phases, waits for each phase to reach terminal state, and stops later-phase scheduling on scoped-workflow cancellation; individual tasks remain the live execution and diagnostics surface.
   - all current manager adapters are considered complete for Helm's intended scope
   - intentionally narrower manager scopes remain explicit (`nix_darwin` detect/refresh-only; detection-only adapters such as `sparkle`, `setapp`, and `parallels_desktop`; guarded/status adapters such as `docker_desktop`, `podman`, `colima`, `rosetta2`, `firmware_updates`, and `xcode_command_line_tools`)
@@ -357,7 +357,7 @@ Current checkpoint:
     - audit-remediation follow-up delivered: stable CLI update metadata now points to published `v0.17.2` CLI release assets with real checksums (no placeholder zeros), and auto-check last-checked timestamps now update only after eligible direct self-managed check attempts instead of policy-gated skips
     - audit-remediation follow-up delivered: distribution profile contract is now centralized in `docs/contracts/distribution-profiles.json` and consumed by shared build orchestration (`scripts/build.sh`, `scripts/release/build_unsigned_variant.sh`, matrix-based `release-all-variants.yml` auxiliary jobs); Swift update-authority mapping now has one source (`AppUpdateConfiguration`), targeted updater policy tests pass on macOS, and GUI checksum-publication symmetry is explicitly documented as deferred while Sparkle remains canonical GUI integrity authority
     - trust-chain future work is now explicitly tracked: detached signatures + signing-key rotation for CLI update artifacts (`docs/roadmap/CLI_DISTRIBUTION_CI_MILESTONES.md`, milestone M5)
-- latest stable release on `main`: `v0.17.12`
+- latest stable release on `main`: `v0.18.0`
 - validation gates are green through the stable cut (`cargo test`, macOS `xcodebuild` tests, locale integrity/length audits, release workflow smoke across `v0.17.0-rc.1` through `v0.17.0-rc.5`)
 - `v0.15.0` released on `main` (tag `v0.15.0`)
 - `v0.14.0` released (merged to `main`, tagged, manager rollout + docs/version alignment complete)
@@ -375,8 +375,8 @@ Current checkpoint:
 - `v0.14.0` distribution/licensing architecture planning docs aligned (future-state, no implementation changes)
 
 Next release targets:
-- `v0.18.x` — Doctor/repair and local security groundwork (implementation complete; `v0.18.0` release validation in progress)
 - `v0.19.x` — Stability & Pre-1.0 hardening
+- `v1.0.0` — Stable control plane release
 
 ## Historical v0.17.x Delivery Tracker (0.17.3 Checkpoint)
 
@@ -1271,3 +1271,4 @@ Delivered:
 - Distribution/licensing future-state planning documentation is aligned for 0.14 release notes and roadmap planning (no implementation yet).
 - 0.14.x and 0.15.x release execution are complete on `main` (`v0.14.1` and `v0.15.0`).
 - 0.17.12 release execution is complete on `main`; 0.17.x diagnostics/logging delivery and post-`0.17.x` follow-up stabilization are now closed with stable lineage `v0.17.0`, `v0.17.1`, `v0.17.2`, `v0.17.3`, `v0.17.4`, `v0.17.5`, `v0.17.6`, `v0.17.7`, `v0.17.8`, `v0.17.9`, `v0.17.10`, `v0.17.11`, and `v0.17.12`.
+- 0.18.0 release execution is complete on `main`; doctor/repair persistence and execution plus internal local-security groundwork are published with notarized GUI and direct CLI artifacts.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -62,7 +62,7 @@ This checklist is required before creating a release tag on `main`.
   - `CLI Update Metadata Drift Guard`
 - [ ] Review `TMP_RELEASE_FRICTION`; promote recurring friction items into durable docs (`docs/DECISIONS.md`, `docs/operations/CLI_RELEASE_AND_CI.md`) and keep temporary notes uncommitted.
 
-## v0.18.0 (Stable Release Gate, Pending)
+## v0.18.0 (Stable Release Gate, Completed)
 
 ### Scope
 
@@ -76,12 +76,12 @@ This checklist is required before creating a release tag on `main`.
 
 - [x] Doctor/repair and advisory persistence suites cover deterministic lifecycle, hostile imports, stale completion, normalization, and transactional rejection behavior.
 - [x] Run the full repository quality gate, documentation sync, Sparkle checklist, and non-mutating release rehearsal from the release-preparation branch.
-- [ ] Merge release preparation through `dev` and the protected `dev` to `main` path.
-- [ ] Run rehearsal and preflight from a clean, current `main` checkout.
-- [ ] Run a fresh successful `Release macOS Canary` on `macos-26` after the final release changes.
-- [ ] Dispatch and pass `Release Publish Auth Check` with `write_probe=true` after explicit maintainer approval.
-- [ ] Obtain explicit maintainer approval before tag creation and publication.
-- [ ] Complete release publication and post-publication metadata verification.
+- [x] Merge release preparation through `dev` and the protected `dev` to `main` path.
+- [x] Run rehearsal and preflight from a clean, current `main` checkout.
+- [x] Run a fresh successful `Release macOS Canary` on `macos-26` after the final release changes.
+- [x] Dispatch and pass `Release Publish Auth Check` with `write_probe=true` after explicit maintainer approval.
+- [x] Obtain explicit maintainer approval before tag creation and publication.
+- [x] Complete release publication and post-publication metadata verification.
 
 ## v0.17.12 (Stable Patch Release Gate, Completed)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -543,7 +543,7 @@ Exit Criteria:
 
 ---
 
-## v0.17.12 — Upgrade Workflow Authority Correction (pending patch)
+## v0.17.12 — Upgrade Workflow Authority Correction (released)
 
 Goal:
 
@@ -559,9 +559,9 @@ Exit Criteria:
 
 ---
 
-## 0.18.x — Doctor & Repair Foundation - Completed on `dev`
+## 0.18.x — Doctor & Repair Foundation - Released on `main`
 
-Release status: included in the `v0.18.0` stable release validation.
+Release status: published in the `v0.18.0` stable release.
 
 Goal:
 
@@ -626,9 +626,9 @@ Stage 3 (`1.4.x`) — Shared Brain:
 
 ---
 
-## 0.18.x — Local Security Groundwork (second slice) - Completed on `dev`
+## 0.18.x — Local Security Groundwork (second slice) - Released on `main`
 
-Release status: included in the `v0.18.0` stable release validation.
+Release status: published in the `v0.18.0` stable release.
 
 Goal:
 

--- a/docs/contracts/release-line.json
+++ b/docs/contracts/release-line.json
@@ -1,3 +1,3 @@
 {
-  "stable_version": "0.17.12"
+  "stable_version": "0.18.0"
 }

--- a/docs/operations/RELEASE_FLOW.md
+++ b/docs/operations/RELEASE_FLOW.md
@@ -56,6 +56,8 @@ After explicit maintainer approval:
    scripts/release/runbook.sh verify --tag vX.Y.Z
    ```
 
+   The verify command uses an explicit post-publication preflight mode that permits stable metadata to equal the released tag. Standalone preflight and tag preparation remain strict and reject that state.
+
 7. Confirm public `https://helmapp.dev/updates/appcast.xml` and `https://helmapp.dev/updates/cli/latest.json` reference the released version.
 
 ## Recovery Rules
@@ -65,6 +67,7 @@ After explicit maintainer approval:
 - If neither credential can create the publish branch/PR, retrieve the generated metadata from the workflow artifact, open the documented `chore/publish-*` PR manually, merge it, then run `verify_only`. Do not regenerate or replace release artifacts.
 - If a workflow/runtime upgrade fails the canary, update the runner label, expected Xcode major, and immutable action pin together in a dedicated workflow-maintenance PR before the next tag.
 - Record recurring friction in `TMP_RELEASE_FRICTION` and promote it to durable docs or contracts before the next release.
+- Preflight requires every release and drift-monitor workflow to report GitHub state `active`; re-enable workflows that GitHub marks `disabled_inactivity`, then run the affected monitor before release sign-off.
 
 ## Credential Ownership
 

--- a/scripts/release/preflight.sh
+++ b/scripts/release/preflight.sh
@@ -11,6 +11,7 @@ CHECK_SECRETS=1
 CHECK_WORKFLOWS=1
 CHECK_RULESET_POLICY=1
 ALLOW_EXISTING_TAG=0
+ALLOW_PUBLISHED_METADATA=0
 TAG_NAME=""
 ERROR_COUNT=0
 WARN_COUNT=0
@@ -29,6 +30,7 @@ Options:
   --skip-workflows            Skip GitHub workflow presence checks.
   --skip-ruleset-policy       Skip main-branch ruleset bypass policy checks.
   --allow-existing-tag        Allow tag to already exist locally/remotely.
+  --allow-published-metadata  Allow stable metadata to equal the target during post-publication verification.
   -h, --help                  Show this help.
 
 This script validates release prerequisites before tagging/publishing.
@@ -315,7 +317,11 @@ check_pre_tag_metadata_snapshot() {
     info "stable metadata on origin/main is behind target tag (${appcast_version} < ${expected_version})"
     ;;
   0)
-    fail "stable metadata on origin/main already matches target version ${expected_version}; choose the next tag or resolve existing publication state"
+    if [ "$ALLOW_PUBLISHED_METADATA" -eq 1 ]; then
+      info "stable metadata on origin/main matches target version ${expected_version} (post-publication verification)"
+    else
+      fail "stable metadata on origin/main already matches target version ${expected_version}; choose the next tag or resolve existing publication state"
+    fi
     ;;
   1)
     fail "stable metadata on origin/main is ahead of target version (${appcast_version} > ${expected_version})"
@@ -577,6 +583,12 @@ check_required_workflows() {
     return
   fi
 
+  local repo
+  if ! repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)" || [ -z "$repo" ]; then
+    fail "unable to resolve repository slug for workflow state checks"
+    return
+  fi
+
   local required_workflows=(
     "release-macos-dmg.yml"
     "release-cli-direct.yml"
@@ -587,10 +599,14 @@ check_required_workflows() {
     "cli-update-drift.yml"
   )
 
-  local wf
+  local wf workflow_state
   for wf in "${required_workflows[@]}"; do
-    if ! gh workflow view "$wf" >/dev/null 2>&1; then
+    if ! workflow_state="$(gh api "repos/${repo}/actions/workflows/${wf}" --jq '.state' 2>/dev/null)"; then
       fail "required workflow not found or inaccessible: ${wf}"
+      continue
+    fi
+    if [ "$workflow_state" != "active" ]; then
+      fail "required workflow is not active: ${wf} (state=${workflow_state:-unknown})"
     fi
   done
 }
@@ -678,6 +694,10 @@ parse_args() {
       ;;
     --allow-existing-tag)
       ALLOW_EXISTING_TAG=1
+      shift
+      ;;
+    --allow-published-metadata)
+      ALLOW_PUBLISHED_METADATA=1
       shift
       ;;
     -h | --help)

--- a/scripts/release/runbook.sh
+++ b/scripts/release/runbook.sh
@@ -231,7 +231,7 @@ cmd_verify() {
   local missing=""
 
   phase_info "preflight" "running release preflight for ${tag}"
-  "${PREFLIGHT_SCRIPT}" --tag "$tag" --allow-non-main --allow-dirty --skip-secrets --skip-workflows --allow-existing-tag
+  "${PREFLIGHT_SCRIPT}" --tag "$tag" --allow-non-main --allow-dirty --skip-secrets --skip-workflows --allow-existing-tag --allow-published-metadata
 
   if ! gh release view "$tag" >/dev/null 2>&1; then
     fail "GitHub release not found for ${tag}"

--- a/scripts/release/tests/preflight_post_publish_contract.sh
+++ b/scripts/release/tests/preflight_post_publish_contract.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PREFLIGHT_SOURCE="${ROOT_DIR}/scripts/release/preflight.sh"
+
+fail() {
+  printf '[preflight-post-publish-contract] error: %s\n' "$1" >&2
+  exit 1
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+TEST_ROOT="${TMP_DIR}/repo"
+mkdir -p "${TEST_ROOT}/scripts/release" "${TEST_ROOT}/web/public/updates/cli" "${TMP_DIR}/bin"
+cp "$PREFLIGHT_SOURCE" "${TEST_ROOT}/scripts/release/preflight.sh"
+chmod +x "${TEST_ROOT}/scripts/release/preflight.sh"
+
+cat > "${TEST_ROOT}/web/public/updates/appcast.xml" <<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <item>
+      <title>Helm 0.18.0</title>
+      <enclosure sparkle:shortVersionString="0.18.0" />
+    </item>
+  </channel>
+</rss>
+XML
+
+cat > "${TEST_ROOT}/web/public/updates/cli/latest.json" <<'JSON'
+{
+  "version": "0.18.0",
+  "channel": "stable"
+}
+JSON
+
+cat > "${TMP_DIR}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "${1:-}" = "auth" ] && [ "${2:-}" = "status" ]; then
+  exit 0
+fi
+if [ "${1:-}" = "api" ] && [ "${2:-}" = "-i" ] && [ "${3:-}" = "user" ]; then
+  printf 'HTTP/2 200\nx-oauth-scopes: repo, workflow\n'
+  exit 0
+fi
+if [ "${1:-}" = "repo" ] && [ "${2:-}" = "view" ]; then
+  printf 'example/helm\n'
+  exit 0
+fi
+if [ "${1:-}" = "api" ] && [[ "${2:-}" == repos/example/helm/actions/workflows/* ]]; then
+  workflow="${2##*/}"
+  if [ "$workflow" = "${HELM_STUB_DISABLED_WORKFLOW:-}" ]; then
+    printf 'disabled_inactivity\n'
+  else
+    printf 'active\n'
+  fi
+  exit 0
+fi
+exit 97
+STUB
+chmod +x "${TMP_DIR}/bin/gh"
+
+git -C "$TEST_ROOT" init -q -b task
+git -C "$TEST_ROOT" config user.name "Helm Release Contract"
+git -C "$TEST_ROOT" config user.email "release-contract@example.invalid"
+git -C "$TEST_ROOT" add web scripts/release/preflight.sh
+git -C "$TEST_ROOT" commit -q -m "test fixture"
+git -C "$TEST_ROOT" update-ref refs/remotes/origin/main HEAD
+
+base_args=(
+  --tag v0.18.0
+  --allow-non-main
+  --no-fetch
+  --skip-secrets
+  --skip-ruleset-policy
+  --allow-existing-tag
+)
+common_args=("${base_args[@]}" --skip-workflows)
+
+if PATH="${TMP_DIR}/bin:${PATH}" "${TEST_ROOT}/scripts/release/preflight.sh" "${common_args[@]}" >"${TMP_DIR}/strict.log" 2>&1; then
+  fail "equal published metadata must fail in strict pre-tag mode"
+fi
+grep -F "stable metadata on origin/main already matches target version 0.18.0" "${TMP_DIR}/strict.log" >/dev/null || \
+  fail "strict pre-tag failure reason was not reported"
+
+PATH="${TMP_DIR}/bin:${PATH}" "${TEST_ROOT}/scripts/release/preflight.sh" \
+  "${common_args[@]}" --allow-published-metadata >"${TMP_DIR}/post-publish.log" 2>&1
+grep -F "stable metadata on origin/main matches target version 0.18.0 (post-publication verification)" \
+  "${TMP_DIR}/post-publish.log" >/dev/null || fail "post-publication acceptance was not reported"
+
+if HELM_STUB_DISABLED_WORKFLOW=appcast-drift.yml PATH="${TMP_DIR}/bin:${PATH}" \
+  "${TEST_ROOT}/scripts/release/preflight.sh" "${base_args[@]}" --allow-published-metadata \
+  >"${TMP_DIR}/disabled-workflow.log" 2>&1; then
+  fail "disabled required workflow must fail preflight"
+fi
+grep -F "required workflow is not active: appcast-drift.yml (state=disabled_inactivity)" \
+  "${TMP_DIR}/disabled-workflow.log" >/dev/null || fail "disabled workflow failure reason was not reported"
+
+PATH="${TMP_DIR}/bin:${PATH}" "${TEST_ROOT}/scripts/release/preflight.sh" \
+  "${base_args[@]}" --allow-published-metadata >"${TMP_DIR}/active-workflows.log" 2>&1
+
+printf '[preflight-post-publish-contract] passed\n'

--- a/scripts/release/tests/release_workflow_contract.sh
+++ b/scripts/release/tests/release_workflow_contract.sh
@@ -65,5 +65,7 @@ done
 
 expect_pattern 'branches: \[dev, main\]' "$WEB_BUILD_WORKFLOW" "web build must cover dev and main integration branches"
 expect_pattern '"web/\*\*"' "$WEB_BUILD_WORKFLOW" "web build must filter for web paths"
+expect_pattern 'actions/workflows/\$\{wf\}' "$PREFLIGHT_SCRIPT" "release preflight must query required workflow state"
+expect_pattern 'required workflow is not active' "$PREFLIGHT_SCRIPT" "release preflight must reject disabled required workflows"
 
 printf '[release-workflow-contract] passed\n'

--- a/web/src/components/starlight/Banner.astro
+++ b/web/src/components/starlight/Banner.astro
@@ -1,5 +1,5 @@
 ---
-const globalBanner = `<strong>Helm v0.17.12 is live.</strong> Install the latest release and report issues on <a href="https://github.com/jasoncavinder/Helm/issues/new/choose" target="_blank" rel="noreferrer">GitHub</a>.`;
+const globalBanner = `<strong>Helm v0.18.0 is live.</strong> Install the latest release and report issues on <a href="https://github.com/jasoncavinder/Helm/issues/new/choose" target="_blank" rel="noreferrer">GitHub</a>.`;
 const pageBanner = Astro.locals.starlightRoute.entry.data.banner?.content;
 const banners = [globalBanner, pageBanner].filter(Boolean);
 ---

--- a/web/src/content/docs/changelog.md
+++ b/web/src/content/docs/changelog.md
@@ -11,6 +11,23 @@ For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncav
 
 ---
 
+## 0.18.0 — 2026-08-03
+
+Helm `0.18.0` publishes the local doctor/repair foundation and internal security-advisory cache groundwork.
+
+### Added
+- SQLite-backed doctor scan generations, finding lifecycle, repair knowledge, local overrides, provenance, and repair history.
+- Deterministic finding fingerprints and scoped scan completion semantics across CLI and FFI/XPC paths.
+- Internal advisory records and cache persistence with normalized identity, freshness evaluation, deterministic ordering, and pruning.
+
+### Changed
+- Repair planning resolves persisted, integrity-checked knowledge through a compiled allowlist of typed actions.
+- Repair execution revalidates active findings, records history, and verifies outcomes with follow-up scans.
+
+### Security
+- Knowledge imports reject forged trust, policy weakening, equivocation, protected rebinding, unknown actions, and executable payload content.
+- Advisory providers, scheduler integration, doctor advisory findings, and public advisory UI/CLI surfaces remain deferred beyond `0.18.x`.
+
 ## 0.17.12 — 2026-07-29
 
 Patch `0.17.12` moves bulk and scoped upgrade workflow sequencing into the Rust execution boundary.

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -17,7 +17,7 @@ Helm is planned as two product lifecycles: **Helm (Consumer)** and **Helm Busine
 
 ## What it does today
 
-Helm `v0.17.12` supports twenty-eight managers:
+Helm `v0.18.0` supports twenty-eight managers:
 
 | Category | Managers |
 |---------|----------|
@@ -45,7 +45,7 @@ Key features:
 - **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, `ja`, and `hu` with locale override in Settings
 - **Upgrade transparency** — dedicated upgrade preview surface with scoped execution and failure-attribution visibility
 
-> **Current Track:** `v0.17.12` is the latest stable release on `main`; `v0.18.0` implementation is complete on `dev` and is in release validation. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.18.0` is the latest stable release on `main`; `v0.19.x` stability and pre-1.0 hardening is next. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## How it works
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -32,14 +32,14 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 | 0.15.x | Advanced Upgrade Transparency — richer execution-plan visibility, failure isolation, and operator controls (`v0.15.0` released) |
 | 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification (`v0.16.x` stable, latest patch `v0.16.2`) |
 | 0.17.x | Diagnostics & Logging + Release Hardening — task log viewer, structured diagnostics export, manager-detection diagnostics, onboarding/detection hardening, manager-selection controls, and stable release follow-up fixes (`v0.17.0` stable, latest patch `v0.17.12`) |
+| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge and internal advisory cache foundation (`v0.18.0` stable; advisory surface remains internal only) |
 
-> **Current Track:** `v0.17.12` is stable on `main`; `v0.18.0` implementation is complete on `dev` and is in release validation. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.18.0` is stable on `main`; `v0.19.x` stability and pre-1.0 hardening is next. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Planned
 
 | Version | Milestone |
 |---|---|
-| 0.18.x | Doctor & Repair + Local Security Groundwork — implementation complete; `v0.18.0` release validation in progress (advisory surface remains internal only) |
 | 0.19.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit |
 | 1.0.0 | Stable Control Plane Release — production-safe execution, full feature set |
 


### PR DESCRIPTION
## Summary

- mark v0.18.0 as the current stable release across source-of-truth docs, README, website roadmap/changelog, and release-line contract
- make `runbook verify` use an explicit post-publication preflight mode while preserving strict pre-tag metadata ordering
- require GitHub release workflows and drift guards to be active, including protection against `disabled_inactivity`
- add executable regression coverage for strict metadata behavior and inactive workflow rejection

## Release verification

- `scripts/release/runbook.sh verify --tag v0.18.0`
- live `scripts/release/preflight.sh --allow-non-main --allow-dirty`
- Appcast Drift Guard run 30883048546
- CLI Update Metadata Drift Guard run 30883048526
- Release Publish Verify run 30882909142
- all release contract scripts, including the new post-publication contract
- `npm run build` in `web/`

## Notes

- v0.18.0 artifacts and metadata were already published before this PR; this PR records completion and fixes the post-publication verification path.
- the restored drift guards are advisory and remain excluded from required branch checks.
