### PR TITLE
docs(release): close out v0.19.0-rc.1

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,18 +8,19 @@ It reflects reality, not intention.
 
 ## Version
 
-Current documentation baseline: **0.18.2 is the latest public stable release on `main`**; `v0.18.0` remains withdrawn because of a critical SQLite migration defect. `v0.18.2` is the final v0.18 containment release and includes migration-safety hardening plus the closed Project WOW and Native Mac Experience design-definition artifacts before v0.19 implementation begins.
+Current documentation baseline: **0.18.2 remains the latest public stable release on `main`**, and **0.19.0-rc.1 is the published opt-in prerelease**; `v0.18.0` remains withdrawn because of a critical SQLite migration defect. `v0.18.2` is the final v0.18 containment release and includes migration-safety hardening plus the closed Project WOW and Native Mac Experience design-definition artifacts before v0.19 implementation begins.
 
-Implementation baseline: **`0.19.0-rc.1` source preparation on the v0.18.2 lineage**, combining manager/updater reliability, dependency modernization, and the macOS 13 baseline while preserving released migration safety. The broader native-experience and Project WOW implementation remains staged work rather than part of this candidate.
+Implementation baseline: **published `0.19.0-rc.1` validation on the v0.18.2 lineage**, combining manager/updater reliability, dependency modernization, and the macOS 13 baseline while preserving released migration safety. The broader native-experience and Project WOW implementation remains staged work rather than part of this candidate.
 
 See:
 - CHANGELOG.md
 
 Active milestone:
 - latest stable release currently published on `main`: **0.18.2**
-- prepared source candidate: **0.19.0-rc.1** (not tagged or published; public update metadata remains on `v0.18.2`)
+- published opt-in prerelease: **0.19.0-rc.1**, represented by a published GitHub prerelease with signed/notarized GUI artifacts and direct CLI artifacts; GitHub `releases/latest` remains stable-only on `v0.18.2`
 - `v0.18.0` was published on 2026-08-03 and then withdrawn after discovery of a critical SQLite migration defect; its immutable tag is retained for auditability while its release is not publicly distributed.
-- public GUI and CLI update metadata points to the signed `v0.18.2` artifacts.
+- public default-channel GUI appcast and stable CLI metadata remain on signed `v0.18.2` artifacts, while the `beta` appcast item and `latest-rc.json` point to `v0.19.0-rc.1`.
+- owner installation validation confirms `/Applications/Helm.app` is the signed Developer ID build for `0.19.0-rc.1` (`CFBundleVersion` `19000601`); this is one successful owner installation, not broad participant validation.
 - delivered in `v0.18.1`: reconciliation of the known development migration `17` collision before released doctor/repair migrations run, plus prevention of historical DDL replay for already-current databases, preserving package identifiers and user data.
 - delivered in `v0.18.2`: immutable migration identities and definition checksums, fail-closed ledger validation, verified bounded pre-migration backups, debug/release database separation, initialization-error propagation, and migration-compatibility CI/release gates.
 - approved internal product-design planning track: **Project WOW** defines the base Helm first-run value loop and product allocation at `docs/app-design/PROJECT_WOW.md`; its v0.18 machine contracts, bootstrap audit, CLI/TUI contract, native prototype, state matrix, and research protocol are complete planning artifacts, staged implementation/validation follows in `0.19.x`-`0.22.x`, and no related runtime behavior is implemented by this documentation checkpoint

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -11,16 +11,16 @@ It is intentionally tactical.
 Helm is in:
 
 ```
-v0.19.0-rc.1 manager/updater integration and release-candidate validation
+v0.19.0-rc.1 published-candidate validation and v0.19.x implementation
 ```
 
 Focus:
-- validate the prepared `v0.19.0-rc.1` source without tagging or publishing until the protected integration path and explicit release authorization are complete
+- validate the published opt-in `v0.19.0-rc.1` candidate, triaging release blockers and security fixes separately from planned v0.19.x product work
 - begin production `v0.19.x` work from the closed Native Mac Experience and Project WOW contracts
-- maintain release-process hardening guardrails now that `v0.18.2` publication is complete
+- maintain release-process hardening guardrails now that `v0.19.0-rc.1` publication and closeout verification are complete
 - preserve the released `v0.18.2` migration-safety baseline and `v0.18.1` affected-database recovery coverage
 - preserve manager-specific expected nonzero update-check outcomes as completed refreshes with actionable outdated state, starting with rustup's exit code `100`
