### PR TITLE
chore: sync v0.18.2 release closeout to dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <br>
   A macOS control center and CLI for unified package manager control.
   <br>
-  <strong>Pre-1.0 &middot; v0.18.1</strong>
+  <strong>Pre-1.0 &middot; v0.18.2</strong>
 </p>
 
 <p align="center">
@@ -23,9 +23,9 @@
 
 Helm manages software across multiple package managers (Homebrew, npm, pip, Cargo, etc.) and runtime tools (mise, rustup) from a single menu bar interface. It is designed as infrastructure software: deterministic, safety-first, and explicit about authority, orchestration, and error handling.
 
-> **Release notice:** Active pre-1.0 development continues with stable `v0.18.1` on `main` while `v0.18.2` completes release validation on `dev`. `v0.18.0` remains withdrawn because of a critical SQLite migration defect; `v0.18.2` contains the final v0.18 migration-safety and design-definition work before v0.19 implementation begins.
+> **Release notice:** Active pre-1.0 development continues with stable `v0.18.2` on `main`. `v0.18.0` remains withdrawn because of a critical SQLite migration defect; `v0.18.2` is the final v0.18 containment release before v0.19 native-experience and first-run implementation.
 >
-> **Testing:** Please test `v0.18.1`. If you installed `v0.18.0`, update to `v0.18.1` before further use. Report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Testing:** Please test `v0.18.2`. If you installed `v0.18.0`, update to `v0.18.2` before further use. Report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Editions (Beta)
 
@@ -191,8 +191,8 @@ Or open `apps/macos-ui/Helm.xcodeproj` in Xcode and run the **Helm** scheme. The
 | 0.16.1 | Documentation, Milestone Restructure & Security Staging Clarification | Completed (documentation-only) |
 | 0.16.2 | Sparkle Connectivity + Platform Baseline Alignment — network-client entitlement, feed diagnostics, macOS 11 deployment target enforcement | Completed |
 | 0.17.x | Diagnostics & Logging — log viewer, structured error export, health panel | Completed (`v0.17.x` stable, latest patch `v0.17.12`) |
-| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge, migration-safety hardening, internal advisory cache foundation, and pre-1.0 experience-definition contracts (no public advisory feature surface) | `v0.18.2` release validation (`v0.18.0` withdrawn) |
-| 0.19.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit | Next |
+| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge, migration-safety hardening, internal advisory cache foundation, and pre-1.0 experience-definition contracts (no public advisory feature surface) | Completed (`v0.18.2` final containment release; `v0.18.0` withdrawn) |
+| 0.19.x | Native Experience Foundation & First-Run Value — native app shell, commands, Settings/window behavior, Environment Brief, and stability baselines | Next |
 | 1.0.0 | Stable Control Plane Release — production-safe execution, full feature set | Planned |
 
 See [`docs/ROADMAP.md`](docs/ROADMAP.md) for the full roadmap through 1.x.
@@ -249,7 +249,7 @@ The `1.4.x` Shared Brain milestone is planned as **Postgres-first** and **provid
 - Durable Objects / D1 are not the Shared Brain system-of-record.
 - Large artifacts (if introduced later) should live in S3-compatible object storage; Postgres stores references/metadata.
 
-Current releases (through `v0.18.1`) do **not** send package/fingerprint data to a shared backend. Security-advisory value remains local-first until the `1.4.x` Shared Brain milestone.
+Current releases (through `v0.18.2`) do **not** send package/fingerprint data to a shared backend. Security-advisory value remains local-first until the `1.4.x` Shared Brain milestone.
 
 ## Repository Layout
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -474,7 +474,7 @@ Stage 3 (`1.4.x`) - Shared Brain:
 
 - The Security Advisory System (`1.3.x`) is independent of Shared Brain and remains functional without Helm-hosted services.
 - Shared Brain (`1.4.x`) is additive infrastructure that can enrich advisory outcomes but is not a prerequisite for local advisory evaluation.
-- Current releases (through `v0.18.1`) do not send package/fingerprint telemetry to a shared backend.
+- Current releases (through `v0.18.2`) do not send package/fingerprint telemetry to a shared backend.
 - Helm `1.0` crash/error reporting posture is local-only with no automatic remote crash telemetry; operational policy and payload expectations are documented in `docs/operations/CRASH_REPORTING_POLICY.md`.
 
 ---

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,20 +8,19 @@ It reflects reality, not intention.
 
 ## Version
 
