### PR TITLE
fix(release): target repository in variant precheck

### DIFF
--- a/.github/workflows/release-all-variants.yml
+++ b/.github/workflows/release-all-variants.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Verify release is already published
         run: |
           set -euo pipefail
-          if ! IS_DRAFT="$(gh release view "$TAG_NAME" --json isDraft --jq '.isDraft')"; then
+          if ! IS_DRAFT="$(gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --json isDraft --jq '.isDraft')"; then
             echo "::error::Release $TAG_NAME does not exist. Publish and verify the direct release before running this auxiliary workflow."
             exit 1
           fi

--- a/scripts/release/tests/release_workflow_contract.sh
+++ b/scripts/release/tests/release_workflow_contract.sh
@@ -38,7 +38,7 @@ reject_pattern() {
 }
 
 expect_pattern 'verify-published-release:' "$ALL_VARIANTS_WORKFLOW" "all-variants workflow must verify an existing release"
-expect_pattern 'gh release view "\$TAG_NAME" --json isDraft' "$ALL_VARIANTS_WORKFLOW" "all-variants workflow must inspect existing release state"
+expect_pattern 'gh release view "\$TAG_NAME" --repo "\$GITHUB_REPOSITORY" --json isDraft' "$ALL_VARIANTS_WORKFLOW" "all-variants workflow must inspect existing release state with explicit repository context"
 expect_pattern 'default: false' "$ALL_VARIANTS_WORKFLOW" "unsigned auxiliary release uploads must default off"
 reject_pattern 'gh release create' "$ALL_VARIANTS_WORKFLOW" "all-variants workflow must not create releases"
 reject_pattern 'release-macos-dmg\.yml' "$ALL_VARIANTS_WORKFLOW" "all-variants workflow must not invoke the DMG builder"


### PR DESCRIPTION
## Summary

- give the checkout-free auxiliary release precheck explicit repository context
- strengthen the release workflow contract to require that context

## Release impact

The `v0.19.0-rc.1` direct DMG/CLI release and metadata are already published and verified. This fixes the precheck that blocked the optional MAS, Setapp, and Business artifact matrix before any builds began.

## Verification

- `actionlint`
- `scripts/release/tests/release_workflow_contract.sh`
- `scripts/release/tests/ci_toolchain_contract.sh`
- `.opencode/skills/run-quality-gate/scripts/run-quality-gate.sh release-contracts`
