### PR TITLE
docs(release): mark v0.18.0 withdrawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <br>
   A macOS control center and CLI for unified package manager control.
   <br>
-  <strong>Pre-1.0 &middot; v0.18.0</strong>
+  <strong>Pre-1.0 &middot; v0.17.12</strong>
 </p>
 
 <p align="center">
@@ -23,9 +23,9 @@
 
 Helm manages software across multiple package managers (Homebrew, npm, pip, Cargo, etc.) and runtime tools (mise, rustup) from a single menu bar interface. It is designed as infrastructure software: deterministic, safety-first, and explicit about authority, orchestration, and error handling.
 
-> **Status:** Active pre-1.0 development with stable `v0.18.0` on `main` and `v0.19.x` stability and pre-1.0 hardening next.
+> **Release notice:** Active pre-1.0 development continues with stable `v0.17.12` on `main`. `v0.18.0` has been withdrawn because of a critical SQLite migration defect while `v0.18.1` is prepared.
 >
-> **Testing:** Please test `v0.18.0` and report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Testing:** Please test `v0.17.12`. If you installed `v0.18.0`, avoid further use and preserve your Helm data until recovery guidance is published. Report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Editions (Beta)
 
@@ -191,7 +191,7 @@ Or open `apps/macos-ui/Helm.xcodeproj` in Xcode and run the **Helm** scheme. The
 | 0.16.1 | Documentation, Milestone Restructure & Security Staging Clarification | Completed (documentation-only) |
 | 0.16.2 | Sparkle Connectivity + Platform Baseline Alignment — network-client entitlement, feed diagnostics, macOS 11 deployment target enforcement | Completed |
 | 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel | Completed (`v0.17.x` stable, latest patch `v0.17.12`) |
-| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge and internal advisory cache foundation (no public advisory feature surface) | Completed (`v0.18.0`) |
+| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge and internal advisory cache foundation (no public advisory feature surface) | `v0.18.0` withdrawn; `v0.18.1` remediation in progress |
 | 0.19.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit | Next |
 | 1.0.0 | Stable Control Plane Release — production-safe execution, full feature set | Planned |
 

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,23 +8,24 @@ It reflects reality, not intention.
 
 ## Version
 
-Current documentation baseline: **0.18.0 stable released on `main`**; `v0.19.x` stability and pre-1.0 hardening is the next milestone.
+Current documentation baseline: **0.17.12 is the latest public stable release**; `v0.18.0` was withdrawn because of a critical SQLite migration defect, and `v0.18.1` remediation is in progress.
 
-Implementation baseline: **0.18.x doctor/repair and local security groundwork released on `main`** after diagnostics/logging delivery, package workflow hardening, manager-selection/enablement and onboarding/detection hardening, release-process hardening phases 1-5, current-scope manager adapter completion, and local doctor/repair follow-up for executable-path drift.
+Implementation baseline: **0.18.x doctor/repair and local security groundwork remains implemented on `main` but is not currently distributed** pending the `v0.18.1` corrective release.
 
 See:
 - CHANGELOG.md
 
 Active milestone:
-- latest stable release currently published on `main`: **0.18.0** (released on 2026-08-03)
-- `v0.18.0` is published with notarized universal DMG, direct CLI binaries, appcast, CLI update metadata, release notes, checksums, and provenance.
+- latest stable release currently published on `main`: **0.17.12**
+- `v0.18.0` was published on 2026-08-03 and then withdrawn after discovery of a critical SQLite migration defect; its immutable tag is retained for auditability while its release is not publicly distributed.
+- public GUI and CLI update metadata is restored to the signed `v0.17.12` artifacts while `v0.18.1` remediation and recovery validation completes.
 - `v0.17.12` moves bulk and scoped upgrade authority sequencing into Rust/FFI/XPC; every submitted task reaches a terminal state before the next phase is scheduled, and scoped-workflow cancellation prevents later-phase submission while preserving individual task cancellation and diagnostics.
 - delivered on `main` for **0.18.x**: SQLite-backed doctor finding lifecycle and repair knowledge, deterministic cross-installation fingerprints, guarded bundled/imported knowledge, repair verification history, and the local security-advisory domain/cache groundwork; provider fetchers and user-facing advisory features remain deferred to the staged advisory release.
 - repository operations follow-up on `main`: agent-agnostic operating model with policy-only root `AGENTS.md`, isolated agent task worktrees under `.worktrees/` with the `agent-worktree-isolation` Skill, workflow Skills under `.opencode/skills/`, inactive prompt drafts under `.opencode/templates/`, and structured local notify logging to `dev/logs/agent-runs.ndjson`.
