### PR TITLE
fix(release): avoid canary version probe pipe failure

### DIFF
--- a/.github/workflows/release-macos-canary.yml
+++ b/.github/workflows/release-macos-canary.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           set -euo pipefail
           MACOS_VERSION="$(sw_vers -productVersion)"
-          XCODE_VERSION="$(xcodebuild -version | awk '/^Xcode / {print $2; exit}')"
+          XCODE_VERSION="$(xcodebuild -version | awk '/^Xcode / {print $2}')"
           XCODE_MAJOR="${XCODE_VERSION%%.*}"
 
           if [ -z "$XCODE_VERSION" ] || [ "$XCODE_MAJOR" != "$EXPECTED_XCODE_MAJOR" ]; then

--- a/scripts/release/tests/release_workflow_contract.sh
+++ b/scripts/release/tests/release_workflow_contract.sh
@@ -48,6 +48,7 @@ done
 
 expect_pattern 'runs-on: macos-26' "$CANARY_WORKFLOW" "release canary must use the supported macOS runner"
 expect_pattern 'EXPECTED_XCODE_MAJOR: "26"' "$CANARY_WORKFLOW" "release canary must pin the expected Xcode major"
+reject_pattern 'xcodebuild -version.*awk.*exit' "$CANARY_WORKFLOW" "release canary must not close the xcodebuild version pipe early"
 expect_pattern 'cargo test --workspace --manifest-path core/rust/Cargo.toml -- --test-threads=1' "$CANARY_WORKFLOW" "release canary must run the serialized Rust release gate"
 expect_pattern 'Build unsigned universal release app' "$CANARY_WORKFLOW" "release canary must build an unsigned universal app"
 


### PR DESCRIPTION
## Summary

- What changed: Keeps the canary Xcode-version parser attached until `xcodebuild -version` finishes and adds a contract rejecting early parser exits.
- Why: The macOS 26 runner image now throws `NSFileHandleOperationException` when `awk` exits after the first version line and closes the pipe while `xcodebuild` is still writing.

## Branch Policy

- [x] Base branch is correct for this scope (`dev` or `main` hotfix/promotion flow).
- [x] Head branch naming follows policy.
- [x] If targeting `main`, source branch is valid per the categories above.

## Scope Declaration

- [ ] App/core/runtime changes included
- [ ] Docs-only changes included
- [ ] Website-only changes included

Release-workflow-only changes included.

## Validation

- [x] Relevant local validation was run (tests/lint/build as applicable).
- [x] Required CI checks for the target branch are expected to pass.
- [x] No unrelated changes were bundled.
- [x] If docs were changed, terminology matches contract (`manager`/`task`/`service` for user-facing docs; `adapter` reserved for architecture/developer docs).

Validation completed:

- `scripts/release/tests/release_workflow_contract.sh`
- `scripts/release/tests/ci_toolchain_contract.sh`
- `bash -n scripts/release/tests/release_workflow_contract.sh`
- `git diff --check`

Failed canary evidence: [run 30909094133](https://github.com/jasoncavinder/Helm/actions/runs/30909094133). The failure occurred in the Xcode-version preflight before product tests or builds started.

## Release Impact

- [x] No shipped-product release impact.
- [ ] Release impact exists and checklist/docs were updated (`docs/RELEASE_CHECKLIST.md`, `docs/CURRENT_STATE.md`, `docs/NEXT_STEPS.md`).

This repairs a mandatory `v0.18.1` release gate. No tag, artifact publication, or public metadata mutation is included.
