### PR TITLE
fix(release): bootstrap tagged variant output

### DIFF
--- a/.github/workflows/release-all-variants.yml
+++ b/.github/workflows/release-all-variants.yml
@@ -78,6 +78,7 @@ jobs:
         id: build_variant
         run: |
           set -euo pipefail
+          mkdir -p "$PWD/apps/macos-ui/Generated"
           OUTPUT_ROOT="$PWD/build/all-variants" \
           VARIANT="${{ matrix.variant }}" \
           TAG_NAME="$TAG_NAME" \

--- a/scripts/release/tests/release_workflow_contract.sh
+++ b/scripts/release/tests/release_workflow_contract.sh
@@ -40,6 +40,7 @@ reject_pattern() {
 expect_pattern 'verify-published-release:' "$ALL_VARIANTS_WORKFLOW" "all-variants workflow must verify an existing release"
 expect_pattern 'gh release view "\$TAG_NAME" --repo "\$GITHUB_REPOSITORY" --json isDraft' "$ALL_VARIANTS_WORKFLOW" "all-variants workflow must inspect existing release state with explicit repository context"
 expect_pattern 'default: false' "$ALL_VARIANTS_WORKFLOW" "unsigned auxiliary release uploads must default off"
+expect_pattern 'mkdir -p "\$PWD/apps/macos-ui/Generated"' "$ALL_VARIANTS_WORKFLOW" "all-variants workflow must bootstrap generated output for existing tags"
 reject_pattern 'gh release create' "$ALL_VARIANTS_WORKFLOW" "all-variants workflow must not create releases"
 reject_pattern 'release-macos-dmg\.yml' "$ALL_VARIANTS_WORKFLOW" "all-variants workflow must not invoke the DMG builder"
 reject_pattern 'release-cli-direct\.yml' "$ALL_VARIANTS_WORKFLOW" "all-variants workflow must not invoke the CLI builder"


### PR DESCRIPTION
## Summary

- create the generated channel-config directory in the auxiliary workflow before invoking tagged build scripts
- enforce the compatibility bootstrap in the release workflow contract

## Root cause

The auxiliary workflow definition is dispatched from `main`, but it intentionally checks out the release tag before building. The renderer fix from PR #368 therefore protects future tags but cannot change the already-pushed `v0.19.0-rc.1` source. The workflow must create the ignored generated directory before invoking that tag's build script.

## Impact

Existing immutable tags can build auxiliary variants without rewriting tagged source. The workflow continues to build product code from the tag, and unsigned artifacts remain workflow-only unless the separate upload input is explicitly enabled.

## Validation

- `actionlint .github/workflows/release-all-variants.yml`
- `scripts/release/tests/release_workflow_contract.sh`
- `scripts/release/tests/ci_toolchain_contract.sh`
- `.opencode/skills/run-quality-gate/scripts/run-quality-gate.sh release-contracts`