-- latest stable publication cut completed for `v0.18.0`:
-  - workspace, website, appcast, CLI metadata, and release notes reflect the published `0.18.0` stable line.
-  - signed/notarized DMG and direct CLI artifacts passed release canary, publish-auth, provenance, metadata convergence, and drift-guard verification.
-  - release-process follow-up now keeps post-publication verification distinct from strict pre-tag metadata ordering checks.
+- withdrawn release record for `v0.18.0`:
+  - signed/notarized DMG and direct CLI artifacts passed release canary, publish-auth, provenance, metadata convergence, and drift-guard verification before the migration defect was discovered.
+  - the public release and update pointers were withdrawn without deleting or retagging the immutable release history.
+  - `v0.18.1` must validate clean upgrades from `v0.17.12` and recovery from affected `v0.18.0` databases before publication.
 - 0.17.x — Diagnostics & Logging (**stable released on `main`**, RC lineage `v0.17.0-rc.1` through `v0.17.0-rc.5`)
   - delivered: `feat/v0.17-log-foundation` (SQLite-backed task lifecycle logs + retrieval plumbing)
   - delivered: `feat/v0.17-task-log-viewer` (inspector diagnostics logs tab with level/status filters + load-more pagination)
@@ -101,7 +102,7 @@ Active milestone:
   - delivered for `v0.17.11`: task terminal transitions and request/response persistence now preserve final results deterministically; Homebrew formula and cask work share one execution lease; XPC connections reuse one service runtime; system-manager helper paths are canonicalized before selection; release, cancellation, MacPorts, and XPC hardening close the release line.
   - `v0.17.12` stable release execution status: released on `main` with tag, notarized DMG and CLI assets, published appcast and CLI metadata, and post-publication verification complete.
   - delivered for `v0.17.12`: bulk and scoped upgrade workflow sequencing is backend-owned, authority phases wait for submitted tasks to become terminal, and scoped cancellation prevents later-phase submission.
-  - `v0.18.0` stable release execution status: released on `main` with tag, notarized DMG and CLI assets, published appcast and CLI metadata, provenance, and post-publication verification complete.
+  - `v0.18.0` release execution status: published with notarized DMG and CLI assets, then withdrawn because of a critical SQLite migration defect; `v0.17.12` remains the public stable line pending `v0.18.1`.
   - delivered for `v0.18.0`: persisted doctor/repair lifecycle, guarded repair knowledge, repair verification history, and deterministic local security-advisory cache groundwork without a public advisory surface.
 
 Security rollout staging status:
@@ -1020,4 +1021,4 @@ Helm is a **functional control plane for 28 implemented managers** with:
 
 The core architecture is in place. The Rust core passed a full audit with no critical issues.
 
-0.13.x through 0.18.0 stable checkpoints are complete on `main`; the completed 0.17.x RC and patch lineage led into `v0.18.0`, which publishes the doctor/repair and local-security groundwork milestone.
+0.13.x through 0.17.12 stable checkpoints are complete on `main`; `v0.18.0` was withdrawn, and its doctor/repair and local-security groundwork will return to public distribution through the corrective `v0.18.1` release.

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -11,12 +11,14 @@ It is intentionally tactical.
 Helm is in:
 
 ```
-v0.19.x stability and pre-1.0 hardening (post-v0.18.0 stable release)
+v0.18.1 critical migration remediation and recovery release
 ```
 
 Focus:
