### PR TITLE
docs: close v0.18.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
 
 ## [Unreleased]
 
-## [0.18.1] - 2026-08-03
+## [0.18.1] - 2026-08-04
 
 ### Fixed
 - SQLite startup now reconciles the known development migration `17` collision before applying the released doctor/repair schema, preserving existing user data.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <br>
   A macOS control center and CLI for unified package manager control.
   <br>
-  <strong>Pre-1.0 &middot; v0.17.12</strong>
+  <strong>Pre-1.0 &middot; v0.18.1</strong>
 </p>
 
 <p align="center">
@@ -23,9 +23,9 @@
 
 Helm manages software across multiple package managers (Homebrew, npm, pip, Cargo, etc.) and runtime tools (mise, rustup) from a single menu bar interface. It is designed as infrastructure software: deterministic, safety-first, and explicit about authority, orchestration, and error handling.
 
-> **Release notice:** Active pre-1.0 development continues with stable `v0.17.12` on `main`. `v0.18.0` has been withdrawn because of a critical SQLite migration defect while the `v0.18.1` corrective release is validated.
+> **Release notice:** Active pre-1.0 development continues with stable `v0.18.1` on `main`. `v0.18.0` remains withdrawn because of a critical SQLite migration defect; `v0.19.x` stability and pre-1.0 hardening is next.
 >
-> **Testing:** Please test `v0.17.12`. If you installed `v0.18.0`, avoid further use and preserve your Helm data until recovery guidance is published. Report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Testing:** Please test `v0.18.1`. If you installed `v0.18.0`, update to `v0.18.1` before further use. Report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Editions (Beta)
 
@@ -191,7 +191,7 @@ Or open `apps/macos-ui/Helm.xcodeproj` in Xcode and run the **Helm** scheme. The
 | 0.16.1 | Documentation, Milestone Restructure & Security Staging Clarification | Completed (documentation-only) |
 | 0.16.2 | Sparkle Connectivity + Platform Baseline Alignment — network-client entitlement, feed diagnostics, macOS 11 deployment target enforcement | Completed |
 | 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel | Completed (`v0.17.x` stable, latest patch `v0.17.12`) |
-| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge and internal advisory cache foundation (no public advisory feature surface) | `v0.18.0` withdrawn; `v0.18.1` remediation in progress |
+| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge and internal advisory cache foundation (no public advisory feature surface) | Completed (`v0.18.1` corrective release; `v0.18.0` withdrawn) |
 | 0.19.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit | Next |
 | 1.0.0 | Stable Control Plane Release — production-safe execution, full feature set | Planned |
 
@@ -249,7 +249,7 @@ The `1.4.x` Shared Brain milestone is planned as **Postgres-first** and **provid
 - Durable Objects / D1 are not the Shared Brain system-of-record.
 - Large artifacts (if introduced later) should live in S3-compatible object storage; Postgres stores references/metadata.
 
-Current releases (`<=0.17.x`) do **not** send package/fingerprint data to a shared backend. Security-advisory value remains local-first until the `1.4.x` Shared Brain milestone.
+Current releases (through `v0.18.1`) do **not** send package/fingerprint data to a shared backend. Security-advisory value remains local-first until the `1.4.x` Shared Brain milestone.
 
 ## Repository Layout
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -474,7 +474,7 @@ Stage 3 (`1.4.x`) - Shared Brain:
 
 - The Security Advisory System (`1.3.x`) is independent of Shared Brain and remains functional without Helm-hosted services.
 - Shared Brain (`1.4.x`) is additive infrastructure that can enrich advisory outcomes but is not a prerequisite for local advisory evaluation.
-- Current releases (`<=0.17.x`) do not send package/fingerprint telemetry to a shared backend.
+- Current releases (through `v0.18.1`) do not send package/fingerprint telemetry to a shared backend.
 - Helm `1.0` crash/error reporting posture is local-only with no automatic remote crash telemetry; operational policy and payload expectations are documented in `docs/operations/CRASH_REPORTING_POLICY.md`.
 
 ---

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,25 +8,25 @@ It reflects reality, not intention.
 
 ## Version
 