-- complete the `0.19.x` manager/updater integration: preserve the v0.18 migration-safety baseline while landing npm/MAS reliability fixes, full standard-root Sparkle inventory and static-appcast visibility, external-bundle GUI update actions, scheduled direct-channel Helm checks, explicit beta/RC opt-in with stable-channel isolation, dependency modernization, and the macOS 13 Ventura baseline
+- preserve the published `0.19.0-rc.1` manager/updater baseline: v0.18 migration safety, npm/MAS reliability fixes, full standard-root Sparkle inventory and static-appcast visibility, external-bundle GUI update actions, scheduled direct-channel Helm checks, explicit beta/RC opt-in with stable-channel isolation, dependency modernization, and the macOS 13 Ventura baseline
 - preserve the released SQLite doctor/repair lifecycle, bundled knowledge bootstrap, import/export hardening, and repair verification path without widening into online knowledge lookup
 - preserve the compiled typed-action registry as the immutable execution boundary; knowledge remains declarative and cannot carry commands, arguments, scripts, plugins, or arbitrary executable content
 - retain deterministic `v2` finding identity while keeping sensitive local evidence outside shared fingerprint inputs
@@ -398,6 +398,9 @@ Current checkpoint:
     - audit-remediation follow-up delivered: distribution profile contract is now centralized in `docs/contracts/distribution-profiles.json` and consumed by shared build orchestration (`scripts/build.sh`, `scripts/release/build_unsigned_variant.sh`, matrix-based `release-all-variants.yml` auxiliary jobs); Swift update-authority mapping now has one source (`AppUpdateConfiguration`), targeted updater policy tests pass on macOS, and GUI checksum-publication symmetry is explicitly documented as deferred while Sparkle remains canonical GUI integrity authority
     - trust-chain future work is now explicitly tracked: detached signatures + signing-key rotation for CLI update artifacts (`docs/roadmap/CLI_DISTRIBUTION_CI_MILESTONES.md`, milestone M5)
 - latest stable release on `main`: `v0.18.2`
+- latest published prerelease on `main`: `v0.19.0-rc.1`; stable GitHub/latest, appcast, and CLI pointers remain isolated from the opt-in RC channel
+- owner installation validation confirms the signed Developer ID app at `0.19.0-rc.1` build `19000601`; broader RC feedback remains pending and should not be inferred from this single installation
+- post-publication release verification is green for the GUI beta appcast, RC CLI metadata, GitHub prerelease state, and stable/RC coexistence contract
 - validation gates are green through the stable cut (`cargo test`, macOS `xcodebuild` tests, locale integrity/length audits, release workflow smoke across `v0.17.0-rc.1` through `v0.17.0-rc.5`)
 - `v0.15.0` released on `main` (tag `v0.15.0`)
 - `v0.14.0` released (merged to `main`, tagged, manager rollout + docs/version alignment complete)

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -62,7 +62,7 @@ This checklist is required before creating a release tag on `main`.
   - `CLI Update Metadata Drift Guard`
 - [x] Review `TMP_RELEASE_FRICTION`; promote recurring friction items into durable docs (`docs/DECISIONS.md`, `docs/operations/CLI_RELEASE_AND_CI.md`) and keep temporary notes uncommitted.
 
-## v0.19.0-rc.1 (Manager and Updater Modernization RC)
+## v0.19.0-rc.1 (Manager and Updater Modernization RC, Completed)
 
 ### Scope and Versioning
 
@@ -89,12 +89,20 @@ This checklist is required before creating a release tag on `main`.
 
 ### Protected Integration and Publication
 
-- [ ] Merge the candidate through the protected branch path and rerun required checks from current `main`.
-- [ ] Confirm a fresh successful `Release macOS Canary` after the final workflow/toolchain changes.
-- [ ] Dispatch and pass `Release Publish Auth Check` with `write_probe=true` under explicit maintainer authorization.
-- [ ] Obtain explicit maintainer approval before creating or pushing `v0.19.0-rc.1` or publishing artifacts.
-- [ ] Confirm the published appcast retains `v0.18.2` as the default-channel item and adds `v0.19.0-rc.1` only as the `beta` item.
-- [ ] Complete signed/notarized GUI and direct CLI prerelease publication and post-publication verification.
+- [x] Merge the candidate through the protected branch path and rerun required checks from current `main`.
+- [x] Confirm a fresh successful `Release macOS Canary` after the final workflow/toolchain changes.
+- [x] Dispatch and pass `Release Publish Auth Check` with `write_probe=true` under explicit maintainer authorization.
+- [x] Obtain explicit maintainer approval before creating or pushing `v0.19.0-rc.1` or publishing artifacts.
+- [x] Confirm the published appcast retains `v0.18.2` as the default-channel item and adds `v0.19.0-rc.1` only as the `beta` item.
+- [x] Complete signed/notarized GUI and direct CLI prerelease publication and post-publication verification.
+
+### Closeout Record
+
+- `v0.19.0-rc.1` is a published GitHub prerelease; `v0.18.2` remains the published non-prerelease returned by `releases/latest`.
+- The direct macOS DMG and CLI release workflows completed successfully, and publication PRs `#364` and `#365` merged the RC CLI metadata and beta appcast/release notes into `main`.
+- `Release Publish Verify`, the Sparkle/appcast checklist, and `scripts/release/runbook.sh verify --tag v0.19.0-rc.1` pass with no open release-publication PRs.
+- The optional all-variant workflow completed after compatibility fixes `#367`-`#369`; its unsigned auxiliary artifacts remain workflow-only by default.
+- Owner installation validation confirms the signed Developer ID app at `0.19.0-rc.1` build `19000601`; this does not claim broader participant validation.
 
 ## v0.18.2 (Final v0.18 Containment Release Gate, Completed)
 