-- begin the `v0.19.x` stability and pre-1.0 hardening track with stress, crash-recovery, and memory audits
-- maintain release-process hardening guardrails now that `v0.18.0` publication is complete (preflight, publish verification, drift prevention)
+- complete and review the `v0.18.1` SQLite migration remediation, including affected-database recovery behavior
+- keep `v0.17.12` as the only public stable update target until the corrective release passes every gate
+- validate fresh installs, `v0.17.12 -> v0.18.1` upgrades, and recovery from databases touched by `v0.18.0`
+- resume the `v0.19.x` stability and pre-1.0 hardening track only after the corrective release is complete
 - preserve manager-specific expected nonzero update-check outcomes as completed refreshes with actionable outdated state, starting with rustup's exit code `100`
 - preserve the released SQLite doctor/repair lifecycle, bundled knowledge bootstrap, import/export hardening, and repair verification path without widening into online knowledge lookup
 - preserve the compiled typed-action registry as the immutable execution boundary; knowledge remains declarative and cannot carry commands, arguments, scripts, plugins, or arbitrary executable content
@@ -27,8 +29,8 @@ Focus:
 - keep the agent-agnostic operating model current (lean `AGENTS`, isolated task worktrees under `.worktrees/` via `agent-worktree-isolation`, `.opencode/skills/`, inactive prompt drafts under `.opencode/templates/`, notify logging to `dev/logs/agent-runs.ndjson`, and `scripts/agents/` workflows) so recurring AI workflows remain deterministic and low-friction
 
 Current checkpoint:
-- `0.18.x` internal groundwork is released on `main`: migrations 17-19 persist doctor/repair, ranked repair knowledge, and advisory cache state; strict canonical knowledge envelopes seed and resolve bundled typed repairs; CLI and FFI doctor scans persist scoped generations; CLI and FFI repair tasks record verification outcomes; advisory records have deterministic normalization, validation, ordering, freshness, and transactional SQLite cache behavior.
-- `v0.18.0` is the current stable release on `main`; current-scope manager adapter completion, doctor/repair delivery, local security groundwork, and package workflow hardening are now published:
+- `0.18.x` internal groundwork remains implemented on `main`, but `v0.18.0` was withdrawn because of a critical SQLite migration defect and must not be distributed.
+- `v0.17.12` is the current public stable release while `v0.18.1` remediation and recovery validation is completed; the withdrawn `v0.18.0` implementation included:
   - bulk and scoped upgrade phase coordination now resides in Rust/FFI/XPC. The backend derives the current safe plan, schedules authority phases, waits for each phase to reach terminal state, and stops later-phase scheduling on scoped-workflow cancellation; individual tasks remain the live execution and diagnostics surface.
   - all current manager adapters are considered complete for Helm's intended scope
   - intentionally narrower manager scopes remain explicit (`nix_darwin` detect/refresh-only; detection-only adapters such as `sparkle`, `setapp`, and `parallels_desktop`; guarded/status adapters such as `docker_desktop`, `podman`, `colima`, `rosetta2`, `firmware_updates`, and `xcode_command_line_tools`)
@@ -357,7 +359,7 @@ Current checkpoint:
     - audit-remediation follow-up delivered: stable CLI update metadata now points to published `v0.17.2` CLI release assets with real checksums (no placeholder zeros), and auto-check last-checked timestamps now update only after eligible direct self-managed check attempts instead of policy-gated skips
     - audit-remediation follow-up delivered: distribution profile contract is now centralized in `docs/contracts/distribution-profiles.json` and consumed by shared build orchestration (`scripts/build.sh`, `scripts/release/build_unsigned_variant.sh`, matrix-based `release-all-variants.yml` auxiliary jobs); Swift update-authority mapping now has one source (`AppUpdateConfiguration`), targeted updater policy tests pass on macOS, and GUI checksum-publication symmetry is explicitly documented as deferred while Sparkle remains canonical GUI integrity authority
     - trust-chain future work is now explicitly tracked: detached signatures + signing-key rotation for CLI update artifacts (`docs/roadmap/CLI_DISTRIBUTION_CI_MILESTONES.md`, milestone M5)