-Current documentation baseline: **0.17.12 is the latest public stable release**; `v0.18.0` was withdrawn because of a critical SQLite migration defect, and `v0.18.1` remediation is in progress.
+Current documentation baseline: **0.18.1 is the latest public stable release**; `v0.18.0` remains withdrawn because of a critical SQLite migration defect, and `v0.19.x` stability and pre-1.0 hardening is next.
 
-Implementation baseline: **0.18.x doctor/repair and local security groundwork remains implemented on `main` but is not currently distributed** pending the `v0.18.1` corrective release.
+Implementation baseline: **0.18.x doctor/repair and local security groundwork is released on `main` through corrective `v0.18.1`**; `v0.18.0` remains withdrawn.
 
 See:
 - CHANGELOG.md
 
 Active milestone:
-- latest stable release currently published on `main`: **0.17.12**
+- latest stable release currently published on `main`: **0.18.1**
 - `v0.18.0` was published on 2026-08-03 and then withdrawn after discovery of a critical SQLite migration defect; its immutable tag is retained for auditability while its release is not publicly distributed.
-- public GUI and CLI update metadata is restored to the signed `v0.17.12` artifacts while `v0.18.1` remediation and recovery validation completes.
-- `v0.18.1` hotfix scope: reconcile the known development migration `17` collision before released doctor/repair migrations run and stop replaying historical DDL for already-current databases, restoring service initialization while preserving package identifiers and user data.
+- public GUI and CLI update metadata points to the signed `v0.18.1` artifacts.
+- delivered in `v0.18.1`: reconciliation of the known development migration `17` collision before released doctor/repair migrations run, plus prevention of historical DDL replay for already-current databases, preserving package identifiers and user data.
 - `v0.17.12` moves bulk and scoped upgrade authority sequencing into Rust/FFI/XPC; every submitted task reaches a terminal state before the next phase is scheduled, and scoped-workflow cancellation prevents later-phase submission while preserving individual task cancellation and diagnostics.
 - delivered on `main` for **0.18.x**: SQLite-backed doctor finding lifecycle and repair knowledge, deterministic cross-installation fingerprints, guarded bundled/imported knowledge, repair verification history, and the local security-advisory domain/cache groundwork; provider fetchers and user-facing advisory features remain deferred to the staged advisory release.
 - repository operations follow-up on `main`: agent-agnostic operating model with policy-only root `AGENTS.md`, isolated agent task worktrees under `.worktrees/` with the `agent-worktree-isolation` Skill, workflow Skills under `.opencode/skills/`, inactive prompt drafts under `.opencode/templates/`, and structured local notify logging to `dev/logs/agent-runs.ndjson`.
 - withdrawn release record for `v0.18.0`:
   - signed/notarized DMG and direct CLI artifacts passed release canary, publish-auth, provenance, metadata convergence, and drift-guard verification before the migration defect was discovered.
   - the public release and update pointers were withdrawn without deleting or retagging the immutable release history.
-  - `v0.18.1` must validate clean upgrades from `v0.17.12` and recovery from affected `v0.18.0` databases before publication.
+  - `v0.18.1` completed clean-upgrade validation from `v0.17.12` and recovery validation for affected `v0.18.0` databases before publication.
 - 0.17.x — Diagnostics & Logging (**stable released on `main`**, RC lineage `v0.17.0-rc.1` through `v0.17.0-rc.5`)
   - delivered: `feat/v0.17-log-foundation` (SQLite-backed task lifecycle logs + retrieval plumbing)
   - delivered: `feat/v0.17-task-log-viewer` (inspector diagnostics logs tab with level/status filters + load-more pagination)
@@ -103,8 +103,10 @@ Active milestone:
   - delivered for `v0.17.11`: task terminal transitions and request/response persistence now preserve final results deterministically; Homebrew formula and cask work share one execution lease; XPC connections reuse one service runtime; system-manager helper paths are canonicalized before selection; release, cancellation, MacPorts, and XPC hardening close the release line.
   - `v0.17.12` stable release execution status: released on `main` with tag, notarized DMG and CLI assets, published appcast and CLI metadata, and post-publication verification complete.
   - delivered for `v0.17.12`: bulk and scoped upgrade workflow sequencing is backend-owned, authority phases wait for submitted tasks to become terminal, and scoped cancellation prevents later-phase submission.