--- a/docs/operations/CLI_RELEASE_AND_CI.md
+++ b/docs/operations/CLI_RELEASE_AND_CI.md
@@ -2,7 +2,7 @@
 
 Status: Active operational guide  
 Owner: Helm Release Engineering  
-Last Updated: 2026-02-24
+Last Updated: 2026-08-07
 
 ---
 
@@ -447,8 +447,10 @@ gh run view <run-id> --log
 Notes:
 
 - Publish and verify the direct GUI and CLI release before running this workflow. It requires an existing published GitHub release and never creates or publishes a release itself.
+- The release-state precheck runs before repository checkout, so repository-scoped `gh` commands must pass `--repo "$GITHUB_REPOSITORY"` explicitly.
 - Direct channel release workflows are not invoked by this workflow, so their release-event builders cannot be duplicated.
 - MAS/Setapp/business orchestration shares one matrix-driven build path and one helper (`scripts/release/build_unsigned_variant.sh`) keyed by `docs/contracts/distribution-profiles.json`.
+- The workflow definition comes from current `main` but product source comes from the immutable tag. Workflow-level compatibility bootstraps may create ignored generated-output directories before tagged scripts run; they must not rewrite tagged source.
 - MAS/Setapp/business outputs are intentionally unsigned in the baseline orchestration workflow.
 - Unsigned auxiliary artifacts upload only to the workflow run by default. Pass `-f upload_auxiliary_assets=true` only after explicit review to attach them to the existing GitHub release.
 - signed store/vendor pipelines remain a separate follow-up.
@@ -472,6 +474,11 @@ Promotion path after each release:
 - The direct CLI and DMG workflows now classify complete publish-PR JSON snapshots, preserving an open PR with nullable `mergedAt` as a non-red follow-up-required outcome. Hard failures remain unchanged for build, signing, notarization, verification, upload, credential, or PR-creation faults ([#332](https://github.com/jasoncavinder/Helm/issues/332)).
 
 `v0.18.2` reproduced the historical [#332](https://github.com/jasoncavinder/Helm/issues/332) failure before this fix: both artifact workflows opened auto-merge publication PRs and uploaded valid assets, but nullable TSV field collapse made the open PR appear merged before the still-old `main` metadata check. The v0.19 contracts now preserve the documented merge-and-`verify_only=true` handoff state while keeping all earlier build, signing, notarization, upload, credential, or PR-creation failures blocking.
+
+`v0.19.0-rc.1` closeout promoted two auxiliary-release lessons into the permanent workflow contract:
+
+- The checkout-free published-release precheck must provide explicit repository context. PR [#367](https://github.com/jasoncavinder/Helm/pull/367) added `--repo "$GITHUB_REPOSITORY"` and contract coverage after the optional variant matrix failed before checkout.
+- Clean tag checkouts do not contain ignored `apps/macos-ui/Generated/` output. PR [#368](https://github.com/jasoncavinder/Helm/pull/368) made the renderer create parent directories for future tags, while PR [#369](https://github.com/jasoncavinder/Helm/pull/369) added a workflow-level bootstrap so the already-immutable `v0.19.0-rc.1` tag could build without retagging or source mutation.
 
 ---
 


### PR DESCRIPTION
## Summary

- close the `v0.19.0-rc.1` protected integration and publication checklist
- update current-state and next-step docs from prepared-candidate language to published opt-in RC validation
- record stable/RC feed coexistence and the successful owner installation of the notarized Developer ID app
- promote the auxiliary-release lessons from #367-#369 into the permanent operations guide

## Release state

- [`v0.19.0-rc.1`](https://github.com/jasoncavinder/Helm/releases/tag/v0.19.0-rc.1) is a published GitHub prerelease with GUI and CLI artifacts
- `v0.18.2` remains the stable `releases/latest` release and default update line
- the beta appcast and `latest-rc.json` point to `v0.19.0-rc.1`
- `/Applications/Helm.app` reports `0.19.0-rc.1` build `19000601` and is accepted by Gatekeeper as Notarized Developer ID

## Scope

Documentation only. This PR does not change product code, release assets, appcasts, CLI metadata, tags, or updater behavior.

## Validation

- `.opencode/skills/docs-sync/scripts/docs-sync-check.sh`
- `.opencode/skills/sparkle-appcast-checklist/scripts/run-checklist.sh v0.19.0-rc.1`
- `.opencode/skills/run-quality-gate/scripts/run-quality-gate.sh release-contracts`
- `scripts/release/runbook.sh verify --tag v0.19.0-rc.1`
- repository Docs Checks equivalent
- `spctl -a -vv -t exec /Applications/Helm.app`