-Current documentation baseline: **0.18.1 is the latest public stable release and v0.18.2 is in release validation on `dev`**; `v0.18.0` remains withdrawn because of a critical SQLite migration defect. `v0.18.2` contains the final v0.18 migration-safety hardening and the closed Project WOW and Native Mac Experience design-definition artifacts before v0.19 implementation begins.
+Current documentation baseline: **0.18.2 is the latest public stable release on `main`**; `v0.18.0` remains withdrawn because of a critical SQLite migration defect. `v0.18.2` is the final v0.18 containment release and includes migration-safety hardening plus the closed Project WOW and Native Mac Experience design-definition artifacts before v0.19 implementation begins.
 
-Implementation baseline: **0.18.x doctor/repair and local security groundwork is released on `main` through corrective `v0.18.1`; additional SQLite migration-safety hardening is complete on `dev` for v0.18.2**. The design-definition additions are planning contracts and do not implement the planned first-run or redesigned UI behavior.
+Implementation baseline: **0.18.x doctor/repair, local security groundwork, and migration-safety hardening are released on `main` through `v0.18.2`**. The design-definition additions are planning contracts and do not implement the planned first-run or redesigned UI behavior.
 
 See:
 - CHANGELOG.md
 
 Active milestone:
-- latest stable release currently published on `main`: **0.18.1**
-- `v0.18.2` stable release preparation is in progress on `dev`; public GUI and CLI update metadata remains pinned to `v0.18.1` until publication succeeds.
+- latest stable release currently published on `main`: **0.18.2**
 - `v0.18.0` was published on 2026-08-03 and then withdrawn after discovery of a critical SQLite migration defect; its immutable tag is retained for auditability while its release is not publicly distributed.
-- public GUI and CLI update metadata points to the signed `v0.18.1` artifacts.
+- public GUI and CLI update metadata points to the signed `v0.18.2` artifacts.
 - delivered in `v0.18.1`: reconciliation of the known development migration `17` collision before released doctor/repair migrations run, plus prevention of historical DDL replay for already-current databases, preserving package identifiers and user data.
-- complete on `dev` for `v0.18.2`: immutable migration identities and definition checksums, fail-closed ledger validation, verified bounded pre-migration backups, debug/release database separation, initialization-error propagation, and migration-compatibility CI/release gates.
+- delivered in `v0.18.2`: immutable migration identities and definition checksums, fail-closed ledger validation, verified bounded pre-migration backups, debug/release database separation, initialization-error propagation, and migration-compatibility CI/release gates.
 - approved internal product-design planning track: **Project WOW** defines the base Helm first-run value loop and product allocation at `docs/app-design/PROJECT_WOW.md`; its v0.18 machine contracts, bootstrap audit, CLI/TUI contract, native prototype, state matrix, and research protocol are complete planning artifacts, staged implementation/validation follows in `0.19.x`-`0.22.x`, and no related runtime behavior is implemented by this documentation checkpoint
 - approved internal whole-app design planning track: the **Native Mac Experience initiative** at `docs/app-design/NATIVE_MACOS_EXPERIENCE.md` now has a complete v0.18 audit, component inventory, approved Health/Updates/Packages/Activity/Sources IA, native prototypes, state matrix, quality budgets, research protocol/expert walkthrough, and incremental migration map; Settings is separate, diagnostics contextual, and search command-based; production implementation remains staged across `0.19.x`-`0.22.x`
 - human-validation status: no participant session is claimed by the v0.18 artifact closure; the owner-run moderated checkpoint in `docs/app-design/NATIVE_MACOS_RESEARCH_VALIDATION.md` remains required before v0.20 workflow sign-off and before v0.22 UI lock
@@ -112,6 +111,8 @@ Active milestone:
   - delivered for `v0.18.0`: persisted doctor/repair lifecycle, guarded repair knowledge, repair verification history, and deterministic local security-advisory cache groundwork without a public advisory surface.
   - `v0.18.1` corrective release execution status: released on `main` with tag, notarized DMG and CLI assets, published appcast and CLI metadata, and post-publication verification complete.
   - delivered for `v0.18.1`: migration-collision recovery, idempotent initialization for current databases, and restored service/Refresh/CLI operation for affected stores.
+  - `v0.18.2` final-containment release execution status: released on `main` with tag, signed/notarized DMG, direct CLI assets, published appcast and CLI metadata, generated release notes, and post-publication verification/drift guards complete.
+  - delivered for `v0.18.2`: immutable migration identity enforcement and recovery controls plus the planning-only Project WOW and Native Mac Experience contract baseline for v0.19 implementation.
 
 Security rollout staging status:
 - Stage 0 (`<=0.16.x`): planning/docs only (active in `0.16.1`)