-- latest stable release on `main`: `v0.18.0`
+- latest stable release on `main`: `v0.17.12`; `v0.18.0` is withdrawn and `v0.18.1` is in remediation
 - validation gates are green through the stable cut (`cargo test`, macOS `xcodebuild` tests, locale integrity/length audits, release workflow smoke across `v0.17.0-rc.1` through `v0.17.0-rc.5`)
 - `v0.15.0` released on `main` (tag `v0.15.0`)
 - `v0.14.0` released (merged to `main`, tagged, manager rollout + docs/version alignment complete)
@@ -1271,4 +1273,4 @@ Delivered:
 - Distribution/licensing future-state planning documentation is aligned for 0.14 release notes and roadmap planning (no implementation yet).
 - 0.14.x and 0.15.x release execution are complete on `main` (`v0.14.1` and `v0.15.0`).
 - 0.17.12 release execution is complete on `main`; 0.17.x diagnostics/logging delivery and post-`0.17.x` follow-up stabilization are now closed with stable lineage `v0.17.0`, `v0.17.1`, `v0.17.2`, `v0.17.3`, `v0.17.4`, `v0.17.5`, `v0.17.6`, `v0.17.7`, `v0.17.8`, `v0.17.9`, `v0.17.10`, `v0.17.11`, and `v0.17.12`.
-- 0.18.0 release execution is complete on `main`; doctor/repair persistence and execution plus internal local-security groundwork are published with notarized GUI and direct CLI artifacts.
+- 0.18.0 release execution completed but the release was withdrawn because of a critical SQLite migration defect; doctor/repair persistence and local-security groundwork will return through `v0.18.1` after recovery validation.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -62,7 +62,19 @@ This checklist is required before creating a release tag on `main`.
   - `CLI Update Metadata Drift Guard`
 - [ ] Review `TMP_RELEASE_FRICTION`; promote recurring friction items into durable docs (`docs/DECISIONS.md`, `docs/operations/CLI_RELEASE_AND_CI.md`) and keep temporary notes uncommitted.
 
-## v0.18.0 (Stable Release Gate, Completed)
+## v0.18.1 (Corrective Release Gate, In Progress)
+
+### Required Remediation
+
+- [ ] Resolve and review every Critical and High issue identified after the `v0.18.0` withdrawal.
+- [ ] Verify fresh database creation and migration from the `v0.17.12` schema.
+- [ ] Verify safe recovery for databases already touched by `v0.18.0`.
+- [ ] Verify migration atomicity, idempotency, failure rollback, and data preservation.
+- [ ] Complete the full rehearsal, preflight, canary, signing, notarization, publication, and post-publication verification gates.
+
+## v0.18.0 (Withdrawn)
+
+`v0.18.0` was published on 2026-08-03 and withdrawn after discovery of a critical SQLite migration defect. The immutable tag is retained for auditability; `v0.17.12` remains the public stable line until `v0.18.1` is ready.
 
 ### Scope
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -559,9 +559,9 @@ Exit Criteria:
 
 ---
 
-## 0.18.x — Doctor & Repair Foundation - Released on `main`
+## 0.18.x — Doctor & Repair Foundation - Corrective release in progress
 
-Release status: published in the `v0.18.0` stable release.
+Release status: `v0.18.0` was withdrawn because of a critical SQLite migration defect; `v0.18.1` remediation is in progress while `v0.17.12` remains public stable.
 
 Goal:
 
@@ -626,9 +626,9 @@ Stage 3 (`1.4.x`) — Shared Brain:
 
 ---
 
-## 0.18.x — Local Security Groundwork (second slice) - Released on `main`
+## 0.18.x — Local Security Groundwork (second slice) - Corrective release in progress
 
-Release status: published in the `v0.18.0` stable release.
+Release status: implemented on `main`; public distribution resumes with `v0.18.1` after migration remediation and recovery validation.
 
 Goal:
 

--- a/docs/contracts/release-line.json
+++ b/docs/contracts/release-line.json
@@ -1,3 +1,3 @@
 {
-  "stable_version": "0.18.0"
+  "stable_version": "0.17.12"
 }

--- a/web/src/components/starlight/Banner.astro
+++ b/web/src/components/starlight/Banner.astro
@@ -1,5 +1,5 @@
 ---
