### PR TITLE
test: stabilize active install timeout coverage

### DIFF
--- a/core/rust/crates/helm-core/tests/tokio_process_executor.rs
+++ b/core/rust/crates/helm-core/tests/tokio_process_executor.rs
@@ -182,7 +182,9 @@ async fn hard_timeout_extends_for_active_install_process() {
             "for i in 1 2 3 4 5 6 7 8 9 10; do echo tick; sleep 0.2; done",
         ]),
     )
-    .timeout(Duration::from_millis(1500))
+    // The command must cross the base deadline while retaining CI scheduling
+    // margin before the active-install extension expires.
+    .timeout(Duration::from_millis(1900))
     .idle_timeout(Duration::from_secs(5));
 
     let handle = spawn_validated(&executor, request).expect("spawn should succeed");


### PR DESCRIPTION
## Summary

- What changed: Increases the active-install timeout test’s base deadline from 1.5s to 1.9s, preserving the required extension while expanding the total deadline from 3.0s to 3.8s.
- Why: The nominal 2-second command exceeded the original extended deadline under load on the macOS canary runner, producing a test-only false failure.

## Branch Policy

- [x] Base branch is correct for this scope (`dev` or `main` hotfix/promotion flow).
- [x] Head branch naming follows policy.
- [x] If targeting `main`, source branch is valid per the categories above.

## Scope Declaration

- [x] App/core/runtime changes included
- [ ] Docs-only changes included
- [ ] Website-only changes included

Test-only Rust timing change; production behavior is unchanged.

## Validation

- [x] Relevant local validation was run (tests/lint/build as applicable).
- [x] Required CI checks for the target branch are expected to pass.
- [x] No unrelated changes were bundled.
- [x] If docs were changed, terminology matches contract (`manager`/`task`/`service` for user-facing docs; `adapter` reserved for architecture/developer docs).

Validation completed:

- Targeted test passed 20 consecutive serialized runs.
- Complete `tokio_process_executor` target passed: 15/15.
- Targeted Clippy passed with warnings denied.
- Rust formatting and `git diff --check` passed.

Failed canary evidence: [run 30911802794](https://github.com/jasoncavinder/Helm/actions/runs/30911802794). All migration contracts passed before this unrelated timing test failed.

## Release Impact

- [x] No shipped-product release impact.
- [ ] Release impact exists and checklist/docs were updated (`docs/RELEASE_CHECKLIST.md`, `docs/CURRENT_STATE.md`, `docs/NEXT_STEPS.md`).

No tag, artifact publication, or public metadata mutation is included.
