### PR TITLE
release: prepare v0.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on Keep a Changelog and follows SemVer-compatible Helm versi
 
 ## [Unreleased]
 
+## [0.18.2] - 2026-08-04
+
+### Added
+- An append-only SQLite migration identity manifest now records each released migration's version, name, up/down SQL, and SHA-256 definition checksum.
+- Migration `20` persists and backfills migration-definition checksums, while verified private pre-migration backups provide bounded recovery points before future schema changes.
+- Project WOW first-run contracts and the Native Mac Experience audit, approved information architecture, prototypes, state matrix, quality budgets, research protocol, and incremental migration map now form the closed v0.18 design baseline for v0.19 implementation.
+
+### Changed
+- SQLite initialization now validates ledger continuity and immutable migration identity before applying new work, separates default debug databases from release data, and surfaces initialization failures through CLI, FFI, XPC, and Service Health paths.
+- Release CI now exercises persisted SQLite upgrade, rollback, tampering, backup, CLI, and FFI boundaries through the shared migration-compatibility gate.
+- Pre-1.0 planning now targets Health, Updates, Packages, Activity, and Sources in the Control Center, with separate Settings, contextual diagnostics, command-based search, and explicit base Helm, Helm Pro, and Helm Fleet boundaries.
+
+### Security
+- Unknown, missing, reordered, renamed, or checksum-mismatched migration ledger entries fail closed instead of allowing an incompatible database history to continue.
+
+This release contains the completed v0.18 work before production v0.19 native-experience and first-run implementation begins. The design artifacts are planning contracts only; they do not add the planned first-run or redesigned UI behavior in v0.18.2.
+
 ## [0.18.1] - 2026-08-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 Helm manages software across multiple package managers (Homebrew, npm, pip, Cargo, etc.) and runtime tools (mise, rustup) from a single menu bar interface. It is designed as infrastructure software: deterministic, safety-first, and explicit about authority, orchestration, and error handling.
 
-> **Release notice:** Active pre-1.0 development continues with stable `v0.18.1` on `main`. `v0.18.0` remains withdrawn because of a critical SQLite migration defect; `v0.19.x` stability and pre-1.0 hardening is next.
+> **Release notice:** Active pre-1.0 development continues with stable `v0.18.1` on `main` while `v0.18.2` completes release validation on `dev`. `v0.18.0` remains withdrawn because of a critical SQLite migration defect; `v0.18.2` contains the final v0.18 migration-safety and design-definition work before v0.19 implementation begins.
 >
 > **Testing:** Please test `v0.18.1`. If you installed `v0.18.0`, update to `v0.18.1` before further use. Report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
@@ -191,7 +191,7 @@ Or open `apps/macos-ui/Helm.xcodeproj` in Xcode and run the **Helm** scheme. The
 | 0.16.1 | Documentation, Milestone Restructure & Security Staging Clarification | Completed (documentation-only) |
 | 0.16.2 | Sparkle Connectivity + Platform Baseline Alignment — network-client entitlement, feed diagnostics, macOS 11 deployment target enforcement | Completed |
 | 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel | Completed (`v0.17.x` stable, latest patch `v0.17.12`) |
-| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge and internal advisory cache foundation (no public advisory feature surface) | Completed (`v0.18.1` corrective release; `v0.18.0` withdrawn) |
+| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge, migration-safety hardening, internal advisory cache foundation, and pre-1.0 experience-definition contracts (no public advisory feature surface) | `v0.18.2` release validation (`v0.18.0` withdrawn) |
 | 0.19.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit | Next |
 | 1.0.0 | Stable Control Plane Release — production-safe execution, full feature set | Planned |
 

--- a/core/rust/Cargo.lock
+++ b/core/rust/Cargo.lock
@@ -650,7 +650,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helm-cli"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "crossterm 0.28.1",
  "helm-core",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "helm-core"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "libc",
  "rusqlite",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "helm-ffi"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "cbindgen",
  "helm-core",