-  - `v0.18.0` release execution status: published with notarized DMG and CLI assets, then withdrawn because of a critical SQLite migration defect; `v0.17.12` remains the public stable line pending `v0.18.1`.
+  - `v0.18.0` release execution status: published with notarized DMG and CLI assets, then withdrawn because of a critical SQLite migration defect; `v0.18.1` is its public stable successor.
   - delivered for `v0.18.0`: persisted doctor/repair lifecycle, guarded repair knowledge, repair verification history, and deterministic local security-advisory cache groundwork without a public advisory surface.
+  - `v0.18.1` corrective release execution status: released on `main` with tag, notarized DMG and CLI assets, published appcast and CLI metadata, and post-publication verification complete.
+  - delivered for `v0.18.1`: migration-collision recovery, idempotent initialization for current databases, and restored service/Refresh/CLI operation for affected stores.
 
 Security rollout staging status:
 - Stage 0 (`<=0.16.x`): planning/docs only (active in `0.16.1`)
@@ -1022,4 +1024,4 @@ Helm is a **functional control plane for 28 implemented managers** with:
 
 The core architecture is in place. The Rust core passed a full audit with no critical issues.
 
-0.13.x through 0.17.12 stable checkpoints are complete on `main`; `v0.18.0` was withdrawn, and its doctor/repair and local-security groundwork will return to public distribution through the corrective `v0.18.1` release.
+0.13.x through 0.18.1 stable checkpoints are complete on `main`; `v0.18.0` remains withdrawn, and `v0.18.1` is the corrective stable release for the doctor/repair and local-security groundwork.

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -11,15 +11,13 @@ It is intentionally tactical.
 Helm is in:
 
 ```
-v0.18.1 critical migration remediation and recovery release
+v0.19.x stability and pre-1.0 hardening (post-v0.18.1 corrective release)
 ```
 
 Focus:
-- complete and review the `v0.18.1` SQLite migration remediation, including affected-database recovery behavior
-- keep `v0.17.12` as the only public stable update target until the corrective release passes every gate
-- validate fresh installs, `v0.17.12 -> v0.18.1` upgrades, and recovery from databases touched by `v0.18.0`
-- complete the migration-recovery regression checks, quality gates, release rehearsal, preflight, and explicit approval checkpoints before tagging
-- resume the `v0.19.x` stability and pre-1.0 hardening track only after the corrective release is complete
+- begin the `v0.19.x` stability and pre-1.0 hardening track with stress, crash-recovery, and memory audits
+- maintain release-process hardening guardrails now that `v0.18.1` publication is complete
+- preserve the released `v0.18.1` migration-reconciliation behavior and its affected-database recovery coverage
 - preserve manager-specific expected nonzero update-check outcomes as completed refreshes with actionable outdated state, starting with rustup's exit code `100`
 - preserve the released SQLite doctor/repair lifecycle, bundled knowledge bootstrap, import/export hardening, and repair verification path without widening into online knowledge lookup
 - preserve the compiled typed-action registry as the immutable execution boundary; knowledge remains declarative and cannot carry commands, arguments, scripts, plugins, or arbitrary executable content
@@ -30,9 +28,9 @@ Focus:
 - keep the agent-agnostic operating model current (lean `AGENTS`, isolated task worktrees under `.worktrees/` via `agent-worktree-isolation`, `.opencode/skills/`, inactive prompt drafts under `.opencode/templates/`, notify logging to `dev/logs/agent-runs.ndjson`, and `scripts/agents/` workflows) so recurring AI workflows remain deterministic and low-friction
 
 Current checkpoint:
