### PR TITLE
hotfix(release): withdraw v0.18.0 update pointers

### DIFF
--- a/web/public/updates/appcast.xml
+++ b/web/public/updates/appcast.xml
@@ -6,16 +6,16 @@
     <description>Helm direct-channel updates</description>
     <language>en</language>
     <item>
-      <title>Helm 0.18.0</title>
-      <pubDate>Tue, 04 Aug 2026 05:53:44 +0000</pubDate>
-      <sparkle:releaseNotesLink>https://helmapp.dev/updates/release-notes/v0.18.0.html</sparkle:releaseNotesLink>
+      <title>Helm 0.17.12</title>
+      <pubDate>Wed, 29 Jul 2026 19:15:22 +0000</pubDate>
+      <sparkle:releaseNotesLink>https://helmapp.dev/updates/release-notes/v0.17.12.html</sparkle:releaseNotesLink>
       <enclosure
-        url="https://github.com/jasoncavinder/Helm/releases/download/v0.18.0/Helm-v0.18.0-macos-universal.dmg"
-        sparkle:version="18000900"
-        sparkle:shortVersionString="0.18.0"
-        sparkle:edSignature="kRR4A3Q+QEqjDIbDXWUKfPoRSyrlabIwW6vMb9kG6rLwaYy9zVeLUgcOEl9E7L5/9F9A+GCKuI6R0hLu4MrJCg=="
+        url="https://github.com/jasoncavinder/Helm/releases/download/v0.17.12/Helm-v0.17.12-macos-universal.dmg"
+        sparkle:version="17012900"
+        sparkle:shortVersionString="0.17.12"
+        sparkle:edSignature="CSiapiD0V3Wti0z7aLuh0aglgZVfdnJJdps1PXftAXNbLFjXwb7974PThz8RnXV8KTVXzq/0jrxstVlAW9BnCA=="
          sparkle:minimumSystemVersion="11.0"
-        length="31172875"
+        length="30044720"
         type="application/octet-stream"/>
     </item>
   </channel>

--- a/web/public/updates/cli/latest.json
+++ b/web/public/updates/cli/latest.json
@@ -1,19 +1,19 @@
 {
-  "version": "0.18.0",
+  "version": "0.17.12",
   "channel": "stable",
-  "published_at": "2026-08-04T05:41:06Z",
+  "published_at": "2026-07-29T18:51:18Z",
   "downloads": {
     "universal": {
-      "url": "https://github.com/jasoncavinder/Helm/releases/download/v0.18.0/helm-cli-v0.18.0-darwin-universal",
-      "sha256": "ec900af6eb92f562de041a2aba4ec2d78b1c8de22c1d3fc780a6a69a0555ec85"
+      "url": "https://github.com/jasoncavinder/Helm/releases/download/v0.17.12/helm-cli-v0.17.12-darwin-universal",
+      "sha256": "e2fd054e13f9ec890b6e5377e2e35bdb372b69d8745e80e2417ebe645a9c10fa"
     },
     "arm64": {
-      "url": "https://github.com/jasoncavinder/Helm/releases/download/v0.18.0/helm-cli-v0.18.0-darwin-arm64",
-      "sha256": "9eb757180b41ffb3013f731f796075298f120b7b56384816636567c34d542746"
+      "url": "https://github.com/jasoncavinder/Helm/releases/download/v0.17.12/helm-cli-v0.17.12-darwin-arm64",
+      "sha256": "4e407110d1ed89155cdf0f945f3b007c1be5548d3f286217763408c769d03a2d"
     },
     "x86_64": {
-      "url": "https://github.com/jasoncavinder/Helm/releases/download/v0.18.0/helm-cli-v0.18.0-darwin-x86_64",
-      "sha256": "b48b427b9e5ef8e88ebd150c13c2ee067eadb57d472f2e33b3cf3f9c3074b694"
+      "url": "https://github.com/jasoncavinder/Helm/releases/download/v0.17.12/helm-cli-v0.17.12-darwin-x86_64",
+      "sha256": "e43d919b3490ea671c4d60bceb3e8824aa2cc088307c0d7cea7cf4bf624c827b"
     }
   }
 }


### PR DESCRIPTION
## Summary

- withdraw the v0.18.0 GUI appcast pointer
- restore the exact signed v0.17.12 appcast from the immutable v0.18.0 tag snapshot
- restore the exact v0.17.12 CLI download URLs and checksums

## Incident context

v0.18.0 contains a critical SQLite migration defect and must not remain available through Helm's public update channels. The v0.18.0 tag and release evidence remain preserved; this PR changes only public update pointers.

## Verification

- `git diff --exit-code v0.18.0 -- web/public/updates/appcast.xml web/public/updates/cli/latest.json`
- `apps/macos-ui/scripts/verify_sparkle_appcast_policy.sh web/public/updates/appcast.xml`
- stable CLI metadata schema, URLs, and SHA-256 values validated with `jq`

## Cutover order

Do not merge until the v0.18.0 GitHub release has been converted to draft. Merge immediately afterward so v0.17.12 resumes as the GUI and CLI stable target.