@@ -1029,4 +1030,4 @@ Helm is a **functional control plane for 28 implemented managers** with:
 
 The core architecture is in place. The Rust core passed a full audit with no critical issues.
 
-0.13.x through 0.18.1 stable checkpoints are complete on `main`; `v0.18.0` remains withdrawn, `v0.18.1` is the corrective public stable release, and `v0.18.2` is in validation as the final v0.18 containment release before v0.19 implementation.
+0.13.x through 0.18.2 stable checkpoints are complete on `main`; `v0.18.0` remains withdrawn, `v0.18.1` is its corrective successor, and `v0.18.2` is the final v0.18 containment release before v0.19 implementation.

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -11,13 +11,13 @@ It is intentionally tactical.
 Helm is in:
 
 ```
-v0.18.2 release validation, then v0.19.x native-experience foundation and first-run value
+v0.19.x native-experience foundation and first-run value
 ```
 
 Focus:
-- complete the `v0.18.2` quality gate, rehearsal, protected-branch promotion, canary, publish-auth, signing, notarization, publication, and post-publication verification before beginning production `v0.19.x` work
-- maintain release-process hardening guardrails while containing the final `0.18.x` work in `v0.18.2`
-- preserve the released `v0.18.1` migration-reconciliation behavior and its affected-database recovery coverage
+- begin production `v0.19.x` work from the closed Native Mac Experience and Project WOW contracts
+- maintain release-process hardening guardrails now that `v0.18.2` publication is complete
+- preserve the released `v0.18.2` migration-safety baseline and `v0.18.1` affected-database recovery coverage
 - preserve manager-specific expected nonzero update-check outcomes as completed refreshes with actionable outdated state, starting with rustup's exit code `100`
 - preserve the released SQLite doctor/repair lifecycle, bundled knowledge bootstrap, import/export hardening, and repair verification path without widening into online knowledge lookup
 - preserve the compiled typed-action registry as the immutable execution boundary; knowledge remains declarative and cannot carry commands, arguments, scripts, plugins, or arbitrary executable content
@@ -60,10 +60,10 @@ Native Mac Experience planning source:
 - `1.0.0`: native experience and Project WOW release gates must both pass on the production app
 
 Current checkpoint:
-- `0.18.x` internal groundwork is released on `main` through `v0.18.1`; `v0.18.2` is in release validation as the final containment release, and `v0.18.0` remains withdrawn because of its critical SQLite migration defect.
+- `0.18.x` internal groundwork and migration-safety hardening are released on `main` through final-containment `v0.18.2`; `v0.18.0` remains withdrawn because of its critical SQLite migration defect.
 - Project WOW and Native Mac Experience v0.18 planning artifacts are closed and cross-linked. The owner-run moderated-study checkpoint remains open and is not represented as participant evidence.
 - `v0.18.1` transactionally reconciles the migration `17` collision, avoids historical DDL replay, and passed fresh-install, `v0.17.12` upgrade, and affected-`v0.18.0` recovery validation.
-- `v0.18.1` remains the current public stable release until `v0.18.2` publication completes; doctor/repair, local security groundwork, migration recovery, and package workflow hardening are already published:
+- `v0.18.2` is the current public stable release; doctor/repair, local security groundwork, migration recovery/safety, package workflow hardening, and planning-only pre-1.0 experience contracts are published:
   - bulk and scoped upgrade phase coordination now resides in Rust/FFI/XPC. The backend derives the current safe plan, schedules authority phases, waits for each phase to reach terminal state, and stops later-phase scheduling on scoped-workflow cancellation; individual tasks remain the live execution and diagnostics surface.
   - all current manager adapters are considered complete for Helm's intended scope
   - intentionally narrower manager scopes remain explicit (`nix_darwin` detect/refresh-only; detection-only adapters such as `sparkle`, `setapp`, and `parallels_desktop`; guarded/status adapters such as `docker_desktop`, `podman`, `colima`, `rosetta2`, `firmware_updates`, and `xcode_command_line_tools`)