-- `0.18.x` internal groundwork remains implemented on `main`, but `v0.18.0` was withdrawn because of a critical SQLite migration defect and must not be distributed.
-- a previously recorded development migration `17` (`add_advisory_cache`) can collide with the released doctor/repair migration at the same version, preventing Rust service initialization; `v0.18.1` reconciles that known collision transactionally before dependent migrations run.
-- `v0.17.12` is the current public stable release while `v0.18.1` remediation and recovery validation is completed; the withdrawn `v0.18.0` implementation included:
+- `0.18.x` internal groundwork is released on `main` through `v0.18.1`; `v0.18.0` remains withdrawn because of its critical SQLite migration defect.
+- `v0.18.1` transactionally reconciles the migration `17` collision, avoids historical DDL replay, and passed fresh-install, `v0.17.12` upgrade, and affected-`v0.18.0` recovery validation.
+- `v0.18.1` is the current public stable release; doctor/repair, local security groundwork, migration recovery, and package workflow hardening are now published:
   - bulk and scoped upgrade phase coordination now resides in Rust/FFI/XPC. The backend derives the current safe plan, schedules authority phases, waits for each phase to reach terminal state, and stops later-phase scheduling on scoped-workflow cancellation; individual tasks remain the live execution and diagnostics surface.
   - all current manager adapters are considered complete for Helm's intended scope
   - intentionally narrower manager scopes remain explicit (`nix_darwin` detect/refresh-only; detection-only adapters such as `sparkle`, `setapp`, and `parallels_desktop`; guarded/status adapters such as `docker_desktop`, `podman`, `colima`, `rosetta2`, `firmware_updates`, and `xcode_command_line_tools`)
@@ -361,7 +359,7 @@ Current checkpoint:
     - audit-remediation follow-up delivered: stable CLI update metadata now points to published `v0.17.2` CLI release assets with real checksums (no placeholder zeros), and auto-check last-checked timestamps now update only after eligible direct self-managed check attempts instead of policy-gated skips
     - audit-remediation follow-up delivered: distribution profile contract is now centralized in `docs/contracts/distribution-profiles.json` and consumed by shared build orchestration (`scripts/build.sh`, `scripts/release/build_unsigned_variant.sh`, matrix-based `release-all-variants.yml` auxiliary jobs); Swift update-authority mapping now has one source (`AppUpdateConfiguration`), targeted updater policy tests pass on macOS, and GUI checksum-publication symmetry is explicitly documented as deferred while Sparkle remains canonical GUI integrity authority
     - trust-chain future work is now explicitly tracked: detached signatures + signing-key rotation for CLI update artifacts (`docs/roadmap/CLI_DISTRIBUTION_CI_MILESTONES.md`, milestone M5)
-- latest stable release on `main`: `v0.17.12`; `v0.18.0` is withdrawn and `v0.18.1` is in remediation
+- latest stable release on `main`: `v0.18.1`
 - validation gates are green through the stable cut (`cargo test`, macOS `xcodebuild` tests, locale integrity/length audits, release workflow smoke across `v0.17.0-rc.1` through `v0.17.0-rc.5`)
 - `v0.15.0` released on `main` (tag `v0.15.0`)
 - `v0.14.0` released (merged to `main`, tagged, manager rollout + docs/version alignment complete)
@@ -379,7 +377,6 @@ Current checkpoint:
 - `v0.14.0` distribution/licensing architecture planning docs aligned (future-state, no implementation changes)
 
 Next release targets:
-- `v0.18.1` — SQLite migration-recovery hotfix (validation in progress)
 - `v0.19.x` — Stability & Pre-1.0 hardening
 - `v1.0.0` — Stable control plane release
 
@@ -1276,4 +1273,4 @@ Delivered:
 - Distribution/licensing future-state planning documentation is aligned for 0.14 release notes and roadmap planning (no implementation yet).
 - 0.14.x and 0.15.x release execution are complete on `main` (`v0.14.1` and `v0.15.0`).
 - 0.17.12 release execution is complete on `main`; 0.17.x diagnostics/logging delivery and post-`0.17.x` follow-up stabilization are now closed with stable lineage `v0.17.0`, `v0.17.1`, `v0.17.2`, `v0.17.3`, `v0.17.4`, `v0.17.5`, `v0.17.6`, `v0.17.7`, `v0.17.8`, `v0.17.9`, `v0.17.10`, `v0.17.11`, and `v0.17.12`.