-const globalBanner = `<strong>Helm v0.18.0 is live.</strong> Install the latest release and report issues on <a href="https://github.com/jasoncavinder/Helm/issues/new/choose" target="_blank" rel="noreferrer">GitHub</a>.`;
+const globalBanner = `<strong>Helm v0.17.12 is live. v0.18.0 has been withdrawn.</strong> Use v0.17.12 while v0.18.1 is prepared. If you installed v0.18.0, avoid further use and preserve your Helm data until recovery guidance is published. Follow updates on <a href="https://github.com/jasoncavinder/Helm/issues" target="_blank" rel="noreferrer">GitHub</a>.`;
 const pageBanner = Astro.locals.starlightRoute.entry.data.banner?.content;
 const banners = [globalBanner, pageBanner].filter(Boolean);
 ---

--- a/web/src/content/docs/changelog.md
+++ b/web/src/content/docs/changelog.md
@@ -13,6 +13,8 @@ For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncav
 
 ## 0.18.0 — 2026-08-03
 
+> **Withdrawn:** `v0.18.0` was removed from public distribution after discovery of a critical SQLite migration defect. `v0.17.12` remains the current stable release while `v0.18.1` is prepared. Users who installed `v0.18.0` should avoid further use and preserve their Helm data until recovery guidance is published.
+
 Helm `0.18.0` publishes the local doctor/repair foundation and internal security-advisory cache groundwork.
 
 ### Added

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -17,7 +17,7 @@ Helm is planned as two product lifecycles: **Helm (Consumer)** and **Helm Busine
 
 ## What it does today
 
-Helm `v0.18.0` supports twenty-eight managers:
+Helm's current implementation supports twenty-eight managers:
 
 | Category | Managers |
 |---------|----------|
@@ -45,7 +45,7 @@ Key features:
 - **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, `ja`, and `hu` with locale override in Settings
 - **Upgrade transparency** — dedicated upgrade preview surface with scoped execution and failure-attribution visibility
 
-> **Current Track:** `v0.18.0` is the latest stable release on `main`; `v0.19.x` stability and pre-1.0 hardening is next. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Release notice:** `v0.18.0` has been withdrawn because of a critical SQLite migration defect. Use `v0.17.12` while `v0.18.1` is prepared. If you installed `v0.18.0`, avoid further use and preserve your Helm data until recovery guidance is published.
 
 ## How it works
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -32,9 +32,9 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 | 0.15.x | Advanced Upgrade Transparency — richer execution-plan visibility, failure isolation, and operator controls (`v0.15.0` released) |
 | 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification (`v0.16.x` stable, latest patch `v0.16.2`) |
 | 0.17.x | Diagnostics & Logging + Release Hardening — task log viewer, structured diagnostics export, manager-detection diagnostics, onboarding/detection hardening, manager-selection controls, and stable release follow-up fixes (`v0.17.0` stable, latest patch `v0.17.12`) |
-| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge and internal advisory cache foundation (`v0.18.0` stable; advisory surface remains internal only) |
+| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge and internal advisory cache foundation (`v0.18.0` withdrawn; `v0.18.1` remediation in progress) |
 
-> **Current Track:** `v0.18.0` is stable on `main`; `v0.19.x` stability and pre-1.0 hardening is next. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.17.12` remains public stable after the `v0.18.0` withdrawal. `v0.18.1` migration remediation and recovery validation is in progress. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Planned
 


### PR DESCRIPTION
## Summary

- restore v0.17.12 as the documented public stable release line
- prominently mark v0.18.0 as withdrawn because of a critical SQLite migration defect
- tell affected users to avoid further use and preserve Helm data pending recovery guidance
- establish the v0.18.1 corrective release gate without erasing v0.18.0 history

## Scope

This PR intentionally excludes appcast and CLI metadata, which are handled by the policy-scoped emergency rollback PR. The v0.18.0 tag remains immutable and retained for auditability.

## Verification

- `scripts/release/check_release_line_copy.sh`
- `git diff --check`
- `npm --prefix web run build`