@@ -392,7 +392,7 @@ Current checkpoint:
     - audit-remediation follow-up delivered: stable CLI update metadata now points to published `v0.17.2` CLI release assets with real checksums (no placeholder zeros), and auto-check last-checked timestamps now update only after eligible direct self-managed check attempts instead of policy-gated skips
     - audit-remediation follow-up delivered: distribution profile contract is now centralized in `docs/contracts/distribution-profiles.json` and consumed by shared build orchestration (`scripts/build.sh`, `scripts/release/build_unsigned_variant.sh`, matrix-based `release-all-variants.yml` auxiliary jobs); Swift update-authority mapping now has one source (`AppUpdateConfiguration`), targeted updater policy tests pass on macOS, and GUI checksum-publication symmetry is explicitly documented as deferred while Sparkle remains canonical GUI integrity authority
     - trust-chain future work is now explicitly tracked: detached signatures + signing-key rotation for CLI update artifacts (`docs/roadmap/CLI_DISTRIBUTION_CI_MILESTONES.md`, milestone M5)
-- latest stable release on `main`: `v0.18.1`
+- latest stable release on `main`: `v0.18.2`
 - validation gates are green through the stable cut (`cargo test`, macOS `xcodebuild` tests, locale integrity/length audits, release workflow smoke across `v0.17.0-rc.1` through `v0.17.0-rc.5`)
 - `v0.15.0` released on `main` (tag `v0.15.0`)
 - `v0.14.0` released (merged to `main`, tagged, manager rollout + docs/version alignment complete)
@@ -1309,4 +1309,4 @@ Delivered:
 - Distribution/licensing future-state planning documentation is aligned for 0.14 release notes and roadmap planning (no implementation yet).
 - 0.14.x and 0.15.x release execution are complete on `main` (`v0.14.1` and `v0.15.0`).
 - 0.17.12 release execution is complete on `main`; 0.17.x diagnostics/logging delivery and post-`0.17.x` follow-up stabilization are now closed with stable lineage `v0.17.0`, `v0.17.1`, `v0.17.2`, `v0.17.3`, `v0.17.4`, `v0.17.5`, `v0.17.6`, `v0.17.7`, `v0.17.8`, `v0.17.9`, `v0.17.10`, `v0.17.11`, and `v0.17.12`.
-- 0.18.1 corrective release execution is complete on `main`; `v0.18.0` remains withdrawn, and `v0.18.2` is in release validation to contain the final migration-safety and design-definition work before v0.19.
+- 0.18.2 final-containment release execution is complete on `main`; `v0.18.0` remains withdrawn, `v0.18.1` remains its corrective successor, and v0.19 native-experience/first-run implementation is next.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -62,7 +62,7 @@ This checklist is required before creating a release tag on `main`.
   - `CLI Update Metadata Drift Guard`
 - [x] Review `TMP_RELEASE_FRICTION`; promote recurring friction items into durable docs (`docs/DECISIONS.md`, `docs/operations/CLI_RELEASE_AND_CI.md`) and keep temporary notes uncommitted.
 
-## v0.18.2 (Final v0.18 Containment Release Gate, Pending)
+## v0.18.2 (Final v0.18 Containment Release Gate, Completed)
 
 ### Scope
 
@@ -84,9 +84,9 @@ This checklist is required before creating a release tag on `main`.
 - [x] Run rehearsal and preflight from a clean, current `main` checkout.
 - [x] Confirm a fresh successful `Release macOS Canary` on `macos-26` after the final release changes.
 - [x] Dispatch and pass `Release Publish Auth Check` with `write_probe=true` under the maintainer's release authorization.
-- [ ] Create and push annotated tag `v0.18.2` from the verified `main` revision.
-- [ ] Complete signed/notarized GUI and direct CLI artifact publication.
-- [ ] Merge generated metadata PRs if required and complete post-publication verification and drift guards.
+- [x] Create and push annotated tag `v0.18.2` from the verified `main` revision.
+- [x] Complete signed/notarized GUI and direct CLI artifact publication.
+- [x] Merge generated metadata PRs if required and complete post-publication verification and drift guards.
 
 ## v0.18.1 (Corrective Release Gate, Completed)
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -80,10 +80,10 @@ This checklist is required before creating a release tag on `main`.
 
 - [x] Stateful v0.17.12 upgrade, affected-v0.18.0 recovery, rollback, tampering, backup, CLI, and FFI migration suites pass on the merged implementation.
 - [x] Run the full repository quality gate, documentation sync, Sparkle checklist, and non-mutating `v0.18.2` release rehearsal from the release-preparation branch.
