### PR TITLE
fix(web): update nanoid security patch

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5379,9 +5379,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- update the transitive `nanoid` lockfile entry from `3.3.16` to `3.3.18`
- resolve high-severity Dependabot alert [#59](https://github.com/jasoncavinder/Helm/security/dependabot/59)
- leave direct dependencies and application code unchanged

## Root cause

`nanoid` is introduced through `postcss`, whose `^3.3.16` constraint accepts the patched release. GitHub's generated security-update job allowed only direct dependency updates and disabled subdependency updates, so Dependabot reported `fix_unavailable` even though npm can safely update the lockfile entry.

## Validation

- `npm ci --ignore-scripts --no-audit`
- `npm run build`
- `npm run check:content-ids`
- `npm audit --omit=dev --audit-level=high` (`0 vulnerabilities`)