-- 0.18.0 release execution completed but the release was withdrawn because of a critical SQLite migration defect; doctor/repair persistence and local-security groundwork will return through `v0.18.1` after recovery validation.
+- 0.18.1 corrective release execution is complete on `main`; `v0.18.0` remains withdrawn, while doctor/repair persistence, local-security groundwork, and migration recovery are publicly distributed through `v0.18.1`.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -51,18 +51,18 @@ This checklist is required before creating a release tag on `main`.
 
 ## Release Publication Verification (All Releases)
 
-- [ ] Review release workflow summary output for both release workflows:
+- [x] Review release workflow summary output for both release workflows:
   - `Artifacts uploaded: yes`
   - `Publish PR opened: yes/no`
   - `Main metadata synced: yes/no`
-- [ ] If workflow summary reports follow-up required (publish PR still open), merge the publish PR and run workflow_dispatch with `verify_only=true` for the corresponding release workflow to verify `Main metadata synced: yes` without rebuilding artifacts.
-- [ ] Confirm release publication verification status is green after publish PR merge:
+- [x] If workflow summary reports follow-up required (publish PR still open), merge the publish PR and run workflow_dispatch with `verify_only=true` for the corresponding release workflow to verify `Main metadata synced: yes` without rebuilding artifacts.
+- [x] Confirm release publication verification status is green after publish PR merge:
   - `Release Publish Verify`
   - `Appcast Drift Guard`
   - `CLI Update Metadata Drift Guard`
-- [ ] Review `TMP_RELEASE_FRICTION`; promote recurring friction items into durable docs (`docs/DECISIONS.md`, `docs/operations/CLI_RELEASE_AND_CI.md`) and keep temporary notes uncommitted.
+- [x] Review `TMP_RELEASE_FRICTION`; promote recurring friction items into durable docs (`docs/DECISIONS.md`, `docs/operations/CLI_RELEASE_AND_CI.md`) and keep temporary notes uncommitted.
 
-## v0.18.1 (Corrective Release Gate, In Progress)
+## v0.18.1 (Corrective Release Gate, Completed)
 
 ### Required Remediation
 
@@ -79,11 +79,11 @@ This checklist is required before creating a release tag on `main`.
 - [x] Merge the hotfix through the protected branch path and run rehearsal/preflight from a clean, current `main` checkout.
 - [x] Run a fresh successful `Release macOS Canary` on `macos-26`.
 - [x] Obtain explicit maintainer approval before tag creation and publication.
-- [ ] Complete the full rehearsal, preflight, canary, signing, notarization, publication, and post-publication verification gates.
+- [x] Complete the full rehearsal, preflight, canary, signing, notarization, publication, and post-publication verification gates.
 
 ## v0.18.0 (Withdrawn)
 
-`v0.18.0` was published on 2026-08-03 and withdrawn after discovery of a critical SQLite migration defect. The immutable tag is retained for auditability; `v0.17.12` remains the public stable line until `v0.18.1` is ready.
+`v0.18.0` was published on 2026-08-03 and withdrawn after discovery of a critical SQLite migration defect. The immutable tag is retained for auditability; `v0.18.1` is the corrective public stable successor.
 
 ### Scope
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -559,9 +559,9 @@ Exit Criteria:
 
 ---
 
-## 0.18.x — Doctor & Repair Foundation - Corrective release in progress
+## 0.18.x — Doctor & Repair Foundation - Released on `main`
 
-Release status: `v0.18.0` was withdrawn because of a critical SQLite migration defect; `v0.18.1` remediation is in progress while `v0.17.12` remains public stable.
+Release status: published through corrective `v0.18.1`; `v0.18.0` remains withdrawn because of its critical SQLite migration defect.
 
 Goal:
 
@@ -626,9 +626,9 @@ Stage 3 (`1.4.x`) — Shared Brain:
 
 ---
 
-## 0.18.x — Local Security Groundwork (second slice) - Corrective release in progress
+## 0.18.x — Local Security Groundwork (second slice) - Released on `main`
 
-Release status: implemented on `main`; public distribution resumes with `v0.18.1` after migration remediation and recovery validation.
+Release status: published through `v0.18.1` after migration remediation and recovery validation.
 
 Goal:
 