-- [ ] Merge release preparation through `dev` and the protected `dev` to `main` path.
-- [ ] Run rehearsal and preflight from a clean, current `main` checkout.
-- [ ] Confirm a fresh successful `Release macOS Canary` on `macos-26` after the final release changes.
-- [ ] Dispatch and pass `Release Publish Auth Check` with `write_probe=true` under the maintainer's release authorization.
+- [x] Merge release preparation through `dev` and the protected `dev` to `main` path.
+- [x] Run rehearsal and preflight from a clean, current `main` checkout.
+- [x] Confirm a fresh successful `Release macOS Canary` on `macos-26` after the final release changes.
+- [x] Dispatch and pass `Release Publish Auth Check` with `write_probe=true` under the maintainer's release authorization.
 - [ ] Create and push annotated tag `v0.18.2` from the verified `main` revision.
 - [ ] Complete signed/notarized GUI and direct CLI artifact publication.
 - [ ] Merge generated metadata PRs if required and complete post-publication verification and drift guards.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -561,7 +561,7 @@ Exit Criteria:
 
 ## 0.18.x — Doctor & Repair Foundation - Released on `main`
 
-Release status: published through corrective `v0.18.1`, with final migration-safety hardening in `v0.18.2` release validation; `v0.18.0` remains withdrawn because of its critical SQLite migration defect.
+Release status: published through final-containment `v0.18.2`; `v0.18.0` remains withdrawn because of its critical SQLite migration defect, and `v0.18.1` remains its corrective successor.
 
 Goal:
 
@@ -628,7 +628,7 @@ Stage 3 (`1.4.x`) — Shared Brain:
 
 ## 0.18.x — Local Security Groundwork (second slice) - Released on `main`
 
-Release status: published through `v0.18.1` after migration remediation and recovery validation, with final v0.18 containment in `v0.18.2` release validation.
+Release status: published through final-containment `v0.18.2` after migration remediation, recovery validation, and migration-safety hardening.
 
 Goal:
 

--- a/docs/contracts/release-line.json
+++ b/docs/contracts/release-line.json
@@ -1,3 +1,3 @@
 {
-  "stable_version": "0.18.1"
+  "stable_version": "0.18.2"
 }

