### PR TITLE
docs: record v0.18.1 final release gates

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -35,19 +35,19 @@ This checklist is required before creating a release tag on `main`.
 
 ## Release Preflight (All Releases, Mandatory Before Tagging)
 
-- [ ] Run `scripts/release/preflight.sh --tag <vX.Y.Z|vX.Y.Z-rc.N>` from a clean local clone before tag creation.
-- [ ] Read and follow `docs/operations/RELEASE_FLOW.md` before any release mutation.
-- [ ] Run `scripts/release/rehearsal_dry_run.sh --tag <vX.Y.Z|vX.Y.Z-rc.N>` and retain its passing report.
-- [ ] Confirm `Release macOS Canary` passed on `macos-26` after the latest release-workflow or toolchain change.
-- [ ] Dispatch and pass `Release Publish Auth Check` with `write_probe=true` after any release credential rotation or permission change.
-- [ ] Confirm preflight reports token scopes include `repo` and `workflow`.
-- [ ] Confirm preflight validates required release workflows are present and enabled.
-- [ ] Confirm preflight validates required DMG/signing/update secrets are present.
-- [ ] Confirm `RELEASE_PUBLISH_PAT` is configured and authenticated so release-generated publish PRs can receive required checks and auto-merge normally.
-- [ ] Confirm preflight validates `main` ruleset publish-PR bypass policy (prefer GitHub Actions app `pull_request` bypass when available; otherwise use `Repository admin` `pull_request` fallback; no `always` bypass actors).
-- [ ] Confirm preflight snapshot sanity passes for stable tags (`origin/main` appcast + `cli/latest.json` in sync and behind target tag).
-- [ ] Confirm crash/error reporting policy remains local-only for the release line and no automatic remote telemetry path was introduced (`docs/operations/CRASH_REPORTING_POLICY.md`).
-- [ ] Optional wrapper path: `scripts/release/runbook.sh prepare --tag <tag>`.
+- [x] Run `scripts/release/preflight.sh --tag <vX.Y.Z|vX.Y.Z-rc.N>` from a clean local clone before tag creation.
+- [x] Read and follow `docs/operations/RELEASE_FLOW.md` before any release mutation.
+- [x] Run `scripts/release/rehearsal_dry_run.sh --tag <vX.Y.Z|vX.Y.Z-rc.N>` and retain its passing report.
+- [x] Confirm `Release macOS Canary` passed on `macos-26` after the latest release-workflow or toolchain change.
+- [x] Dispatch and pass `Release Publish Auth Check` with `write_probe=true` after any release credential rotation or permission change.
+- [x] Confirm preflight reports token scopes include `repo` and `workflow`.
+- [x] Confirm preflight validates required release workflows are present and enabled.
+- [x] Confirm preflight validates required DMG/signing/update secrets are present.
+- [x] Confirm `RELEASE_PUBLISH_PAT` is configured and authenticated so release-generated publish PRs can receive required checks and auto-merge normally.
+- [x] Confirm preflight validates `main` ruleset publish-PR bypass policy (prefer GitHub Actions app `pull_request` bypass when available; otherwise use `Repository admin` `pull_request` fallback; no `always` bypass actors).
+- [x] Confirm preflight snapshot sanity passes for stable tags (`origin/main` appcast + `cli/latest.json` in sync and behind target tag).
+- [x] Confirm crash/error reporting policy remains local-only for the release line and no automatic remote telemetry path was introduced (`docs/operations/CRASH_REPORTING_POLICY.md`).
+- [x] Optional wrapper path: `scripts/release/runbook.sh prepare --tag <tag>`.
 
 ## Release Publication Verification (All Releases)
 
@@ -73,12 +73,12 @@ This checklist is required before creating a release tag on `main`.
 - [x] Verify safe recovery for databases already touched by `v0.18.0`.
 - [x] Verify migration atomicity, idempotency, failure rollback, and data preservation.
 - [x] Verify affected-database startup through a CLI subprocess and Refresh acceptance through an isolated FFI process.
-- [ ] Verify Refresh and CLI installation through the final signed app/XPC service boundary against recovered database copies.
+- [x] Verify Refresh and CLI installation through the final signed app/XPC service boundary against recovered database copies.
 - [x] Run targeted SQLite, doctor/repair, Rust workspace, macOS UI/service, documentation, web, and release-contract checks after rebasing onto withdrawal-complete `main`.
 - [x] Run the non-mutating `v0.18.1` release rehearsal.
-- [ ] Merge the hotfix through the protected branch path and run rehearsal/preflight from a clean, current `main` checkout.
-- [ ] Run a fresh successful `Release macOS Canary` on `macos-26`.
-- [ ] Obtain explicit maintainer approval before tag creation and publication.
+- [x] Merge the hotfix through the protected branch path and run rehearsal/preflight from a clean, current `main` checkout.
+- [x] Run a fresh successful `Release macOS Canary` on `macos-26`.
+- [x] Obtain explicit maintainer approval before tag creation and publication.
 - [ ] Complete the full rehearsal, preflight, canary, signing, notarization, publication, and post-publication verification gates.
 
 ## v0.18.0 (Withdrawn)


### PR DESCRIPTION
## Summary

- What changed: Records the completed v0.18.1 preflight, signed XPC smoke, publish-auth, canary, and maintainer-approval gates.
- Why: Preserves the final pre-tag evidence in the protected release checklist while leaving publication and post-publication gates open.

## Branch Policy

- [x] Base branch is correct for this scope (`dev` or `main` hotfix/promotion flow).
- [x] Head branch naming follows policy.
- [x] If targeting `main`, source branch is valid per the categories above.

## Scope Declaration

- [ ] App/core/runtime changes included
- [x] Docs-only changes included
- [ ] Website-only changes included

## Validation

- [x] Relevant local validation was run (tests/lint/build as applicable).
- [x] Required CI checks for the target branch are expected to pass.
- [x] No unrelated changes were bundled.
- [x] If docs were changed, terminology matches contract (`manager`/`task`/`service` for user-facing docs; `adapter` reserved for architecture/developer docs).

Local validation:

- Docs structure and merge-marker checks
- Release-line copy contract
- Release workflow, CI toolchain, publish-state, post-publish preflight, provenance, unsigned-build, and rehearsal contracts

Gate evidence:

- Release Publish Auth Check: run `30909094097`
- Final Release macOS Canary: run `30922316042`
- Signed app/XPC recovery smoke: passed against isolated affected-database copies

## Release Impact

- [ ] No release impact.
- [x] Release impact exists and checklist/docs were updated (`docs/RELEASE_CHECKLIST.md`, `docs/CURRENT_STATE.md`, `docs/NEXT_STEPS.md`).
