### PR TITLE
docs: record v0.18.2 final release gates

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -80,10 +80,10 @@ This checklist is required before creating a release tag on `main`.
 
 - [x] Stateful v0.17.12 upgrade, affected-v0.18.0 recovery, rollback, tampering, backup, CLI, and FFI migration suites pass on the merged implementation.
 - [x] Run the full repository quality gate, documentation sync, Sparkle checklist, and non-mutating `v0.18.2` release rehearsal from the release-preparation branch.
-- [ ] Merge release preparation through `dev` and the protected `dev` to `main` path.
-- [ ] Run rehearsal and preflight from a clean, current `main` checkout.
-- [ ] Confirm a fresh successful `Release macOS Canary` on `macos-26` after the final release changes.
-- [ ] Dispatch and pass `Release Publish Auth Check` with `write_probe=true` under the maintainer's release authorization.
+- [x] Merge release preparation through `dev` and the protected `dev` to `main` path.
+- [x] Run rehearsal and preflight from a clean, current `main` checkout.
+- [x] Confirm a fresh successful `Release macOS Canary` on `macos-26` after the final release changes.
+- [x] Dispatch and pass `Release Publish Auth Check` with `write_probe=true` under the maintainer's release authorization.
 - [ ] Create and push annotated tag `v0.18.2` from the verified `main` revision.
 - [ ] Complete signed/notarized GUI and direct CLI artifact publication.
 - [ ] Merge generated metadata PRs if required and complete post-publication verification and drift guards.


### PR DESCRIPTION
## Summary

- record protected release-preparation merge through `dev` to `main`
- record passing rehearsal and live preflight from clean current `main`
- record fresh successful macOS 26 canary and publication write-auth probe

## Evidence

- Release macOS Canary: https://github.com/jasoncavinder/Helm/actions/runs/30976083953
- Release Publish Auth Check: https://github.com/jasoncavinder/Helm/actions/runs/30976086442
- `scripts/release/rehearsal_dry_run.sh --tag v0.18.2`: passed
- `scripts/release/runbook.sh prepare --tag v0.18.2`: passed
- docs sync and release-line copy checks: passed

## Scope

Documentation-only release gate evidence. Tagging and publication remain pending until this PR merges and the final clean-main preflight is repeated.