--- a/docs/operations/CLI_RELEASE_AND_CI.md
+++ b/docs/operations/CLI_RELEASE_AND_CI.md
@@ -452,6 +452,8 @@ Promotion path after each release:
 - `scripts/release/runbook.sh tag` requires a branch named `main`, while agent policy requires release work in an isolated linked worktree and reserves the primary `main` checkout for coordination. Add a worktree-safe tag path that requires a clean `HEAD` exactly equal to `origin/main` before mutation ([#333](https://github.com/jasoncavinder/Helm/issues/333)).
 - The direct CLI and DMG workflows successfully uploaded artifacts and opened publish PRs, but their immediate metadata checks still concluded as failures while `main` intentionally remained behind those PRs. Align the workflow result and publication summary with the documented non-red follow-up-required state; hard failures must remain unchanged for build, signing, notarization, verification, upload, or PR-creation faults ([#332](https://github.com/jasoncavinder/Helm/issues/332)).
 
+`v0.18.2` confirmed that [#332](https://github.com/jasoncavinder/Helm/issues/332) remains active: both artifact workflows opened auto-merge publication PRs and uploaded valid assets, but set `PUBLISH_FOLLOWUP_REQUIRED=no` before checking the still-old `main` metadata, producing red terminal runs. Operators must continue treating this specific post-upload metadata race as the documented merge-and-`verify_only=true` path until the workflow-state fix lands; all earlier build, signing, notarization, upload, or PR-creation failures remain blocking.
+
 ---
 
 ## 6. Install Script CI Responsibilities

--- a/web/public/updates/appcast.xml
+++ b/web/public/updates/appcast.xml
@@ -6,16 +6,16 @@
     <description>Helm direct-channel updates</description>
     <language>en</language>
     <item>
-      <title>Helm 0.18.1</title>
-      <pubDate>Tue, 04 Aug 2026 16:43:22 +0000</pubDate>
-      <sparkle:releaseNotesLink>https://helmapp.dev/updates/release-notes/v0.18.1.html</sparkle:releaseNotesLink>
+      <title>Helm 0.18.2</title>
+      <pubDate>Wed, 05 Aug 2026 05:29:50 +0000</pubDate>
+      <sparkle:releaseNotesLink>https://helmapp.dev/updates/release-notes/v0.18.2.html</sparkle:releaseNotesLink>
       <enclosure
-        url="https://github.com/jasoncavinder/Helm/releases/download/v0.18.1/Helm-v0.18.1-macos-universal.dmg"
-        sparkle:version="18001900"
-        sparkle:shortVersionString="0.18.1"
-        sparkle:edSignature="4Pz4bdWhZd3EFVcArO1qAwG+VZOvur/Uc9MA2WZ9MViDPYtc7puLln0CkTduOMKLlt1thHRZVLKFTr8BgUoNCQ=="
+        url="https://github.com/jasoncavinder/Helm/releases/download/v0.18.2/Helm-v0.18.2-macos-universal.dmg"
+        sparkle:version="18002900"
+        sparkle:shortVersionString="0.18.2"
+        sparkle:edSignature="PkshXlXe/7UOSpaSZXn+rs1D6tSxX88abqdoWogSZTPkN2IfhOGP9h6g/fun4jGhJg//s8YZ4gmglapUNj1GAg=="
          sparkle:minimumSystemVersion="11.0"
-        length="31179971"
+        length="31297100"
         type="application/octet-stream"/>
     </item>
   </channel>

--- a/web/public/updates/cli/latest.json
+++ b/web/public/updates/cli/latest.json
@@ -1,19 +1,19 @@
 {
-  "version": "0.18.1",
+  "version": "0.18.2",
   "channel": "stable",
-  "published_at": "2026-08-04T16:32:33Z",
+  "published_at": "2026-08-05T05:15:18Z",
   "downloads": {
     "universal": {
-      "url": "https://github.com/jasoncavinder/Helm/releases/download/v0.18.1/helm-cli-v0.18.1-darwin-universal",
-      "sha256": "9186e61355f44fd9cc4896f551a22ebad3f7ffc3f82e212a66fc3ca7a50bdfc2"
+      "url": "https://github.com/jasoncavinder/Helm/releases/download/v0.18.2/helm-cli-v0.18.2-darwin-universal",
+      "sha256": "f49888a59922ae973c1159baeb49948f2803df747412383222f6c8d58136afff"
     },
     "arm64": {
-      "url": "https://github.com/jasoncavinder/Helm/releases/download/v0.18.1/helm-cli-v0.18.1-darwin-arm64",
-      "sha256": "fc8a04b9d28b7db143ec186dab75c6910a153bc332e71ba5c113877e16e74b22"
+      "url": "https://github.com/jasoncavinder/Helm/releases/download/v0.18.2/helm-cli-v0.18.2-darwin-arm64",
+      "sha256": "d61f6bd89635fffc995009cf83d84e62470333640dec4e1d1902ba6bf6fe30cc"
     },
     "x86_64": {
-      "url": "https://github.com/jasoncavinder/Helm/releases/download/v0.18.1/helm-cli-v0.18.1-darwin-x86_64",
-      "sha256": "7e029dc2e49c344b993616668550c20763ec7f2af2df88bfb78cd9f804039953"
+      "url": "https://github.com/jasoncavinder/Helm/releases/download/v0.18.2/helm-cli-v0.18.2-darwin-x86_64",
+      "sha256": "8409810bdf9a49cedab26c75b92350749531c09335f1f787a97184c60d255367"
     }
   }
 }

--- a/web/public/updates/release-notes/v0.18.2.html
+++ b/web/public/updates/release-notes/v0.18.2.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Helm 0.18.2 Release Notes</title>
+  <link rel="canonical" href="https://helmapp.dev/updates/release-notes/v0.18.2.html">
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, sans-serif;
+      line-height: 1.55;
+      background: #f7f8fa;
+      color: #111827;
+    }
+    main {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 24px;
+    }
+    article {
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      padding: 24px;
+    }
+    h1 {
+      margin: 0 0 4px;
+      font-size: 1.6rem;
+      line-height: 1.3;
+    }
+    h2 {
+      margin: 24px 0 8px;
+      font-size: 1.1rem;
+    }
+    p, ul {
+      margin: 8px 0;
+    }
+    ul {
+      padding-left: 20px;
+    }
+    .meta {
+      color: #4b5563;
+      font-size: 0.95rem;
+      margin: 0 0 12px;
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      background: #f3f4f6;
+      border-radius: 6px;
+      padding: 0.1rem 0.35rem;
+      font-size: 0.92em;
+    }
+    footer {
+      margin-top: 16px;
+      color: #6b7280;
+      font-size: 0.9rem;
+    }
+    @media (prefers-color-scheme: dark) {
+      body {
+        background: #0b1220;
+        color: #e5e7eb;
+      }
+      article {
+        background: #0f172a;
+        border-color: #1f2937;
+      }
+      .meta {
+        color: #9ca3af;
+      }
+      code {
+        background: #111827;
+      }
+      footer {
+        color: #9ca3af;
+      }
+      a {
+        color: #93c5fd;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <article>
+      <h1>Helm 0.18.2 Release Notes</h1>
+      <p class="meta">Release date: August 4, 2026</p>
+    <h2>Added</h2>
+    <ul>
+      <li>An append-only SQLite migration identity manifest now records each released migration&#x27;s version, name, up/down SQL, and SHA-256 definition checksum.</li>
+      <li>Migration <code>20</code> persists and backfills migration-definition checksums, while verified private pre-migration backups provide bounded recovery points before future schema changes.</li>
+      <li>Project WOW first-run contracts and the Native Mac Experience audit, approved information architecture, prototypes, state matrix, quality budgets, research protocol, and incremental migration map now form the closed v0.18 design baseline for v0.19 implementation.</li>
+    </ul>
+    <h2>Changed</h2>
+    <ul>
+      <li>SQLite initialization now validates ledger continuity and immutable migration identity before applying new work, separates default debug databases from release data, and surfaces initialization failures through CLI, FFI, XPC, and Service Health paths.</li>
+      <li>Release CI now exercises persisted SQLite upgrade, rollback, tampering, backup, CLI, and FFI boundaries through the shared migration-compatibility gate.</li>
+      <li>Pre-1.0 planning now targets Health, Updates, Packages, Activity, and Sources in the Control Center, with separate Settings, contextual diagnostics, command-based search, and explicit base Helm, Helm Pro, and Helm Fleet boundaries.</li>
+    </ul>
+    <h2>Security</h2>
+    <ul>
+      <li>Unknown, missing, reordered, renamed, or checksum-mismatched migration ledger entries fail closed instead of allowing an incompatible database history to continue.</li>
+    </ul>
+    <p>This release contains the completed v0.18 work before production v0.19 native-experience and first-run implementation begins. The design artifacts are planning contracts only; they do not add the planned first-run or redesigned UI behavior in v0.18.2.</p>
+    <p class="meta">Need full context? <a href="https://github.com/jasoncavinder/Helm/releases/tag/v0.18.2" rel="noopener noreferrer">View this release on GitHub</a>.</p>
+    </article>
+    <footer>Generated from <code>CHANGELOG.md</code>.</footer>
+  </main>
+</body>
+</html>

--- a/web/src/components/starlight/Banner.astro
+++ b/web/src/components/starlight/Banner.astro
@@ -1,5 +1,5 @@
 ---
-const globalBanner = `<strong>Helm v0.18.1 is live.</strong> v0.18.0 remains withdrawn; users of v0.18.0 should update to v0.18.1 before further use. Report issues on <a href="https://github.com/jasoncavinder/Helm/issues/new/choose" target="_blank" rel="noreferrer">GitHub</a>.`;
+const globalBanner = `<strong>Helm v0.18.2 is live.</strong> This final v0.18 containment release precedes v0.19 native-experience and first-run implementation. v0.18.0 remains withdrawn; users of v0.18.0 should update to v0.18.2. Report issues on <a href="https://github.com/jasoncavinder/Helm/issues/new/choose" target="_blank" rel="noreferrer">GitHub</a>.`;
 const pageBanner = Astro.locals.starlightRoute.entry.data.banner?.content;
 const banners = [globalBanner, pageBanner].filter(Boolean);
 ---

--- a/web/src/content/docs/changelog.md
+++ b/web/src/content/docs/changelog.md
@@ -11,6 +11,25 @@ For the full changelog, see [CHANGELOG.md on GitHub](https://github.com/jasoncav
 
 ---
 
+## 0.18.2 — 2026-08-04
+
+Patch `0.18.2` is the final v0.18 containment release before production v0.19 native-experience and first-run implementation.
+
+### Added
+- An append-only SQLite migration identity manifest records released migration versions, names, up/down SQL, and SHA-256 definition checksums.
+- Migration `20` persists and backfills migration-definition checksums, with verified private pre-migration backups providing bounded recovery points.
+- Project WOW first-run contracts and the Native Mac Experience audit, information architecture, prototypes, state matrix, quality budgets, research protocol, and migration map form the closed v0.18 design baseline.
+
+### Changed
+- SQLite initialization validates ledger continuity and immutable migration identity, separates default debug databases from release data, and propagates failures through CLI, FFI, XPC, and Service Health paths.
+- Release CI exercises persisted SQLite upgrade, rollback, tampering, backup, CLI, and FFI boundaries through the shared migration-compatibility gate.
+- Pre-1.0 planning targets Health, Updates, Packages, Activity, and Sources, with separate Settings, contextual diagnostics, command-based search, and explicit Helm, Helm Pro, and Helm Fleet boundaries.
+
+### Security
+- Unknown, missing, reordered, renamed, or checksum-mismatched migration ledger entries fail closed.
+
+The design artifacts are planning contracts only; this release does not add the planned first-run or redesigned UI behavior.
+
 ## 0.18.1 — 2026-08-04
 
 Patch `0.18.1` is the corrective stable successor to withdrawn `v0.18.0`.

--- a/web/src/content/docs/overview.md
+++ b/web/src/content/docs/overview.md
@@ -45,7 +45,7 @@ Key features:
 - **Localization** — `en`, `es`, `de`, `fr`, `pt-BR`, `ja`, and `hu` with locale override in Settings
 - **Upgrade transparency** — dedicated upgrade preview surface with scoped execution and failure-attribution visibility
 
-> **Current release:** `v0.18.1` remains the latest stable release while `v0.18.2` completes release validation. `v0.18.0` remains withdrawn because of its critical SQLite migration defect; users of `v0.18.0` should update to `v0.18.1` or later before further use. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current release:** `v0.18.2` is the latest stable release and the final v0.18 containment release. `v0.18.0` remains withdrawn because of its critical SQLite migration defect; users of `v0.18.0` should update to `v0.18.2` before further use. Please report issues at [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## How it works
 

--- a/web/src/content/docs/roadmap.md
+++ b/web/src/content/docs/roadmap.md
@@ -32,15 +32,15 @@ Helm follows feature-driven milestones. Dates are intentionally omitted — mile
 | 0.15.x | Advanced Upgrade Transparency — richer execution-plan visibility, failure isolation, and operator controls (`v0.15.0` released) |
 | 0.16.x | Self-Update & Installer Hardening — Sparkle integration for direct Developer ID channel, signed verification (`v0.16.x` stable, latest patch `v0.16.2`) |
 | 0.17.x | Diagnostics & Logging + Release Hardening — task log viewer, structured diagnostics export, manager-detection diagnostics, onboarding/detection hardening, manager-selection controls, and stable release follow-up fixes (`v0.17.0` stable, latest patch `v0.17.12`) |
-| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge, migration-safety hardening, internal advisory cache foundation, and pre-1.0 experience-definition contracts (`v0.18.2` release validation; `v0.18.0` withdrawn) |
+| 0.18.x | Doctor & Repair + Local Security Groundwork — SQLite-backed repair knowledge, migration-safety hardening, internal advisory cache foundation, and pre-1.0 experience-definition contracts (`v0.18.2` final containment release; `v0.18.0` withdrawn) |
 
-> **Current Track:** `v0.18.1` is stable on `main`; `v0.18.2` is in release validation as the final v0.18 containment release, `v0.18.0` remains withdrawn, and native-experience/first-run implementation begins in `v0.19.x`. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
+> **Current Track:** `v0.18.2` is stable on `main` as the final v0.18 containment release, `v0.18.0` remains withdrawn, and native-experience/first-run implementation is next in `v0.19.x`. Submit feedback via [GitHub Issues](https://github.com/jasoncavinder/Helm/issues/new/choose).
 
 ## Planned
 
 | Version | Milestone |
 |---|---|
-| 0.19.x | Stability & Pre-1.0 Hardening — stress tests, crash recovery, memory audit |
+| 0.19.x | Native Experience Foundation & First-Run Value — native app shell, commands, Settings/window behavior, Environment Brief, and stability baselines |
 | 1.0.0 | Stable Control Plane Release — production-safe execution, full feature set |
 
 ## Post-1.0


### PR DESCRIPTION
## Summary

- synchronize the fully published v0.18.2 release and metadata from `main` back to `dev`
- carry the completed release checklist, stable-version contract, and v0.19 active-track documentation into the development branch

## Verification

- v0.18.2 aggregate release verifier passed on `main`
- public appcast and CLI metadata both report 0.18.2
- post-closeout `main` Rust and Xcode CI passed
- source commits were already reviewed through the v0.18.2 release, metadata, and closeout PRs