--- a/docs/contracts/release-line.json
+++ b/docs/contracts/release-line.json
@@ -1,3 +1,3 @@
 {
-  "stable_version": "0.17.12"
+  "stable_version": "0.18.1"
 }

--- a/docs/operations/CLI_RELEASE_AND_CI.md
+++ b/docs/operations/CLI_RELEASE_AND_CI.md
@@ -447,6 +447,11 @@ Promotion path after each release:
    - operator/runbook/checklist updates -> this file and `docs/RELEASE_CHECKLIST.md`
 4. link the fixing PR/commit in the promoted entry and close the temporary friction item
 
+`v0.18.1` closeout identified two follow-up items:
+
+- `scripts/release/runbook.sh tag` requires a branch named `main`, while agent policy requires release work in an isolated linked worktree and reserves the primary `main` checkout for coordination. Add a worktree-safe tag path that requires a clean `HEAD` exactly equal to `origin/main` before mutation ([#333](https://github.com/jasoncavinder/Helm/issues/333)).
+- The direct CLI and DMG workflows successfully uploaded artifacts and opened publish PRs, but their immediate metadata checks still concluded as failures while `main` intentionally remained behind those PRs. Align the workflow result and publication summary with the documented non-red follow-up-required state; hard failures must remain unchanged for build, signing, notarization, verification, upload, or PR-creation faults ([#332](https://github.com/jasoncavinder/Helm/issues/332)).
+
 ---
 
 ## 6. Install Script CI Responsibilities

--- a/web/public/updates/release-notes/v0.18.1.html
+++ b/web/public/updates/release-notes/v0.18.1.html
@@ -87,7 +87,7 @@
   <main>
     <article>
       <h1>Helm 0.18.1 Release Notes</h1>
-      <p class="meta">Release date: August 3, 2026</p>
+      <p class="meta">Release date: August 4, 2026</p>
     <h2>Fixed</h2>
     <ul>
       <li>SQLite startup now reconciles the known development migration <code>17</code> collision before applying the released doctor/repair schema, preserving existing user data.</li>

--- a/web/src/components/starlight/Banner.astro
+++ b/web/src/components/starlight/Banner.astro
@@ -1,5 +1,5 @@
 ---
-const globalBanner = `<strong>Helm v0.17.12 is live. v0.18.0 has been withdrawn.</strong> Use v0.17.12 while v0.18.1 is prepared. If you installed v0.18.0, avoid further use and preserve your Helm data until recovery guidance is published. Follow updates on <a href="https://github.com/jasoncavinder/Helm/issues" target="_blank" rel="noreferrer">GitHub</a>.`;
+const globalBanner = `<strong>Helm v0.18.1 is live.</strong> v0.18.0 remains withdrawn; users of v0.18.0 should update to v0.18.1 before further use. Report issues on <a href="https://github.com/jasoncavinder/Helm/issues/new/choose" target="_blank" rel="noreferrer">GitHub</a>.`;
 const pageBanner = Astro.locals.starlightRoute.entry.data.banner?.content;
 const banners = [globalBanner, pageBanner].filter(Boolean);
 ---

--- a/web/src/content/docs/changelog.md
+++ b/web/src/content/docs/changelog.md
@@ -11,9 +11,18 @@ For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncav
 
 ---
 
+## 0.18.1 — 2026-08-04
+
+Patch `0.18.1` is the corrective stable successor to withdrawn `v0.18.0`.
+
+### Fixed
+- SQLite startup now reconciles the known development migration `17` collision before applying the released doctor/repair schema, preserving existing user data.
+- Already-current databases no longer replay destructive historical DDL during startup, preserving package identifiers and making repeated migration initialization idempotent.
+- Rust service initialization now succeeds for affected databases, restoring Refresh task submission and Helm CLI installation after updating to `v0.18.0`.
+
 ## 0.18.0 — 2026-08-03
 
-> **Withdrawn:** `v0.18.0` was removed from public distribution after discovery of a critical SQLite migration defect. `v0.17.12` remains the current stable release while `v0.18.1` is prepared. Users who installed `v0.18.0` should avoid further use and preserve their Helm data until recovery guidance is published.
+> **Withdrawn:** `v0.18.0` was removed from public distribution after discovery of a critical SQLite migration defect. Its immutable release record remains for auditability; `v0.18.1` is the corrective stable successor. Users of `v0.18.0` should update to `v0.18.1` before further use.
 
 Helm `0.18.0` publishes the local doctor/repair foundation and internal security-advisory cache groundwork.
 

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -45,7 +45,7 @@ Key features:
 - **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, `ja`, and `hu` with locale override in Settings
 - **Upgrade transparency** — dedicated upgrade preview surface with scoped execution and failure-attribution visibility
 
-> **Release notice:** `v0.18.0` has been withdrawn because of a critical SQLite migration defect. Use `v0.17.12` while `v0.18.1` is prepared. If you installed `v0.18.0`, avoid further use and preserve your Helm data until recovery guidance is published.
+> **Current release:** `v0.18.1` is the latest stable release. `v0.18.0` remains withdrawn because of its critical SQLite migration defect; users of `v0.18.0` should update to `v0.18.1` before further use. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## How it works
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -32,9 +32,9 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 | 0.15.x | Advanced Upgrade Transparency — richer execution-plan visibility, failure isolation, and operator controls (`v0.15.0` released) |
 | 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification (`v0.16.x` stable, latest patch `v0.16.2`) |
 | 0.17.x | Diagnostics & Logging + Release Hardening — task log viewer, structured diagnostics export, manager-detection diagnostics, onboarding/detection hardening, manager-selection controls, and stable release follow-up fixes (`v0.17.0` stable, latest patch `v0.17.12`) |
-| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge and internal advisory cache foundation (`v0.18.0` withdrawn; `v0.18.1` remediation in progress) |
+| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge and internal advisory cache foundation (`v0.18.1` corrective stable release; `v0.18.0` withdrawn) |
 
-> **Current Track:** `v0.17.12` remains public stable after the `v0.18.0` withdrawal. `v0.18.1` migration remediation and recovery validation is in progress. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.18.1` is stable on `main`; `v0.18.0` remains withdrawn, and `v0.19.x` stability and pre-1.0 hardening is next. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Planned
 


### PR DESCRIPTION
## Summary

- What changed: Marks `v0.18.1` as the current corrective stable release across repository and website source-of-truth files, completes publication gates, advances the active track to `v0.19.x`, and records release-process follow-ups.
- Why: The signed/notarized GUI and CLI artifacts, appcast, CLI metadata, public release notes, `verify_only` workflows, runbook verification, and drift monitors are now complete.

## Branch Policy

- [x] Base branch is correct for this scope (`dev` or `main` hotfix/promotion flow).
- [x] Head branch naming follows policy.
- [x] If targeting `main`, source branch is valid per the categories above.

## Scope Declaration

- [ ] App/core/runtime changes included
- [x] Docs-only changes included
- [x] Website-only changes included

## Validation

- [x] Relevant local validation was run (tests/lint/build as applicable).
- [x] Required CI checks for the target branch are expected to pass.
- [x] No unrelated changes were bundled.
- [x] If docs were changed, terminology matches contract (`manager`/`task`/`service` for user-facing docs; `adapter` reserved for architecture/developer docs).

Validation completed:

- `scripts/release/check_release_line_copy.sh`
- docs structure and merge-marker checks
- `npm --prefix web ci`
- `npm --prefix web run check:content-ids`
- `ASTRO_TELEMETRY_DISABLED=1 npm --prefix web run build`
- release workflow, publish-state, post-publish preflight, and provenance contracts
- `scripts/release/runbook.sh verify --tag v0.18.1`

Post-publication evidence:

- CLI `verify_only`: run `30931892687`
- DMG `verify_only`: run `30931893126`
- Release Publish Verify: run `30931857388`
- Appcast Drift Guard: run `30930842215`
- CLI Update Metadata Drift Guard: run `30932826862`
- Public appcast, CLI metadata, and release notes serve `v0.18.1`

Release friction follow-ups:

- #333
- #332

## Release Impact

- [ ] No release impact.
- [x] Release impact exists and checklist/docs were updated (`docs/RELEASE_CHECKLIST.md`, `docs/CURRENT_STATE.md`, `docs/NEXT_STEPS.md`).
