### PR TITLE
chore: enforce SQLite migration safety

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Persistence and release-safety changes require explicit maintainer visibility.
+/core/rust/crates/helm-core/src/sqlite/ @jasoncavinder
+/core/rust/crates/helm-core/resources/sqlite_migration_manifest.json @jasoncavinder
+/core/rust/crates/helm-core/tests/fixtures/sqlite/ @jasoncavinder
+/core/rust/crates/helm-core/tests/sqlite_migrations_contract.rs @jasoncavinder
+/scripts/ci/check_sqlite_migration_* @jasoncavinder
+/.github/workflows/policy-gate.yml @jasoncavinder
+/.github/workflows/release-*.yml @jasoncavinder

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,3 +38,9 @@ Accepted source categories for PRs into `main`:
 
 - [ ] No release impact.
 - [ ] Release impact exists and checklist/docs were updated (`docs/RELEASE_CHECKLIST.md`, `docs/CURRENT_STATE.md`, `docs/NEXT_STEPS.md`).
+
+## SQLite Migration Safety
+
+- [ ] This PR does not change SQLite migrations or migration behavior.
+- [ ] If it does, the change only appends a new migration and manifest entry; frozen origin fixtures and preservation/rollback/reset tests were updated.
+- [ ] If it does, `scripts/ci/check_sqlite_migration_compatibility.sh` passed and the migration safety changes received independent review.

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -44,6 +44,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('core/rust/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
+      - name: Run SQLite migration compatibility gate
+        working-directory: .
+        run: scripts/ci/check_sqlite_migration_compatibility.sh
+
       - name: Run cargo test
         run: cargo test --workspace
 

--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -118,3 +118,8 @@ jobs:
           fi
 
           echo "Policy gate passed for ${HEAD_REF} -> ${BASE_REF}."
+
+      - name: Enforce immutable SQLite migration history
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: python3 scripts/ci/check_sqlite_migration_manifest.py --base-ref "$BASE_SHA"

--- a/.github/workflows/release-cli-direct.yml
+++ b/.github/workflows/release-cli-direct.yml
@@ -128,6 +128,10 @@ jobs:
           toolchain: 1.93.1
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
+      - name: Run SQLite migration compatibility gate
+        if: ${{ env.VERIFY_ONLY != 'true' }}
+        run: scripts/ci/check_sqlite_migration_compatibility.sh
+
       - name: Build CLI binaries (arm64, x86_64, universal)
         if: ${{ env.VERIFY_ONLY != 'true' }}
         env:

--- a/.github/workflows/release-macos-canary.yml
+++ b/.github/workflows/release-macos-canary.yml
@@ -43,6 +43,9 @@ jobs:
           toolchain: 1.93.1
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
+      - name: Run SQLite migration compatibility gate
+        run: scripts/ci/check_sqlite_migration_compatibility.sh
+
       - name: Run serialized Rust release gate
         run: cargo test --workspace --manifest-path core/rust/Cargo.toml -- --test-threads=1
 

--- a/.github/workflows/release-macos-dmg.yml
+++ b/.github/workflows/release-macos-dmg.yml
@@ -165,6 +165,7 @@ jobs:
         if: ${{ env.VERIFY_ONLY != 'true' }}
         run: |
           set -euo pipefail
+          scripts/ci/check_sqlite_migration_compatibility.sh
           cd core/rust
           cargo test --workspace -- --test-threads=1
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ If behavior or policy changes, update the source-of-truth docs that changed real
 - Do not auto-publish releases/appcasts/website deploys.
 - Release and appcast work must remain dry-run/checklist-first unless user explicitly confirms mutation.
 - Before any release tag, publication, workflow dispatch, or release recovery, read `docs/operations/RELEASE_FLOW.md` and `docs/RELEASE_CHECKLIST.md`; run the required rehearsal and preflight gates, and obtain explicit user confirmation before a mutating step.
+- Treat SQLite migrations as append-only once shared. Never reuse or edit an existing version, name, or SQL definition; follow `docs/architecture/SQLITE_MIGRATION_SAFETY.md` and run `scripts/ci/check_sqlite_migration_compatibility.sh` for persistence changes.
+- Development builds must use the development database namespace or an explicit isolated `HELM_DB_PATH`; never point automated or agent-run development work at the stable user database.
 
 Branch and worktree safety:
 

--- a/apps/macos-ui/HelmService/Sources/HelmService.swift
+++ b/apps/macos-ui/HelmService/Sources/HelmService.swift
@@ -36,21 +36,45 @@ class HelmService: NSObject, HelmServiceProtocol {
     }
 
     private let cliShimCommandRunner = HelmCliShimCommandRunner()
+    private var initializationErrorKey: String?
 
     override init() {
         super.init()
 
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let dbPath = appSupport.appendingPathComponent("Helm/helm.db").path
+        let environmentPath = ProcessInfo.processInfo.environment["HELM_DB_PATH"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let databaseURL: URL
+        if let environmentPath, !environmentPath.isEmpty {
+            databaseURL = URL(fileURLWithPath: environmentPath)
+        } else {
+#if DEBUG
+            let databaseDirectory = "Helm-Development"
+#else
+            let databaseDirectory = "Helm"
+#endif
+            databaseURL = appSupport
+                .appendingPathComponent(databaseDirectory, isDirectory: true)
+                .appendingPathComponent("helm.db", isDirectory: false)
+        }
+        let dbPath = databaseURL.path
 
         logger.info("HelmService init — DB path: \(dbPath)")
 
-        try? FileManager.default.createDirectory(atPath: appSupport.appendingPathComponent("Helm").path, withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(
+            at: databaseURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
 
         let result = dbPath.withCString { cPath in
             helm_init(cPath)
         }
         logger.info("helm_init result: \(result)")
+        if !result, let cString = helm_take_last_error_key() {
+            defer { helm_free_string(cString) }
+            initializationErrorKey = String(cString: cString)
+            logger.error("helm_init failed: \(self.initializationErrorKey ?? "unknown")")
+        }
     }
 
     func listInstalledPackages(withReply reply: @escaping (String?) -> Void) {
@@ -917,6 +941,10 @@ class HelmService: NSObject, HelmServiceProtocol {
     }
 
     func takeLastErrorKey(withReply reply: @escaping (String?) -> Void) {
+        if let initializationErrorKey {
+            reply(initializationErrorKey)
+            return
+        }
         guard let cString = helm_take_last_error_key() else {
             reply(nil)
             return

--- a/core/rust/crates/helm-cli/src/main.rs
+++ b/core/rust/crates/helm-cli/src/main.rs
@@ -1823,9 +1823,17 @@ fn database_path() -> Result<String, String> {
     let path = PathBuf::from(home)
         .join("Library")
         .join("Application Support")
-        .join("Helm")
+        .join(database_directory_name(cfg!(debug_assertions)))
         .join("helm.db");
     Ok(path.to_string_lossy().into_owned())
+}
+
+fn database_directory_name(is_development_build: bool) -> &'static str {
+    if is_development_build {
+        "Helm-Development"
+    } else {
+        "Helm"
+    }
 }
 
 fn cmd_status(store: &SqliteStore, options: GlobalOptions) -> Result<(), String> {
@@ -16502,7 +16510,7 @@ mod tests {
         apply_manager_enablement_self_heal, build_json_payload_lines, classify_failure_class,
         cmd_updates_run, command_bypasses_cli_onboarding, command_help_topic_exists,
         coordinator_transport_for_cancel, coordinator_transport_for_submit,
-        coordinator_transport_for_workflow, count_upgrade_step_failures,
+        coordinator_transport_for_workflow, count_upgrade_step_failures, database_directory_name,
         ensure_cli_onboarding_completed, ensure_repair_execution_mode, exit_code_for_error,
         failure_class_hint, list_managers, manager_operation_failure_error, mark_exit_code,
         parse_args, parse_args_with_tty, parse_homebrew_keg_policy_arg, parse_manager_id,
@@ -16523,6 +16531,7 @@ mod tests {
     use helm_core::persistence::DetectionStore;
     use helm_core::sqlite::SqliteStore;
     use serde_json::json;
+
     use std::fs;
     use std::io::Cursor;
     #[cfg(unix)]
@@ -16533,6 +16542,12 @@ mod tests {
 
     const COORDINATOR_TRANSPORT_INVARIANTS_DOC: &str =
         "../../../../docs/architecture/CLI_COORDINATOR_TRANSPORT_INVARIANTS.md";
+
+    #[test]
+    fn database_directory_separates_development_and_release_builds() {
+        assert_eq!(database_directory_name(true), "Helm-Development");
+        assert_eq!(database_directory_name(false), "Helm");
+    }
 
     fn temp_file_path(name: &str) -> PathBuf {
         let nanos = SystemTime::now()

--- a/core/rust/crates/helm-core/Cargo.toml
+++ b/core/rust/crates/helm-core/Cargo.toml
@@ -6,7 +6,7 @@ license = "UNLICENSED"
 description = "Helm core domain models and manager adapter contracts"
 
 [dependencies]
-rusqlite = { version = "0.33", features = ["bundled"] }
+rusqlite = { version = "0.33", features = ["backup", "bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_jcs = "0.2.0"
 serde_json = "1"

--- a/core/rust/crates/helm-core/resources/sqlite_migration_manifest.json
+++ b/core/rust/crates/helm-core/resources/sqlite_migration_manifest.json
@@ -1,0 +1,106 @@
+{
+  "schema": "helm.sqlite-migration-manifest",
+  "schema_version": 1,
+  "migrations": [
+    {
+      "version": 1,
+      "name": "initial_core_schema",
+      "definition_sha256": "f92f6cdffbd48dc577a849e6691c15cf54dddf3fbce4cfd9ca5fc5db3bca47c1"
+    },
+    {
+      "version": 2,
+      "name": "add_manager_detection_and_preferences",
+      "definition_sha256": "9921f0f952d8643d15aebce92d23b80fed71bdb6f5a36ddd1973b993cc137f4a"
+    },
+    {
+      "version": 3,
+      "name": "add_restart_required_to_outdated",
+      "definition_sha256": "733addafe81def2f18ab870cf30d4aa68afd974cb769d842a3bd4427b60a4697"
+    },
+    {
+      "version": 4,
+      "name": "add_app_settings",
+      "definition_sha256": "da97fc9f00600882ae8273fc922e1dff58396413e1538f19a11417ca6cd41a60"
+    },
+    {
+      "version": 5,
+      "name": "add_homebrew_keg_policy_overrides",
+      "definition_sha256": "c61029b95e21853fa6945acfb9bad9ef0b97c222ac855ac21a6ffe1b9cee3f16"
+    },
+    {
+      "version": 6,
+      "name": "add_task_log_records",
+      "definition_sha256": "a7b0130dd545e5ef0776867fb658b3acbbdb58d9976b40afda58e8b2cccf169e"
+    },
+    {
+      "version": 7,
+      "name": "add_manager_selection_preferences",
+      "definition_sha256": "243e8bcea3234b656b825316a6f3afe799b000bc51bd7a9f06c3780851a39a36"
+    },
+    {
+      "version": 8,
+      "name": "add_manager_timeout_preferences",
+      "definition_sha256": "0f77451be07529df6dde5a27db5032c81f1225a0a519a33f3c62f05b5006f710"
+    },
+    {
+      "version": 9,
+      "name": "add_manager_install_instances",
+      "definition_sha256": "52f1723d5fc1917a32ee64c1ba96afc8ff8a06f1d1048549781fca653586e64e"
+    },
+    {
+      "version": 10,
+      "name": "add_install_instance_decision_margin",
+      "definition_sha256": "f6d7654d408e741ad95d6fb653a57bd5f5aadee7b2e833e209ee068c23b8a98d"
+    },
+    {
+      "version": 11,
+      "name": "add_manager_multi_instance_ack",
+      "definition_sha256": "0665b4400598068510fb592c9fd4f87246c5d3a5391c9908bc77ebca8c3d0ff3"
+    },
+    {
+      "version": 12,
+      "name": "add_package_manager_preferences",
+      "definition_sha256": "00369f96c6d079f625f01a5634fcd8099f611b481100fd9b2a144ddf1d9ce203"
+    },
+    {
+      "version": 13,
+      "name": "add_installed_package_versions",
+      "definition_sha256": "8579998f652354fe22e66bd1ebb265fc826b2b9f8303116ce6e31956baa9d9c5"
+    },
+    {
+      "version": 14,
+      "name": "add_package_runtime_state_flags",
+      "definition_sha256": "5f78c900ed0cb514375f494fea122b483d7cdc419198060db9b177146bd925d9"
+    },
+    {
+      "version": 15,
+      "name": "make_pin_records_version_scoped",
+      "definition_sha256": "a46f710f7c994c89833abc7729f9af7bc46c0b0949e6bea602ef71b2deba5329"
+    },
+    {
+      "version": 16,
+      "name": "add_package_external_identifiers",
+      "definition_sha256": "9cb26e3c4d2af3141944f6964a83456521f2089f2020ecf4a1a721cf61a191cf"
+    },
+    {
+      "version": 17,
+      "name": "add_doctor_and_repair_persistence",
+      "definition_sha256": "9898f26249c17fc04de03fe09060f05eae15752d19e4f1922ddbd6a500768c77"
+    },
+    {
+      "version": 18,
+      "name": "add_security_advisory_cache",
+      "definition_sha256": "b111e6dae804d1de60a41f7c495a1468899e233cba21711879a95aa12ba80732"
+    },
+    {
+      "version": 19,
+      "name": "add_repair_knowledge_recommendation_rank",
+      "definition_sha256": "e768b25ad0cdb7796269db993b6692853334cda55d3637e197332ea177b525d4"
+    },
+    {
+      "version": 20,
+      "name": "add_migration_definition_checksums",
+      "definition_sha256": "5f8e9945c9335f53b70295ab77926c2c724936013ef0923fb89fa8f811d51e3e"
+    }
+  ]
+}

--- a/core/rust/crates/helm-core/src/sqlite/migrations.rs
+++ b/core/rust/crates/helm-core/src/sqlite/migrations.rs
@@ -1,9 +1,116 @@
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SqliteMigration {
     pub version: i64,
     pub name: &'static str,
     pub up_sql: &'static str,
     pub down_sql: &'static str,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SqliteMigrationManifest {
+    schema: String,
+    schema_version: u32,
+    migrations: Vec<SqliteMigrationIdentity>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SqliteMigrationIdentity {
+    version: i64,
+    name: String,
+    definition_sha256: String,
+}
+
+static MIGRATION_MANIFEST: OnceLock<Result<SqliteMigrationManifest, String>> = OnceLock::new();
+
+pub fn migration_definition_checksum(migration: &SqliteMigration) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"helm.sqlite-migration.v1\0");
+    hasher.update(migration.version.to_be_bytes());
+    for field in [
+        migration.name.as_bytes(),
+        migration.up_sql.as_bytes(),
+        migration.down_sql.as_bytes(),
+    ] {
+        hasher.update((field.len() as u64).to_be_bytes());
+        hasher.update(field);
+    }
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+pub fn validate_migration_manifest() -> Result<(), String> {
+    let manifest = migration_manifest()?;
+    if manifest.schema != "helm.sqlite-migration-manifest" || manifest.schema_version != 1 {
+        return Err("unsupported SQLite migration manifest schema".to_string());
+    }
+    if manifest.migrations.len() != MIGRATIONS.len() {
+        return Err(format!(
+            "SQLite migration manifest has {} entries but code defines {}",
+            manifest.migrations.len(),
+            MIGRATIONS.len()
+        ));
+    }
+
+    for (index, (identity, migration)) in manifest
+        .migrations
+        .iter()
+        .zip(MIGRATIONS.iter())
+        .enumerate()
+    {
+        let expected_version = i64::try_from(index + 1)
+            .map_err(|_| "SQLite migration manifest is too large".to_string())?;
+        if identity.version != expected_version || migration.version != expected_version {
+            return Err(format!(
+                "SQLite migration sequence is not contiguous at version {expected_version}"
+            ));
+        }
+        if identity.name != migration.name {
+            return Err(format!(
+                "SQLite migration {expected_version} name differs from the immutable manifest"
+            ));
+        }
+        let checksum = migration_definition_checksum(migration);
+        if identity.definition_sha256 != checksum {
+            return Err(format!(
+                "SQLite migration {expected_version} SQL differs from the immutable manifest"
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn migration_definition_checksum_for_version(
+    version: i64,
+) -> Result<&'static str, String> {
+    let manifest = migration_manifest()?;
+    manifest
+        .migrations
+        .iter()
+        .find(|entry| entry.version == version)
+        .map(|entry| entry.definition_sha256.as_str())
+        .ok_or_else(|| format!("SQLite migration {version} is absent from the immutable manifest"))
+}
+
+fn migration_manifest() -> Result<&'static SqliteMigrationManifest, String> {
+    MIGRATION_MANIFEST
+        .get_or_init(|| {
+            serde_json::from_str(include_str!(
+                "../../resources/sqlite_migration_manifest.json"
+            ))
+            .map_err(|error| format!("invalid SQLite migration manifest: {error}"))
+        })
+        .as_ref()
+        .map_err(Clone::clone)
 }
 
 const MIGRATION_0001: SqliteMigration = SqliteMigration {
@@ -933,7 +1040,20 @@ ALTER TABLE repair_knowledge_entries DROP COLUMN recommendation_rank;
 "#,
 };
 
-const MIGRATIONS: [SqliteMigration; 19] = [
+// The checksum column belongs to migration infrastructure and intentionally
+// remains present when application data is reset to an earlier schema version.
+const MIGRATION_0020: SqliteMigration = SqliteMigration {
+    version: 20,
+    name: "add_migration_definition_checksums",
+    up_sql: r#"
+ALTER TABLE helm_schema_migrations ADD COLUMN definition_checksum TEXT;
+"#,
+    down_sql: r#"
+SELECT 1;
+"#,
+};
+
+const MIGRATIONS: [SqliteMigration; 20] = [
     MIGRATION_0001,
     MIGRATION_0002,
     MIGRATION_0003,
@@ -953,6 +1073,7 @@ const MIGRATIONS: [SqliteMigration; 19] = [
     MIGRATION_0017,
     MIGRATION_0018,
     MIGRATION_0019,
+    MIGRATION_0020,
 ];
 
 pub fn migrations() -> &'static [SqliteMigration] {

--- a/core/rust/crates/helm-core/src/sqlite/store.rs
+++ b/core/rust/crates/helm-core/src/sqlite/store.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, DatabaseName, OptionalExtension, params};
 
 use crate::models::{
     AutomationLevel, CachedSearchResult, CoreError, CoreErrorKind, DetectionInfo,
@@ -23,10 +23,14 @@ use crate::persistence::{
     PersistenceResult, PinStore, SearchCacheStore, TaskStore,
 };
 use crate::security_advisory::{AdvisoryCacheRecord, AdvisoryCacheStore};
-use crate::sqlite::migrations::{SqliteMigration, current_schema_version, migration, migrations};
+use crate::sqlite::migrations::{
+    SqliteMigration, current_schema_version, migration, migration_definition_checksum_for_version,
+    migrations, validate_migration_manifest,
+};
 use crate::versioning::normalize_package_family_key;
 
 const MIGRATIONS_TABLE: &str = "helm_schema_migrations";
+const MIGRATION_CHECKSUM_SCHEMA_VERSION: i64 = 20;
 pub const BUNDLED_REPAIR_KNOWLEDGE_SOURCE_KEY: &str = "bundled:helm";
 
 pub struct SqliteStore {
@@ -102,6 +106,9 @@ impl MigrationStore for SqliteStore {
     }
 
     fn apply_migration(&self, target_version: i64) -> PersistenceResult<()> {
+        validate_migration_manifest()
+            .map_err(|error| storage_error_text("apply_migration", error))?;
+
         if target_version < 0 || target_version > current_schema_version() {
             return Err(storage_error_text(
                 "apply_migration",
@@ -119,9 +126,29 @@ impl MigrationStore for SqliteStore {
         self.with_connection("apply_migration", |connection| {
             ensure_migrations_table(connection)?;
             let current_version = read_current_version(connection)?;
+            let reconciliation_required = replaced_migration_reconciliation_required(
+                connection,
+                current_version,
+                target_version,
+            )?;
+            if current_version > 0 && (target_version > current_version || reconciliation_required)
+            {
+                let backup_path =
+                    create_pre_migration_backup(connection, &self.database_path, current_version)?;
+                tracing::info!(
+                    path = %backup_path.display(),
+                    from_version = current_version,
+                    target_version,
+                    "created verified pre-migration SQLite backup"
+                );
+            }
             reconcile_replaced_migrations(connection, current_version, target_version)?;
+            validate_applied_migration_identities(connection, current_version)?;
 
             if target_version == current_version {
+                if target_version >= MIGRATION_CHECKSUM_SCHEMA_VERSION {
+                    backfill_migration_checksums(connection, target_version)?;
+                }
                 return Ok(());
             }
 
@@ -139,8 +166,19 @@ impl MigrationStore for SqliteStore {
                 }
             }
 
+            if target_version >= MIGRATION_CHECKSUM_SCHEMA_VERSION {
+                backfill_migration_checksums(connection, target_version)?;
+            }
+
             Ok(())
-        })
+        })?;
+
+        if target_version == 0 {
+            remove_pre_migration_backups(&self.database_path).map_err(|error| {
+                storage_error_text("remove_migration_backups", error.to_string())
+            })?;
+        }
+        Ok(())
     }
 }
 
@@ -2318,7 +2356,8 @@ fn ensure_migrations_table(connection: &Connection) -> rusqlite::Result<()> {
 CREATE TABLE IF NOT EXISTS helm_schema_migrations (
     version INTEGER PRIMARY KEY,
     name TEXT NOT NULL,
-    applied_at_unix INTEGER NOT NULL
+    applied_at_unix INTEGER NOT NULL,
+    definition_checksum TEXT
 );
 ",
     )?;
@@ -2342,6 +2381,276 @@ fn read_current_version(connection: &Connection) -> rusqlite::Result<i64> {
         [],
         |row| row.get(0),
     )
+}
+
+fn replaced_migration_reconciliation_required(
+    connection: &Connection,
+    current_version: i64,
+    target_version: i64,
+) -> rusqlite::Result<bool> {
+    const REPLACED_MIGRATION_VERSION: i64 = 17;
+    if current_version < REPLACED_MIGRATION_VERSION || target_version < REPLACED_MIGRATION_VERSION {
+        return Ok(false);
+    }
+    let recorded_name: Option<String> = connection
+        .query_row(
+            &format!("SELECT name FROM {MIGRATIONS_TABLE} WHERE version = ?1"),
+            [REPLACED_MIGRATION_VERSION],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(recorded_name.as_deref() == Some("add_advisory_cache"))
+}
+
+fn create_pre_migration_backup(
+    connection: &Connection,
+    database_path: &Path,
+    current_version: i64,
+) -> rusqlite::Result<PathBuf> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?
+        .as_nanos();
+    let file_name = database_path
+        .file_name()
+        .unwrap_or_else(|| std::ffi::OsStr::new("helm.db"))
+        .to_string_lossy();
+    let parent = database_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let backup_path = parent.join(format!(
+        "{file_name}.pre-migration-v{current_version}-{timestamp}.backup"
+    ));
+    let partial_path = backup_path.with_extension("backup.partial");
+
+    let result = (|| {
+        create_private_file(&partial_path)?;
+        connection.backup(DatabaseName::Main, &partial_path, None)?;
+        let backup = Connection::open(&partial_path)?;
+        let integrity: String = backup.query_row("PRAGMA integrity_check", [], |row| row.get(0))?;
+        if integrity != "ok" {
+            return Err(storage_error_sqlite(&format!(
+                "pre-migration backup integrity check failed: {integrity}"
+            )));
+        }
+        drop(backup);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&partial_path, fs::Permissions::from_mode(0o600))
+                .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?;
+        }
+        fs::rename(&partial_path, &backup_path)
+            .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))?;
+        if let Err(error) = prune_pre_migration_backups(database_path, 3) {
+            tracing::warn!(
+                error = %error,
+                "failed to prune old pre-migration SQLite backups"
+            );
+        }
+        Ok(backup_path.clone())
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&partial_path);
+    }
+    result
+}
+
+fn create_private_file(path: &Path) -> rusqlite::Result<()> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options
+        .open(path)
+        .map(drop)
+        .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error)))
+}
+
+fn pre_migration_backup_paths(database_path: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let parent = database_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let prefix = format!(
+        "{}.pre-migration-",
+        database_path
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("helm.db"))
+            .to_string_lossy()
+    );
+    let mut backups = fs::read_dir(parent)?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name().is_some_and(|name| {
+                let name = name.to_string_lossy();
+                name.starts_with(&prefix)
+                    && (name.ends_with(".backup") || name.ends_with(".backup.partial"))
+            })
+        })
+        .collect::<Vec<_>>();
+    backups.sort_by(|left, right| {
+        let left_modified = fs::metadata(left)
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(UNIX_EPOCH);
+        let right_modified = fs::metadata(right)
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(UNIX_EPOCH);
+        left_modified
+            .cmp(&right_modified)
+            .then_with(|| left.cmp(right))
+    });
+    Ok(backups)
+}
+
+fn prune_pre_migration_backups(database_path: &Path, retain: usize) -> std::io::Result<()> {
+    let backups = pre_migration_backup_paths(database_path)?;
+    let (partial, completed): (Vec<_>, Vec<_>) = backups
+        .into_iter()
+        .partition(|path| path.to_string_lossy().ends_with(".backup.partial"));
+    for backup in partial {
+        fs::remove_file(backup)?;
+    }
+    let remove_count = completed.len().saturating_sub(retain);
+    for backup in completed.into_iter().take(remove_count) {
+        fs::remove_file(backup)?;
+    }
+    Ok(())
+}
+
+fn remove_pre_migration_backups(database_path: &Path) -> std::io::Result<()> {
+    for backup in pre_migration_backup_paths(database_path)? {
+        fs::remove_file(backup)?;
+    }
+    Ok(())
+}
+
+fn migration_checksum_column_exists(connection: &Connection) -> rusqlite::Result<bool> {
+    let mut statement = connection.prepare("PRAGMA table_info(helm_schema_migrations)")?;
+    let columns = statement.query_map([], |row| row.get::<_, String>(1))?;
+    for column in columns {
+        if column? == "definition_checksum" {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn validate_applied_migration_identities(
+    connection: &Connection,
+    current_version: i64,
+) -> rusqlite::Result<()> {
+    if current_version < 0 || current_version > current_schema_version() {
+        return Err(storage_error_sqlite(&format!(
+            "database migration version {current_version} is outside the supported range"
+        )));
+    }
+
+    let has_checksums = migration_checksum_column_exists(connection)?;
+    let records = if has_checksums {
+        let mut statement = connection.prepare(&format!(
+            "SELECT version, name, definition_checksum FROM {MIGRATIONS_TABLE} ORDER BY version"
+        ))?;
+        statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                ))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+    } else {
+        let mut statement = connection.prepare(&format!(
+            "SELECT version, name FROM {MIGRATIONS_TABLE} ORDER BY version"
+        ))?;
+        statement
+            .query_map([], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?, None))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+    };
+
+    if i64::try_from(records.len()).ok() != Some(current_version) {
+        return Err(storage_error_sqlite(
+            "database migration ledger is not contiguous",
+        ));
+    }
+
+    for (index, (version, name, checksum)) in records.iter().enumerate() {
+        let expected_version = i64::try_from(index + 1)
+            .map_err(|_| storage_error_sqlite("database migration ledger is too large"))?;
+        if *version != expected_version {
+            return Err(storage_error_sqlite(&format!(
+                "database migration ledger is missing version {expected_version}"
+            )));
+        }
+        let expected = migration(*version).ok_or_else(|| {
+            storage_error_sqlite(&format!(
+                "database contains unknown migration version {version}"
+            ))
+        })?;
+        if name != expected.name {
+            return Err(storage_error_sqlite(&format!(
+                "unexpected migration identity for version {version}: '{name}'"
+            )));
+        }
+        if has_checksums
+            && current_version >= MIGRATION_CHECKSUM_SCHEMA_VERSION
+            && checksum.as_deref().is_none_or(str::is_empty)
+        {
+            return Err(storage_error_sqlite(&format!(
+                "missing migration checksum for version {version}"
+            )));
+        }
+        if let Some(checksum) = checksum.as_deref().filter(|value| !value.is_empty()) {
+            let expected_checksum = migration_definition_checksum_for_version(*version)
+                .map_err(|error| storage_error_sqlite(&error))?;
+            if checksum != expected_checksum {
+                return Err(storage_error_sqlite(&format!(
+                    "unexpected migration checksum for version {version}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn backfill_migration_checksums(
+    connection: &mut Connection,
+    current_version: i64,
+) -> rusqlite::Result<()> {
+    let transaction = connection.transaction()?;
+    backfill_migration_checksums_in_transaction(&transaction, current_version)?;
+    transaction.commit()?;
+    validate_applied_migration_identities(connection, current_version)
+}
+
+fn backfill_migration_checksums_in_transaction(
+    transaction: &rusqlite::Transaction<'_>,
+    current_version: i64,
+) -> rusqlite::Result<()> {
+    for version in 1..=current_version {
+        let checksum = migration_definition_checksum_for_version(version)
+            .map_err(|error| storage_error_sqlite(&error))?;
+        transaction.execute(
+            &format!(
+                "UPDATE {MIGRATIONS_TABLE}
+                 SET definition_checksum = ?2
+                 WHERE version = ?1
+                   AND (definition_checksum IS NULL OR definition_checksum = '')"
+            ),
+            (version, checksum),
+        )?;
+    }
+    Ok(())
 }
 
 fn reconcile_replaced_migrations(
@@ -2399,13 +2708,29 @@ fn apply_up_migration(
 ) -> rusqlite::Result<()> {
     let transaction = connection.transaction()?;
     execute_batch_tolerant(&transaction, migration.up_sql)?;
-    transaction.execute(
-        &format!(
-            "INSERT INTO {MIGRATIONS_TABLE} (version, name, applied_at_unix)
-             VALUES (?1, ?2, strftime('%s', 'now'))"
-        ),
-        (migration.version, migration.name),
-    )?;
+    if migration_checksum_column_exists(&transaction)? {
+        let checksum = migration_definition_checksum_for_version(migration.version)
+            .map_err(|error| storage_error_sqlite(&error))?;
+        transaction.execute(
+            &format!(
+                "INSERT INTO {MIGRATIONS_TABLE}
+                    (version, name, applied_at_unix, definition_checksum)
+                 VALUES (?1, ?2, strftime('%s', 'now'), ?3)"
+            ),
+            (migration.version, migration.name, checksum),
+        )?;
+    } else {
+        transaction.execute(
+            &format!(
+                "INSERT INTO {MIGRATIONS_TABLE} (version, name, applied_at_unix)
+                 VALUES (?1, ?2, strftime('%s', 'now'))"
+            ),
+            (migration.version, migration.name),
+        )?;
+    }
+    if migration.version == MIGRATION_CHECKSUM_SCHEMA_VERSION {
+        backfill_migration_checksums_in_transaction(&transaction, migration.version)?;
+    }
     transaction.commit()?;
     Ok(())
 }

--- a/core/rust/crates/helm-core/tests/sqlite_migrations_contract.rs
+++ b/core/rust/crates/helm-core/tests/sqlite_migrations_contract.rs
@@ -1,8 +1,9 @@
 use helm_core::persistence::MigrationStore;
 use helm_core::sqlite::SqliteStore;
+use helm_core::sqlite::migrations::validate_migration_manifest;
 use helm_core::sqlite::{current_schema_version, migration, migrations};
 use rusqlite::Connection;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const AFFECTED_V0180_OVERLAY: &str = include_str!("fixtures/sqlite/v0.18.0-affected-overlay.sql");
@@ -119,6 +120,57 @@ fn table_exists(connection: &Connection, table: &str) -> bool {
         .unwrap()
 }
 
+fn column_exists(connection: &Connection, table: &str, column: &str) -> bool {
+    let mut statement = connection
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .unwrap();
+    statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap()
+        .iter()
+        .any(|candidate| candidate == column)
+}
+
+fn remove_checksum_column_from_ledger(connection: &Connection) {
+    connection
+        .execute_batch(
+            r#"
+ALTER TABLE helm_schema_migrations RENAME TO helm_schema_migrations_with_checksums;
+CREATE TABLE helm_schema_migrations (
+    version INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    applied_at_unix INTEGER NOT NULL
+);
+INSERT INTO helm_schema_migrations (version, name, applied_at_unix)
+SELECT version, name, applied_at_unix
+FROM helm_schema_migrations_with_checksums;
+DROP TABLE helm_schema_migrations_with_checksums;
+"#,
+        )
+        .unwrap();
+}
+
+fn migration_backup_paths(database_path: &Path) -> Vec<PathBuf> {
+    let parent = database_path.parent().unwrap();
+    let prefix = format!(
+        "{}.pre-migration-",
+        database_path.file_name().unwrap().to_string_lossy()
+    );
+    let mut paths = std::fs::read_dir(parent)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with(&prefix))
+        })
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths
+}
+
 #[test]
 fn migration_versions_are_strictly_increasing() {
     let entries = migrations();
@@ -147,6 +199,11 @@ fn migration_sql_is_defined_for_up_and_down_paths() {
             "down sql must not be empty"
         );
     }
+}
+
+#[test]
+fn migration_definitions_match_immutable_manifest() {
+    validate_migration_manifest().unwrap();
 }
 
 #[test]
@@ -369,4 +426,222 @@ END;
     assert_eq!(legacy_entries, 1);
     assert!(!table_exists(&connection, "repair_knowledge_entries"));
     assert!(!table_exists(&connection, "doctor_scans"));
+}
+
+#[test]
+fn latest_schema_records_every_migration_checksum() {
+    let store = SqliteStore::new(temp_database("migration-checksums"));
+    store.migrate_to_latest().unwrap();
+
+    let connection = Connection::open(store.database_path()).unwrap();
+    let checksum_count: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM helm_schema_migrations
+             WHERE definition_checksum IS NOT NULL
+               AND length(definition_checksum) = 64",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(checksum_count, current_schema_version());
+}
+
+#[test]
+fn legacy_ledger_is_upgraded_with_checksums() {
+    let store = SqliteStore::new(temp_database("migration-legacy-ledger"));
+    store.apply_migration(19).unwrap();
+
+    let connection = Connection::open(store.database_path()).unwrap();
+    remove_checksum_column_from_ledger(&connection);
+    drop(connection);
+
+    store.migrate_to_latest().unwrap();
+
+    let connection = Connection::open(store.database_path()).unwrap();
+    assert!(column_exists(
+        &connection,
+        "helm_schema_migrations",
+        "definition_checksum"
+    ));
+    let checksum_count: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM helm_schema_migrations
+             WHERE definition_checksum IS NOT NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(checksum_count, current_schema_version());
+}
+
+#[test]
+fn migration_name_tampering_fails_closed() {
+    let store = SqliteStore::new(temp_database("migration-name-tamper"));
+    store.migrate_to_latest().unwrap();
+    let connection = Connection::open(store.database_path()).unwrap();
+    connection
+        .execute(
+            "UPDATE helm_schema_migrations SET name = 'tampered' WHERE version = 5",
+            [],
+        )
+        .unwrap();
+    drop(connection);
+
+    let error = store.migrate_to_latest().unwrap_err();
+    assert!(error.message.contains("unexpected migration identity"));
+}
+
+#[test]
+fn migration_checksum_tampering_fails_closed() {
+    let store = SqliteStore::new(temp_database("migration-checksum-tamper"));
+    store.migrate_to_latest().unwrap();
+    let connection = Connection::open(store.database_path()).unwrap();
+    connection
+        .execute(
+            "UPDATE helm_schema_migrations
+             SET definition_checksum = 'tampered'
+             WHERE version = 5",
+            [],
+        )
+        .unwrap();
+    drop(connection);
+
+    let error = store.migrate_to_latest().unwrap_err();
+    assert!(error.message.contains("unexpected migration checksum"));
+}
+
+#[test]
+fn missing_checksum_on_checksum_aware_ledger_fails_closed() {
+    let store = SqliteStore::new(temp_database("migration-checksum-missing"));
+    store.migrate_to_latest().unwrap();
+    let connection = Connection::open(store.database_path()).unwrap();
+    connection
+        .execute(
+            "UPDATE helm_schema_migrations
+             SET definition_checksum = NULL
+             WHERE version = 5",
+            [],
+        )
+        .unwrap();
+    drop(connection);
+
+    let error = store.migrate_to_latest().unwrap_err();
+    assert!(error.message.contains("missing migration checksum"));
+}
+
+#[test]
+fn migration_ledger_gap_fails_closed() {
+    let store = SqliteStore::new(temp_database("migration-ledger-gap"));
+    store.migrate_to_latest().unwrap();
+    let connection = Connection::open(store.database_path()).unwrap();
+    connection
+        .execute("DELETE FROM helm_schema_migrations WHERE version = 5", [])
+        .unwrap();
+    drop(connection);
+
+    let error = store.migrate_to_latest().unwrap_err();
+    assert!(error.message.contains("ledger is not contiguous"));
+}
+
+#[test]
+fn checksum_ledger_upgrade_rolls_back_atomically() {
+    let store = SqliteStore::new(temp_database("migration-checksum-rollback"));
+    store.apply_migration(19).unwrap();
+    let connection = Connection::open(store.database_path()).unwrap();
+    remove_checksum_column_from_ledger(&connection);
+    connection
+        .execute_batch(
+            r#"
+CREATE TRIGGER reject_checksum_backfill
+BEFORE UPDATE ON helm_schema_migrations
+BEGIN
+    SELECT RAISE(FAIL, 'forced checksum backfill failure');
+END;
+"#,
+        )
+        .unwrap();
+    drop(connection);
+
+    let error = store.migrate_to_latest().unwrap_err();
+    assert!(error.message.contains("forced checksum backfill failure"));
+    assert_eq!(store.current_version().unwrap(), 19);
+
+    let connection = Connection::open(store.database_path()).unwrap();
+    assert!(!column_exists(
+        &connection,
+        "helm_schema_migrations",
+        "definition_checksum"
+    ));
+}
+
+#[test]
+fn forward_migration_creates_one_verified_data_preserving_backup() {
+    let database_path = temp_database("migration-backup");
+    let store = SqliteStore::new(database_path.clone());
+    store.apply_migration(16).unwrap();
+    let connection = Connection::open(store.database_path()).unwrap();
+    seed_v01712_data(&connection);
+    drop(connection);
+
+    store.migrate_to_latest().unwrap();
+    let backup_paths = migration_backup_paths(&database_path);
+    assert_eq!(backup_paths.len(), 1);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            std::fs::metadata(&backup_paths[0])
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+
+    let backup = Connection::open(&backup_paths[0]).unwrap();
+    let integrity: String = backup
+        .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(integrity, "ok");
+    let backup_version: i64 = backup
+        .query_row(
+            "SELECT MAX(version) FROM helm_schema_migrations",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(backup_version, 16);
+    assert_v01712_data_preserved(&backup);
+    drop(backup);
+
+    store.migrate_to_latest().unwrap();
+    store.apply_migration(0).unwrap();
+    assert!(migration_backup_paths(&database_path).is_empty());
+    store.migrate_to_latest().unwrap();
+    assert!(migration_backup_paths(&database_path).is_empty());
+}
+
+#[test]
+fn migration_backup_retention_is_bounded() {
+    let database_path = temp_database("migration-backup-retention");
+    let store = SqliteStore::new(database_path.clone());
+    store.apply_migration(16).unwrap();
+
+    for version in 17..=current_schema_version() {
+        store.apply_migration(version).unwrap();
+    }
+
+    let backups = migration_backup_paths(&database_path);
+    assert_eq!(backups.len(), 3);
+    let names = backups
+        .iter()
+        .map(|path| path.file_name().unwrap().to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+    assert!(names.iter().all(|name| {
+        name.contains("pre-migration-v17-")
+            || name.contains("pre-migration-v18-")
+            || name.contains("pre-migration-v19-")
+    }));
 }

--- a/core/rust/crates/helm-ffi/src/lib.rs
+++ b/core/rust/crates/helm-ffi/src/lib.rs
@@ -5463,8 +5463,9 @@ fn adapter_response_to_coordinator_payload(
 /// `db_path` must be a valid, non-null pointer to a NUL-terminated UTF-8 C string.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn helm_init(db_path: *const c_char) -> bool {
+    clear_last_error_key();
     if db_path.is_null() {
-        return false;
+        return return_error_bool(SERVICE_ERROR_INVALID_INPUT);
     }
 
     // If already initialized, return true
@@ -5475,7 +5476,7 @@ pub unsafe extern "C" fn helm_init(db_path: *const c_char) -> bool {
     let c_str = unsafe { CStr::from_ptr(db_path) };
     let path_str = match c_str.to_str() {
         Ok(s) => s,
-        Err(_) => return false,
+        Err(_) => return return_error_bool(SERVICE_ERROR_INVALID_INPUT),
     };
 
     // Initialize logging
@@ -5489,7 +5490,7 @@ pub unsafe extern "C" fn helm_init(db_path: *const c_char) -> bool {
         Ok(rt) => rt,
         Err(e) => {
             eprintln!("Failed to create Tokio runtime: {}", e);
-            return false;
+            return return_error_bool(SERVICE_ERROR_INTERNAL);
         }
     };
 
@@ -5497,7 +5498,7 @@ pub unsafe extern "C" fn helm_init(db_path: *const c_char) -> bool {
     let store = Arc::new(SqliteStore::new(path_str));
     if let Err(e) = store.migrate_to_latest() {
         eprintln!("Failed to migrate DB: {}", e);
-        return false;
+        return return_error_bool(core_error_service_key(&e));
     }
 
     // Initialize Adapters
@@ -5612,7 +5613,7 @@ pub unsafe extern "C" fn helm_init(db_path: *const c_char) -> bool {
         Ok(rt) => Arc::new(rt),
         Err(e) => {
             eprintln!("Failed to create adapter runtime: {}", e);
-            return false;
+            return return_error_bool(core_error_service_key(&e));
         }
     };
 
@@ -11454,12 +11455,12 @@ mod tests {
     use helm_core::persistence::{
         DetectionStore, ManagerPreference, MigrationStore, PackageStore, TaskStore,
     };
-    use helm_core::sqlite::SqliteStore;
+    use helm_core::sqlite::{SqliteStore, current_schema_version};
     use helm_core::uninstall_preview::{
         DEFAULT_MANAGER_UNINSTALL_SAFE_BLAST_RADIUS_THRESHOLD, ManagerUninstallPreviewContext,
     };
     use std::collections::HashMap;
-    use std::ffi::{CString, OsString};
+    use std::ffi::{CStr, CString, OsString};
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
@@ -14380,7 +14381,7 @@ mod tests {
             String::from_utf8_lossy(&output.stderr)
         );
 
-        assert_eq!(store.current_version().unwrap(), 19);
+        assert_eq!(store.current_version().unwrap(), current_schema_version());
         let connection = rusqlite::Connection::open(&path).unwrap();
         let migration_17_name: String = connection
             .query_row(
@@ -14390,5 +14391,60 @@ mod tests {
             )
             .unwrap();
         assert_eq!(migration_17_name, "add_doctor_and_repair_persistence");
+    }
+
+    #[test]
+    fn ffi_init_failure_exposes_storage_error() {
+        const CHILD_ENV: &str = "HELM_TEST_FFI_MIGRATION_FAILURE_CHILD";
+        const DATABASE_ENV: &str = "HELM_TEST_FFI_MIGRATION_FAILURE_DB";
+
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let database_path = std::env::var(DATABASE_ENV).unwrap();
+            let database_path = CString::new(database_path).unwrap();
+            assert!(!unsafe { super::helm_init(database_path.as_ptr()) });
+            let error_pointer = super::helm_take_last_error_key();
+            assert!(!error_pointer.is_null());
+            let error_key = unsafe { CStr::from_ptr(error_pointer) }
+                .to_str()
+                .unwrap()
+                .to_string();
+            unsafe { super::helm_free_string(error_pointer) };
+            assert_eq!(error_key, super::SERVICE_ERROR_STORAGE_FAILURE);
+            return;
+        }
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("helm-ffi-failure-{nanos}.sqlite3"));
+        let store = SqliteStore::new(path.clone());
+        store.apply_migration(16).unwrap();
+        let connection = rusqlite::Connection::open(&path).unwrap();
+        connection
+            .execute(
+                "INSERT INTO helm_schema_migrations (version, name, applied_at_unix)
+                 VALUES (17, 'unknown_development_schema', 1785514652)",
+                [],
+            )
+            .unwrap();
+        drop(connection);
+
+        let output = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "tests::ffi_init_failure_exposes_storage_error",
+                "--nocapture",
+            ])
+            .env(CHILD_ENV, "1")
+            .env(DATABASE_ENV, &path)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "FFI child failed:\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }

--- a/docs/architecture/SQLITE_MIGRATION_SAFETY.md
+++ b/docs/architecture/SQLITE_MIGRATION_SAFETY.md
@@ -1,0 +1,118 @@
+# SQLite Migration Safety
+
+This document defines Helm's durable SQLite migration invariants and required
+verification. These rules apply to app, service, CLI, FFI, and development
+builds because all of those surfaces can initialize persistent state.
+
+## Immutable Identity
+
+Every migration is identified by all of the following:
+
+- contiguous integer version
+- stable name
+- SHA-256 digest of its version, name, up SQL, and down SQL
+
+The committed manifest is
+`core/rust/crates/helm-core/resources/sqlite_migration_manifest.json`.
+Once a manifest entry reaches a shared branch, it is append-only. Existing
+versions, names, SQL, ordering, and checksums must never be changed. Corrections
+use a new migration version or a narrowly targeted reconciliation for an exact
+known historical identity.
+
+The required Policy Gate compares the PR manifest with its base revision. The
+base entries must remain an exact prefix of the proposed manifest. Runtime also
+validates compiled definitions against the manifest before opening a migration
+transaction.
+
+## Runtime Ledger
+
+Migration 20 adds `definition_checksum` to `helm_schema_migrations`. Existing
+ledgers are backfilled transactionally. New records persist the immutable
+definition checksum when they are inserted.
+
+Before schema mutation, startup verifies:
+
+- the ledger is contiguous from version 1 through its maximum version
+- every recorded version exists in the compiled migration registry
+- every recorded name matches the immutable manifest
+- every populated checksum matches the immutable manifest
+
+Missing, unknown, reordered, renamed, or checksum-mismatched entries fail
+closed. Helm does not replay historical DDL on an already-current database.
+
+Known historical discrepancies require exact identity matching and one atomic
+transaction. Unknown discrepancies must not be guessed, relabeled, or repaired
+generically.
+
+## Pre-Migration Backup
+
+Before any forward migration or known reconciliation, Helm creates an online
+SQLite backup next to the database and verifies it with `PRAGMA integrity_check`.
+On Unix, backup permissions are restricted to `0600`.
+
+Backup names use this form:
+
+```text
+helm.db.pre-migration-v<source>-<timestamp>.backup
+```
+
+At most three completed backups are retained. Failed partial backups are
+removed. Intentional downgrade/reset does not create a backup, and successful
+Reset Local Data removes retained migration backups so reset does not leave an
+undisclosed copy of user data.
+
+## Environment Isolation
+
+Release builds use:
+
+```text
+~/Library/Application Support/Helm/helm.db
+```
+
+Debug app/service and CLI builds use:
+
+```text
+~/Library/Application Support/Helm-Development/helm.db
+```
+
+Tests and explicit recovery work may override the path with `HELM_DB_PATH`.
+Development tooling must not point at the stable database unless the operator
+has intentionally created a backup and explicitly supplied that path.
+
+## Required Compatibility Gate
+
+Run:
+
+```bash
+scripts/ci/check_sqlite_migration_compatibility.sh
+```
+
+The gate validates the immutable manifest and exercises:
+
+- fresh database initialization and repeated startup
+- clean v0.17.12 upgrade with representative data preservation
+- the frozen affected-v0.18.0 schema
+- exact legacy reconciliation and unknown-identity rejection
+- ledger name, checksum, and gap tampering
+- migration and reconciliation rollback
+- reset and reinitialization
+- real CLI initialization
+- isolated-process FFI initialization and Refresh acceptance
+
+The gate runs in normal CI, the macOS release canary, and direct GUI and CLI
+release workflows before artifacts are built.
+
+## Adding A Migration
+
+1. Append one new `SqliteMigration`; never edit an existing definition.
+2. Generate the candidate manifest with
+   `python3 scripts/ci/check_sqlite_migration_manifest.py --emit`.
+3. Append only the new generated identity to the committed manifest.
+4. Add a frozen origin fixture when the migration changes persisted data.
+5. Add preservation, idempotency, rollback, reset, and boundary tests as applicable.
+6. Run the compatibility gate and full repository quality gate.
+7. Obtain independent review for migration-engine, manifest, and recovery changes.
+
+Release canaries must exercise a stateful upgrade from the prior public stable
+release. Signing/notarization success alone is not evidence of database upgrade
+compatibility.

--- a/scripts/ci/check_sqlite_migration_compatibility.sh
+++ b/scripts/ci/check_sqlite_migration_compatibility.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+cd "$ROOT_DIR"
+
+echo "[sqlite-compat] validating immutable migration manifest"
+python3 scripts/ci/check_sqlite_migration_manifest.py
+
+echo "[sqlite-compat] running core migration matrix"
+cargo test \
+  --manifest-path core/rust/Cargo.toml \
+  -p helm-core \
+  --test sqlite_migrations_contract \
+  -- \
+  --test-threads=1
+
+echo "[sqlite-compat] running real CLI recovery boundary"
+cargo test \
+  --manifest-path core/rust/Cargo.toml \
+  -p helm-cli \
+  --test migration_recovery_cli \
+  -- \
+  --test-threads=1
+
+echo "[sqlite-compat] running isolated FFI initialization boundary"
+cargo test \
+  --manifest-path core/rust/Cargo.toml \
+  -p helm-ffi \
+  tests::ffi_init_ \
+  -- \
+  --test-threads=1
+
+echo "[sqlite-compat] migration compatibility gate passed"

--- a/scripts/ci/check_sqlite_migration_manifest.py
+++ b/scripts/ci/check_sqlite_migration_manifest.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Validate Helm's append-only SQLite migration identity manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATIONS_PATH = ROOT / "core/rust/crates/helm-core/src/sqlite/migrations.rs"
+MANIFEST_PATH = (
+    ROOT / "core/rust/crates/helm-core/resources/sqlite_migration_manifest.json"
+)
+MANIFEST_RELATIVE = MANIFEST_PATH.relative_to(ROOT).as_posix()
+MANIFEST_SCHEMA = "helm.sqlite-migration-manifest"
+MIGRATION_PATTERN = re.compile(
+    r"const MIGRATION_(\d{4}): SqliteMigration = SqliteMigration \{\s*"
+    r"version: (\d+),\s*"
+    r'name: "([^"]+)",\s*'
+    r'up_sql: r#"(.*?)"#,\s*'
+    r'down_sql: r#"(.*?)"#,\s*'
+    r"\};",
+    re.DOTALL,
+)
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def definition_checksum(version: int, name: str, up_sql: str, down_sql: str) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"helm.sqlite-migration.v1\0")
+    digest.update(version.to_bytes(8, byteorder="big", signed=True))
+    for field in (name.encode(), up_sql.encode(), down_sql.encode()):
+        digest.update(len(field).to_bytes(8, byteorder="big"))
+        digest.update(field)
+    return digest.hexdigest()
+
+
+def source_entries() -> list[dict[str, Any]]:
+    source = MIGRATIONS_PATH.read_text(encoding="utf-8")
+    matches = MIGRATION_PATTERN.findall(source)
+    if not matches:
+        fail(f"no migrations parsed from {MIGRATIONS_PATH.relative_to(ROOT)}")
+
+    entries: list[dict[str, Any]] = []
+    for index, (suffix, raw_version, name, up_sql, down_sql) in enumerate(matches, 1):
+        version = int(raw_version)
+        if int(suffix) != version or version != index:
+            fail(f"migration sequence is not contiguous at version {index}")
+        entries.append(
+            {
+                "version": version,
+                "name": name,
+                "definition_sha256": definition_checksum(
+                    version, name, up_sql, down_sql
+                ),
+            }
+        )
+    return entries
+
+
+def manifest_document(entries: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema": MANIFEST_SCHEMA,
+        "schema_version": 1,
+        "migrations": entries,
+    }
+
+
+def load_manifest(raw: str, source: str) -> dict[str, Any]:
+    try:
+        document = json.loads(raw)
+    except json.JSONDecodeError as error:
+        fail(f"invalid migration manifest from {source}: {error}")
+    if not isinstance(document, dict):
+        fail(f"migration manifest from {source} must be an object")
+    if document.get("schema") != MANIFEST_SCHEMA or document.get("schema_version") != 1:
+        fail(f"unsupported migration manifest schema in {source}")
+    migrations = document.get("migrations")
+    if not isinstance(migrations, list):
+        fail(f"migration manifest entries in {source} must be an array")
+    return document
+
+
+def validate_current_manifest(entries: list[dict[str, Any]]) -> dict[str, Any]:
+    manifest = load_manifest(MANIFEST_PATH.read_text(encoding="utf-8"), MANIFEST_RELATIVE)
+    if manifest["migrations"] != entries:
+        fail(
+            "SQLite migration definitions differ from the committed manifest; "
+            "released entries are immutable and new entries must be appended"
+        )
+    return manifest
+
+
+def validate_append_only(base_ref: str, current: dict[str, Any]) -> None:
+    base_commit = subprocess.run(
+        ["git", "cat-file", "-e", f"{base_ref}^{{commit}}"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if base_commit.returncode != 0:
+        fail(f"cannot resolve migration manifest base ref {base_ref!r}")
+
+    base_manifest = subprocess.run(
+        ["git", "cat-file", "-e", f"{base_ref}:{MANIFEST_RELATIVE}"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if base_manifest.returncode != 0:
+        print(
+            "SQLite migration manifest is new on the base ref; accepting initial bootstrap."
+        )
+        return
+
+    result = subprocess.run(
+        ["git", "show", f"{base_ref}:{MANIFEST_RELATIVE}"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail(f"cannot read migration manifest from base ref {base_ref!r}")
+
+    base = load_manifest(result.stdout, f"{base_ref}:{MANIFEST_RELATIVE}")
+    base_entries = base["migrations"]
+    current_entries = current["migrations"]
+    if len(current_entries) < len(base_entries):
+        fail("SQLite migration manifest entries may not be removed")
+    if current_entries[: len(base_entries)] != base_entries:
+        fail("existing SQLite migration manifest entries may not be modified or reordered")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base-ref",
+        help="Git ref whose committed manifest must remain an exact prefix",
+    )
+    parser.add_argument(
+        "--emit",
+        action="store_true",
+        help="print a manifest generated from the current Rust definitions",
+    )
+    args = parser.parse_args()
+
+    entries = source_entries()
+    if args.emit:
+        print(json.dumps(manifest_document(entries), indent=2) + "\n", end="")
+        return
+
+    current = validate_current_manifest(entries)
+    if args.base_ref:
+        validate_append_only(args.base_ref, current)
+    print(f"SQLite migration manifest validated ({len(entries)} immutable entries).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements the corrective actions from the v0.18.0 SQLite migration incident so shared migration history is immutable, incompatible ledgers fail closed, upgrades are recoverable, and release CI exercises real persisted-state boundaries.

## Changes

- adds an append-only migration identity manifest covering version, name, up/down SQL, and SHA-256 definition checksum
- adds migration 20 to persist definition checksums and transactionally backfill existing ledgers
- rejects gaps, unknown versions, changed names, changed checksums, and missing checksums on checksum-aware databases
- creates verified private pre-migration backups with integrity checks, bounded retention, and Reset Local Data cleanup
- separates debug databases into `Helm-Development` while preserving explicit `HELM_DB_PATH` overrides
- propagates initialization failures through FFI/XPC for actionable Service Health reporting
- adds stateful v0.17.12, affected-v0.18.0, rollback, tampering, backup, CLI, and FFI tests
- adds migration compatibility gates to normal CI and GUI/CLI release workflows
- adds CODEOWNERS routing, PR policy, agent policy, and migration-safety architecture documentation

## Verification

- `scripts/ci/check_sqlite_migration_compatibility.sh`
  - 21 core migration tests passed
  - real CLI recovery boundary passed
  - 2 isolated FFI initialization boundaries passed
- `.opencode/skills/run-quality-gate/scripts/run-quality-gate.sh all`
  - complete Rust workspace passed
  - formatting and strict clippy passed
  - locale and channel policy checks passed
  - 49 macOS tests passed
  - release contracts, preflight, and rehearsal passed
- docs-sync checks passed

## SQLite Migration Safety

- [ ] This PR does not change SQLite migrations or migration behavior.
- [x] The change only appends migration 20 and its manifest entry; frozen origin fixtures and preservation/rollback/reset tests are covered.
- [x] `scripts/ci/check_sqlite_migration_compatibility.sh` passed.
- [ ] Independent review of migration-engine, manifest, recovery, and CI behavior is complete.

## Release Impact

- [x] No v0.18.1 artifact or publication mutation. This is post-release hardening targeting `dev`.