--- a/core/rust/Cargo.toml
+++ b/core/rust/Cargo.toml
@@ -3,4 +3,4 @@ members = ["crates/helm-core", "crates/helm-ffi", "crates/helm-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.18.1"
+version = "0.18.2"

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,18 +8,20 @@ It reflects reality, not intention.
 
 ## Version
 
-Current documentation baseline: **0.18.1 is the latest public stable release**; `v0.18.0` remains withdrawn because of a critical SQLite migration defect, the `0.18.x` Project WOW and Native Mac Experience design-definition artifact set is closed without runtime changes, and `v0.19.x` native-experience foundation and first-run value is the next implementation milestone.
+Current documentation baseline: **0.18.1 is the latest public stable release and v0.18.2 is in release validation on `dev`**; `v0.18.0` remains withdrawn because of a critical SQLite migration defect. `v0.18.2` contains the final v0.18 migration-safety hardening and the closed Project WOW and Native Mac Experience design-definition artifacts before v0.19 implementation begins.
 
-Implementation baseline: **0.18.x doctor/repair and local security groundwork is released on `main` through corrective `v0.18.1`**; `v0.18.0` remains withdrawn.
+Implementation baseline: **0.18.x doctor/repair and local security groundwork is released on `main` through corrective `v0.18.1`; additional SQLite migration-safety hardening is complete on `dev` for v0.18.2**. The design-definition additions are planning contracts and do not implement the planned first-run or redesigned UI behavior.
 
 See:
 - CHANGELOG.md
 
 Active milestone:
 - latest stable release currently published on `main`: **0.18.1**
+- `v0.18.2` stable release preparation is in progress on `dev`; public GUI and CLI update metadata remains pinned to `v0.18.1` until publication succeeds.
 - `v0.18.0` was published on 2026-08-03 and then withdrawn after discovery of a critical SQLite migration defect; its immutable tag is retained for auditability while its release is not publicly distributed.
 - public GUI and CLI update metadata points to the signed `v0.18.1` artifacts.
 - delivered in `v0.18.1`: reconciliation of the known development migration `17` collision before released doctor/repair migrations run, plus prevention of historical DDL replay for already-current databases, preserving package identifiers and user data.
+- complete on `dev` for `v0.18.2`: immutable migration identities and definition checksums, fail-closed ledger validation, verified bounded pre-migration backups, debug/release database separation, initialization-error propagation, and migration-compatibility CI/release gates.
 - approved internal product-design planning track: **Project WOW** defines the base Helm first-run value loop and product allocation at `docs/app-design/PROJECT_WOW.md`; its v0.18 machine contracts, bootstrap audit, CLI/TUI contract, native prototype, state matrix, and research protocol are complete planning artifacts, staged implementation/validation follows in `0.19.x`-`0.22.x`, and no related runtime behavior is implemented by this documentation checkpoint
 - approved internal whole-app design planning track: the **Native Mac Experience initiative** at `docs/app-design/NATIVE_MACOS_EXPERIENCE.md` now has a complete v0.18 audit, component inventory, approved Health/Updates/Packages/Activity/Sources IA, native prototypes, state matrix, quality budgets, research protocol/expert walkthrough, and incremental migration map; Settings is separate, diagnostics contextual, and search command-based; production implementation remains staged across `0.19.x`-`0.22.x`
 - human-validation status: no participant session is claimed by the v0.18 artifact closure; the owner-run moderated checkpoint in `docs/app-design/NATIVE_MACOS_RESEARCH_VALIDATION.md` remains required before v0.20 workflow sign-off and before v0.22 UI lock
@@ -1027,4 +1029,4 @@ Helm is a **functional control plane for 28 implemented managers** with:
 
 The core architecture is in place. The Rust core passed a full audit with no critical issues.
 
-0.13.x through 0.18.1 stable checkpoints are complete on `main`; `v0.18.0` remains withdrawn, and `v0.18.1` is the corrective stable release for the doctor/repair and local-security groundwork.
+0.13.x through 0.18.1 stable checkpoints are complete on `main`; `v0.18.0` remains withdrawn, `v0.18.1` is the corrective public stable release, and `v0.18.2` is in validation as the final v0.18 containment release before v0.19 implementation.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -875,7 +875,7 @@ The initiative may revise information architecture, layout, workflows, window be
 
 Deliver the work incrementally:
 
-- `0.18.x` planning closure after `v0.18.1` (complete): audit, component inventory, approved IA, prototypes, state matrix, budgets, owner-run research protocol/expert walkthrough, and migration map; no runtime-scope reopening or additional `0.18.x` publication
+- `0.18.x` planning closure after `v0.18.1` (complete): audit, component inventory, approved IA, prototypes, state matrix, budgets, owner-run research protocol/expert walkthrough, and migration map; included as planning-only content in the final `v0.18.2` containment release without claiming implementation of the target experience
 - `0.19.x`: native application foundation and first-run value foundation
 - `0.20.x`: core workflow and information-architecture redesign
 - `0.21.x`: accessibility, system integration, resilience, and first-run recovery/receipt completion

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -11,12 +11,12 @@ It is intentionally tactical.
 Helm is in:
 
 ```
-v0.19.x native-experience foundation and first-run value, using the closed v0.18 design contracts
+v0.18.2 release validation, then v0.19.x native-experience foundation and first-run value
 ```
 
 Focus:
-- begin production `v0.19.x` foundation work from the closed Project WOW and Native Mac Experience artifacts; do not reinterpret the artifact closure as shipped UI/runtime behavior
-- maintain release-process hardening guardrails now that `v0.18.1` publication is complete
+- complete the `v0.18.2` quality gate, rehearsal, protected-branch promotion, canary, publish-auth, signing, notarization, publication, and post-publication verification before beginning production `v0.19.x` work
+- maintain release-process hardening guardrails while containing the final `0.18.x` work in `v0.18.2`
 - preserve the released `v0.18.1` migration-reconciliation behavior and its affected-database recovery coverage
 - preserve manager-specific expected nonzero update-check outcomes as completed refreshes with actionable outdated state, starting with rustup's exit code `100`
 - preserve the released SQLite doctor/repair lifecycle, bundled knowledge bootstrap, import/export hardening, and repair verification path without widening into online knowledge lookup
@@ -35,7 +35,7 @@ Focus:
 - track post-mise lifecycle follow-ups: plugin-as-package modeling evaluation and managed-environment install-source policy controls
 - keep the agent-agnostic operating model current (lean `AGENTS`, isolated task worktrees under `.worktrees/` via `agent-worktree-isolation`, `.opencode/skills/`, inactive prompt drafts under `.opencode/templates/`, notify logging to `dev/logs/agent-runs.ndjson`, and `scripts/agents/` workflows) so recurring AI workflows remain deterministic and low-friction
 
-Completed `0.18.x` design-definition closure is planning/prototype work only. It does not reopen the published `v0.18.1` runtime scope or require a `v0.18.2` release:
+Completed `0.18.x` design-definition closure is planning/prototype work only. It is included in the `v0.18.2` containment release alongside SQLite migration-safety hardening, but it does not claim shipped first-run or redesigned UI behavior:
 
 - Project WOW contracts: Environment Brief, setup session, recommendation/plan, Action Receipt, and redaction schemas; discovery/consent classification; bootstrap feasibility and typed-action boundaries; offline/failure/recovery semantics; CLI/TUI interaction contract; local metrics event definitions; first-run usability/accessibility protocol; Fleet managed-configuration boundary
 - Native Mac Experience artifacts: current-experience screenshot audit; custom-versus-native component inventory; user-research plan and baseline task protocol; information-architecture options and decision; menu bar, Control Center, Settings, and Project WOW prototypes; complete state matrix; accessibility and perceived-performance budgets; incremental production migration map
@@ -60,10 +60,10 @@ Native Mac Experience planning source:
 - `1.0.0`: native experience and Project WOW release gates must both pass on the production app
 
 Current checkpoint:
-- `0.18.x` internal groundwork is released on `main` through `v0.18.1`; `v0.18.0` remains withdrawn because of its critical SQLite migration defect.
+- `0.18.x` internal groundwork is released on `main` through `v0.18.1`; `v0.18.2` is in release validation as the final containment release, and `v0.18.0` remains withdrawn because of its critical SQLite migration defect.
 - Project WOW and Native Mac Experience v0.18 planning artifacts are closed and cross-linked. The owner-run moderated-study checkpoint remains open and is not represented as participant evidence.
 - `v0.18.1` transactionally reconciles the migration `17` collision, avoids historical DDL replay, and passed fresh-install, `v0.17.12` upgrade, and affected-`v0.18.0` recovery validation.
-- `v0.18.1` is the current public stable release; doctor/repair, local security groundwork, migration recovery, and package workflow hardening are now published:
+- `v0.18.1` remains the current public stable release until `v0.18.2` publication completes; doctor/repair, local security groundwork, migration recovery, and package workflow hardening are already published:
   - bulk and scoped upgrade phase coordination now resides in Rust/FFI/XPC. The backend derives the current safe plan, schedules authority phases, waits for each phase to reach terminal state, and stops later-phase scheduling on scoped-workflow cancellation; individual tasks remain the live execution and diagnostics surface.
   - all current manager adapters are considered complete for Helm's intended scope
   - intentionally narrower manager scopes remain explicit (`nix_darwin` detect/refresh-only; detection-only adapters such as `sparkle`, `setapp`, and `parallels_desktop`; guarded/status adapters such as `docker_desktop`, `podman`, `colima`, `rosetta2`, `firmware_updates`, and `xcode_command_line_tools`)
@@ -1309,4 +1309,4 @@ Delivered:
 - Distribution/licensing future-state planning documentation is aligned for 0.14 release notes and roadmap planning (no implementation yet).
 - 0.14.x and 0.15.x release execution are complete on `main` (`v0.14.1` and `v0.15.0`).
 - 0.17.12 release execution is complete on `main`; 0.17.x diagnostics/logging delivery and post-`0.17.x` follow-up stabilization are now closed with stable lineage `v0.17.0`, `v0.17.1`, `v0.17.2`, `v0.17.3`, `v0.17.4`, `v0.17.5`, `v0.17.6`, `v0.17.7`, `v0.17.8`, `v0.17.9`, `v0.17.10`, `v0.17.11`, and `v0.17.12`.
-- 0.18.1 corrective release execution is complete on `main`; `v0.18.0` remains withdrawn, while doctor/repair persistence, local-security groundwork, and migration recovery are publicly distributed through `v0.18.1`.
+- 0.18.1 corrective release execution is complete on `main`; `v0.18.0` remains withdrawn, and `v0.18.2` is in release validation to contain the final migration-safety and design-definition work before v0.19.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -62,6 +62,32 @@ This checklist is required before creating a release tag on `main`.
   - `CLI Update Metadata Drift Guard`
 - [x] Review `TMP_RELEASE_FRICTION`; promote recurring friction items into durable docs (`docs/DECISIONS.md`, `docs/operations/CLI_RELEASE_AND_CI.md`) and keep temporary notes uncommitted.
 
+## v0.18.2 (Final v0.18 Containment Release Gate, Pending)
+
+### Scope
+
+- [x] Append-only SQLite migration identity manifest records released migration version, name, up/down SQL, and SHA-256 definition checksum.
+- [x] Migration `20` persists and backfills migration-definition checksums without rewriting prior released migrations.
+- [x] SQLite initialization rejects ledger gaps, unknown versions, changed names, changed checksums, and missing checksums on checksum-aware databases.
+- [x] Verified private pre-migration backups, integrity checks, bounded retention, and Reset Local Data cleanup provide a recoverable migration boundary.
+- [x] Debug databases are separated from release data by default while explicit `HELM_DB_PATH` overrides remain supported.
+- [x] Initialization failures propagate through CLI, FFI, XPC, and Service Health paths instead of being silently discarded.
+- [x] Migration compatibility checks run in normal CI and GUI/CLI release workflows.
+- [x] Project WOW and Native Mac Experience v0.18 design contracts are complete and included as planning-only release content; no target first-run or redesigned UI behavior is claimed.
+- [x] The owner-run moderated-study checkpoint remains open and required before v0.20 workflow sign-off and v0.22 UI lock.
+
+### Required Validation
+
+- [x] Stateful v0.17.12 upgrade, affected-v0.18.0 recovery, rollback, tampering, backup, CLI, and FFI migration suites pass on the merged implementation.
+- [x] Run the full repository quality gate, documentation sync, Sparkle checklist, and non-mutating `v0.18.2` release rehearsal from the release-preparation branch.
+- [ ] Merge release preparation through `dev` and the protected `dev` to `main` path.
+- [ ] Run rehearsal and preflight from a clean, current `main` checkout.
+- [ ] Confirm a fresh successful `Release macOS Canary` on `macos-26` after the final release changes.
+- [ ] Dispatch and pass `Release Publish Auth Check` with `write_probe=true` under the maintainer's release authorization.
+- [ ] Create and push annotated tag `v0.18.2` from the verified `main` revision.
+- [ ] Complete signed/notarized GUI and direct CLI artifact publication.
+- [ ] Merge generated metadata PRs if required and complete post-publication verification and drift guards.
+
 ## v0.18.1 (Corrective Release Gate, Completed)
 
 ### Required Remediation

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -561,7 +561,7 @@ Exit Criteria:
 
 ## 0.18.x — Doctor & Repair Foundation - Released on `main`
 
-Release status: published through corrective `v0.18.1`; `v0.18.0` remains withdrawn because of its critical SQLite migration defect.
+Release status: published through corrective `v0.18.1`, with final migration-safety hardening in `v0.18.2` release validation; `v0.18.0` remains withdrawn because of its critical SQLite migration defect.
 
 Goal:
 
@@ -628,7 +628,7 @@ Stage 3 (`1.4.x`) — Shared Brain:
 
 ## 0.18.x — Local Security Groundwork (second slice) - Released on `main`
 
-Release status: published through `v0.18.1` after migration remediation and recovery validation.
+Release status: published through `v0.18.1` after migration remediation and recovery validation, with final v0.18 containment in `v0.18.2` release validation.
 
 Goal:
 
@@ -653,7 +653,7 @@ Exit Criteria:
 
 ## 0.18.x — Pre-1.0 Experience Definition (post-release planning closure) - Completed
 
-Status: planning/prototype artifact closure completed after corrective `v0.18.1`; this does not alter the released runtime scope or require another `0.18.x` publication.
+Status: planning/prototype artifact closure completed after corrective `v0.18.1` and is included as planning-only content in the `v0.18.2` containment release alongside migration-safety hardening.
 
 Goal:
 

--- a/docs/app-design/NATIVE_MACOS_EXPERIENCE.md
+++ b/docs/app-design/NATIVE_MACOS_EXPERIENCE.md
@@ -234,7 +234,7 @@ Notifications are reserved for meaningful state changes when Helm is not frontmo
 
 ### 0.18.x — Experience definition and prototypes (post-v0.18.1 planning closure)
 
-This planning and validation artifact closure completed after the corrective `v0.18.1` release. It does not reopen the released runtime scope or require another `0.18.x` publication. Production `0.19.x` redesign implementation begins from these artifacts.
+This planning and validation artifact closure completed after the corrective `v0.18.1` release and is included as planning-only content in the final `v0.18.2` containment release. It does not claim implementation of the target experience. Production `0.19.x` redesign implementation begins from these artifacts.
 
 Deliverables:
 

--- a/docs/app-design/PROJECT_WOW.md
+++ b/docs/app-design/PROJECT_WOW.md
@@ -564,7 +564,7 @@ Fleet-specific indicators:
 - [x] define local metrics events without adding telemetry transport (`docs/contracts/first-run/metrics-event.schema.json`)
 - [x] bootstrap feasibility and typed-action matrix (`docs/architecture/BOOTSTRAP_FEASIBILITY_MATRIX.md`)
 
-This completed planning/prototype closure does not reopen the released `v0.18.1` runtime scope or require another `0.18.x` publication. Production `0.19.x` first-run implementation begins from these contracts.
+This completed planning/prototype closure is included as planning-only content in the final `v0.18.2` containment release. It does not claim implementation of the target first-run experience. Production `0.19.x` first-run implementation begins from these contracts.
 
 Artifact closure is complete. The human moderated-study checkpoint remains explicitly open: no participant session or result is claimed by these documents, and v0.20 workflow sign-off/v0.22 UI lock still require owner-run evidence.
 

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -45,7 +45,7 @@ Key features:
 - **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, `ja`, and `hu` with locale override in Settings
 - **Upgrade transparency** — dedicated upgrade preview surface with scoped execution and failure-attribution visibility
 
-> **Current release:** `v0.18.1` is the latest stable release. `v0.18.0` remains withdrawn because of its critical SQLite migration defect; users of `v0.18.0` should update to `v0.18.1` before further use. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current release:** `v0.18.1` remains the latest stable release while `v0.18.2` completes release validation. `v0.18.0` remains withdrawn because of its critical SQLite migration defect; users of `v0.18.0` should update to `v0.18.1` or later before further use. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## How it works
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -32,9 +32,9 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 | 0.15.x | Advanced Upgrade Transparency — richer execution-plan visibility, failure isolation, and operator controls (`v0.15.0` released) |
 | 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification (`v0.16.x` stable, latest patch `v0.16.2`) |
 | 0.17.x | Diagnostics & Logging + Release Hardening — task log viewer, structured diagnostics export, manager-detection diagnostics, onboarding/detection hardening, manager-selection controls, and stable release follow-up fixes (`v0.17.0` stable, latest patch `v0.17.12`) |
-| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge and internal advisory cache foundation (`v0.18.1` corrective stable release; `v0.18.0` withdrawn) |
+| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge, migration-safety hardening, internal advisory cache foundation, and pre-1.0 experience-definition contracts (`v0.18.2` release validation; `v0.18.0` withdrawn) |
 
-> **Current Track:** `v0.18.1` is stable on `main`; `v0.18.0` remains withdrawn, and `v0.19.x` stability and pre-1.0 hardening is next. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.18.1` is stable on `main`; `v0.18.2` is in release validation as the final v0.18 containment release, `v0.18.0` remains withdrawn, and native-experience/first-run implementation begins in `v0.19.x`. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Planned
 


### PR DESCRIPTION
## Summary

Prepares the final v0.18 containment release, `v0.18.2`, before production v0.19 work begins.

## Release scope

- bumps the Rust workspace and generated build version source to `0.18.2`
- documents the append-only SQLite migration manifest, migration-definition checksums, fail-closed ledger validation, verified pre-migration backups, debug/release database separation, and initialization-error propagation delivered by PR #336
- includes the completed Project WOW and Native Mac Experience contracts from PRs #337 and #338 as planning-only release content
- preserves the owner-run moderated-study checkpoint and makes clear that v0.18.2 does not implement the planned first-run or redesigned UI behavior
- keeps public appcast and CLI metadata on v0.18.1 until publication succeeds

## Validation

- full repository quality gate passed
- Rust workspace tests, formatting, and strict Clippy passed
- 49 macOS tests passed
- SQLite migration compatibility gate passed: 20-entry manifest, 21 core migration tests, CLI recovery boundary, and isolated FFI boundaries
- locale integrity/length and mirror parity passed
- docs sync and release-line contracts passed
- Sparkle/appcast checklist passed
- v0.18.2 non-mutating release rehearsal passed
- live preflight found required release secrets/workflows and acceptable main ruleset policy; warnings were limited to unavailable OAuth scope headers and the documented RepositoryRole PR-bypass fallback

## Release impact

After this PR reaches `dev`, `dev` will be promoted through the protected PR path to `main`. Tagging and publication will occur only from the verified current `main` revision.
