### PR TITLE
fix(macos): stabilize Dashboard native controls

### DIFF
--- a/apps/macos-ui/Helm.xcodeproj/project.pbxproj
+++ b/apps/macos-ui/Helm.xcodeproj/project.pbxproj
@@ -79,6 +79,9 @@
 		Q200000000000000000000002 /* WayfinderPresentationProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = Q100000000000000000000001 /* WayfinderPresentationProjection.swift */; };
 		Q200000000000000000000003 /* WayfinderPresentationProjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = Q100000000000000000000002 /* WayfinderPresentationProjectionTests.swift */; };
 		R200000000000000000000001 /* WayfinderCourseIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = R100000000000000000000001 /* WayfinderCourseIndicatorView.swift */; };
+		S200000000000000000000001 /* ControlCenterSearchBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = S100000000000000000000001 /* ControlCenterSearchBridge.swift */; };
+		S200000000000000000000002 /* ControlCenterSearchBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = S100000000000000000000001 /* ControlCenterSearchBridge.swift */; };
+		S200000000000000000000003 /* ControlCenterSearchBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = S100000000000000000000002 /* ControlCenterSearchBridgeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -179,6 +182,8 @@
 		Q100000000000000000000001 /* WayfinderPresentationProjection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WayfinderPresentationProjection.swift; sourceTree = "<group>"; };
 		Q100000000000000000000002 /* WayfinderPresentationProjectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WayfinderPresentationProjectionTests.swift; sourceTree = "<group>"; };
 		R100000000000000000000001 /* WayfinderCourseIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WayfinderCourseIndicatorView.swift; sourceTree = "<group>"; };
+		S100000000000000000000001 /* ControlCenterSearchBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlCenterSearchBridge.swift; sourceTree = "<group>"; };
+		S100000000000000000000002 /* ControlCenterSearchBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlCenterSearchBridgeTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -276,6 +281,7 @@
 				B30000000000000000000002 /* Onboarding */,
 				B30000000000000000000003 /* Walkthrough */,
 				D10000000000000000000001 /* ControlCenterModels.swift */,
+				S100000000000000000000001 /* ControlCenterSearchBridge.swift */,
 				D10000000000000000000003 /* ControlCenterViews.swift */,
 				F10000000000000000000003 /* ControlCenterSectionViews.swift */,
 				R100000000000000000000001 /* WayfinderCourseIndicatorView.swift */,
@@ -418,6 +424,7 @@
 			isa = PBXGroup;
 			children = (
 				H100000000000000000000001 /* AppUpdateConfigurationTests.swift */,
+				S100000000000000000000002 /* ControlCenterSearchBridgeTests.swift */,
 				N100000000000000000000005 /* HelmCliShimCommandRunnerTests.swift */,
 				C1000000000000000000001A /* LocalizationOverflowValidationTests.swift */,
 				K100000000000000000000002 /* SupportRedactorTests.swift */,
@@ -615,6 +622,7 @@
 				B20000000000000000000014 /* OnboardingConfigureView.swift in Sources */,
 				D20000000000000000000010 /* OnboardingSettingsView.swift in Sources */,
 				D20000000000000000000001 /* ControlCenterModels.swift in Sources */,
+				S200000000000000000000001 /* ControlCenterSearchBridge.swift in Sources */,
 				D20000000000000000000002 /* HelmButtonStyles.swift in Sources */,
 				D20000000000000000000003 /* ControlCenterViews.swift in Sources */,
 				D20000000000000000000004 /* HelmCore+Dashboard.swift in Sources */,
@@ -639,6 +647,8 @@
 			isa = PBXSourcesBuildPhase;
 			files = (
 				J200000000000000000000002 /* AppUpdateConfiguration.swift in Sources */,
+				S200000000000000000000002 /* ControlCenterSearchBridge.swift in Sources */,
+				S200000000000000000000003 /* ControlCenterSearchBridgeTests.swift in Sources */,
 				N100000000000000000000003 /* HelmCliShimCommandRunner.swift in Sources */,
 				N100000000000000000000004 /* HelmCliShimCommandRunnerTests.swift in Sources */,
 				H200000000000000000000001 /* AppUpdateConfigurationTests.swift in Sources */,

--- a/apps/macos-ui/Helm.xcodeproj/project.pbxproj
+++ b/apps/macos-ui/Helm.xcodeproj/project.pbxproj
@@ -82,6 +82,9 @@
 		S200000000000000000000001 /* ControlCenterSearchBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = S100000000000000000000001 /* ControlCenterSearchBridge.swift */; };
 		S200000000000000000000002 /* ControlCenterSearchBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = S100000000000000000000001 /* ControlCenterSearchBridge.swift */; };
 		S200000000000000000000003 /* ControlCenterSearchBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = S100000000000000000000002 /* ControlCenterSearchBridgeTests.swift */; };
+		T200000000000000000000001 /* SettingsOpeningBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = T100000000000000000000001 /* SettingsOpeningBridge.swift */; };
+		T200000000000000000000002 /* SettingsOpeningBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = T100000000000000000000001 /* SettingsOpeningBridge.swift */; };
+		T200000000000000000000003 /* SettingsOpeningBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T100000000000000000000002 /* SettingsOpeningBridgeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -184,6 +187,8 @@
 		R100000000000000000000001 /* WayfinderCourseIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WayfinderCourseIndicatorView.swift; sourceTree = "<group>"; };
 		S100000000000000000000001 /* ControlCenterSearchBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlCenterSearchBridge.swift; sourceTree = "<group>"; };
 		S100000000000000000000002 /* ControlCenterSearchBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlCenterSearchBridgeTests.swift; sourceTree = "<group>"; };
+		T100000000000000000000001 /* SettingsOpeningBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsOpeningBridge.swift; sourceTree = "<group>"; };
+		T100000000000000000000002 /* SettingsOpeningBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsOpeningBridgeTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -282,6 +287,7 @@
 				B30000000000000000000003 /* Walkthrough */,
 				D10000000000000000000001 /* ControlCenterModels.swift */,
 				S100000000000000000000001 /* ControlCenterSearchBridge.swift */,
+				T100000000000000000000001 /* SettingsOpeningBridge.swift */,
 				D10000000000000000000003 /* ControlCenterViews.swift */,
 				F10000000000000000000003 /* ControlCenterSectionViews.swift */,
 				R100000000000000000000001 /* WayfinderCourseIndicatorView.swift */,
@@ -425,6 +431,7 @@
 			children = (
 				H100000000000000000000001 /* AppUpdateConfigurationTests.swift */,
 				S100000000000000000000002 /* ControlCenterSearchBridgeTests.swift */,
+				T100000000000000000000002 /* SettingsOpeningBridgeTests.swift */,
 				N100000000000000000000005 /* HelmCliShimCommandRunnerTests.swift */,
 				C1000000000000000000001A /* LocalizationOverflowValidationTests.swift */,
 				K100000000000000000000002 /* SupportRedactorTests.swift */,
@@ -623,6 +630,7 @@
 				D20000000000000000000010 /* OnboardingSettingsView.swift in Sources */,
 				D20000000000000000000001 /* ControlCenterModels.swift in Sources */,
 				S200000000000000000000001 /* ControlCenterSearchBridge.swift in Sources */,
+				T200000000000000000000001 /* SettingsOpeningBridge.swift in Sources */,
 				D20000000000000000000002 /* HelmButtonStyles.swift in Sources */,
 				D20000000000000000000003 /* ControlCenterViews.swift in Sources */,
 				D20000000000000000000004 /* HelmCore+Dashboard.swift in Sources */,
@@ -649,6 +657,8 @@
 				J200000000000000000000002 /* AppUpdateConfiguration.swift in Sources */,
 				S200000000000000000000002 /* ControlCenterSearchBridge.swift in Sources */,
 				S200000000000000000000003 /* ControlCenterSearchBridgeTests.swift in Sources */,
+				T200000000000000000000002 /* SettingsOpeningBridge.swift in Sources */,
+				T200000000000000000000003 /* SettingsOpeningBridgeTests.swift in Sources */,
 				N100000000000000000000003 /* HelmCliShimCommandRunner.swift in Sources */,
 				N100000000000000000000004 /* HelmCliShimCommandRunnerTests.swift in Sources */,
 				H200000000000000000000001 /* AppUpdateConfigurationTests.swift in Sources */,

--- a/apps/macos-ui/Helm/AppDelegate+Windows.swift
+++ b/apps/macos-ui/Helm/AppDelegate+Windows.swift
@@ -1,16 +1,6 @@
 import Cocoa
 import SwiftUI
 
-enum HelmApplicationWindowCommands {
-    @MainActor
-    static func openSettings() {
-        NSApp.activate(ignoringOtherApps: true)
-        if !NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil) {
-            NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
-        }
-    }
-}
-
 private func handleStandardTextEditingKeyEquivalent(_ event: NSEvent, sender: AnyObject) -> Bool {
     let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
     guard flags.contains(.command),

--- a/apps/macos-ui/Helm/AppDelegate.swift
+++ b/apps/macos-ui/Helm/AppDelegate.swift
@@ -388,7 +388,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUs
 
     private func focusControlCenterSearch() {
         openControlCenter()
-        controlCenterContext.controlCenterSearchFocusToken += 1
+        controlCenterContext.controlCenterSearchFocusRouter.requestFocus()
     }
 
     private func handlePopoverEscape() {

--- a/apps/macos-ui/Helm/AppDelegate.swift
+++ b/apps/macos-ui/Helm/AppDelegate.swift
@@ -45,8 +45,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, UNUs
             self?.openControlCenter()
             self?.closePanel()
         }, onOpenSettings: { [weak self] in
-            self?.closePanel()
-            HelmApplicationWindowCommands.openSettings()
+            guard let self else { return }
+            closePanel()
+            controlCenterContext.settingsOpenRouter.requestOpen()
         })
         .environmentObject(controlCenterContext)
         .background(VisualEffect().ignoresSafeArea())
@@ -725,7 +726,7 @@ private extension AppDelegate {
 
     @MainActor @objc func openAdvancedSettingsFromMenu() {
         closePanel()
-        HelmApplicationWindowCommands.openSettings()
+        controlCenterContext.settingsOpenRouter.requestOpen()
     }
 
     @objc func openUpgradeAllFromMenu() {

--- a/apps/macos-ui/Helm/Views/ControlCenterModels.swift
+++ b/apps/macos-ui/Helm/Views/ControlCenterModels.swift
@@ -173,6 +173,7 @@ final class ControlCenterContext: ObservableObject {
     @Published var popoverOverlayDismissToken: Int = 0
     @Published var popoverSearchFocusToken: Int = 0
     let controlCenterSearchFocusRouter = ControlCenterSearchFocusRouter()
+    let settingsOpenRouter = HelmSettingsOpenRouter()
     @Published var isPopoverOverlayVisible: Bool = false
     @Published var suppressWindowBackgroundDragging: Bool = false
     @Published var isSidebarVisible: Bool = true

--- a/apps/macos-ui/Helm/Views/ControlCenterModels.swift
+++ b/apps/macos-ui/Helm/Views/ControlCenterModels.swift
@@ -191,10 +191,7 @@ final class ControlCenterContext: ObservableObject {
     }
 
     func clearInspectorSelection() {
-        selectedManagerId = nil
-        selectedPackageId = nil
-        selectedTaskId = nil
-        selectedUpgradePlanStepId = nil
+        clearInspectorSelection(except: nil)
     }
 
     func select(_ section: ControlCenterSection) {
@@ -237,36 +234,27 @@ final class ControlCenterContext: ObservableObject {
     }
 
     func alignInspectorSelection(for section: ControlCenterSection?) {
-        guard let section else {
-            clearInspectorSelection()
-            return
-        }
-
-        switch section {
-        case .overview, .settings:
-            clearInspectorSelection()
-        case .updates:
-            let retainedStepId = selectedUpgradePlanStepId
-            clearInspectorSelection()
-            selectedUpgradePlanStepId = retainedStepId
-        case .packages:
-            let retainedPackageId = selectedPackageId
-            clearInspectorSelection()
-            selectedPackageId = retainedPackageId
-        case .tasks:
-            let retainedTaskId = selectedTaskId
-            clearInspectorSelection()
-            selectedTaskId = retainedTaskId
-        case .managers:
-            let retainedManagerId = selectedManagerId
-            clearInspectorSelection()
-            selectedManagerId = retainedManagerId
-        }
+        clearInspectorSelection(except: section)
     }
 
     func requestManagerInstallSheet(for managerId: String) {
         managerInstallSheetRequestManagerId = managerId
         managerInstallSheetRequestToken += 1
+    }
+
+    private func clearInspectorSelection(except section: ControlCenterSection?) {
+        if section != .managers, selectedManagerId != nil {
+            selectedManagerId = nil
+        }
+        if section != .packages, selectedPackageId != nil {
+            selectedPackageId = nil
+        }
+        if section != .tasks, selectedTaskId != nil {
+            selectedTaskId = nil
+        }
+        if section != .updates, selectedUpgradePlanStepId != nil {
+            selectedUpgradePlanStepId = nil
+        }
     }
 }
 

--- a/apps/macos-ui/Helm/Views/ControlCenterModels.swift
+++ b/apps/macos-ui/Helm/Views/ControlCenterModels.swift
@@ -172,7 +172,7 @@ final class ControlCenterContext: ObservableObject {
     @Published var popoverOverlayRequest: PopoverOverlayRoute?
     @Published var popoverOverlayDismissToken: Int = 0
     @Published var popoverSearchFocusToken: Int = 0
-    @Published var controlCenterSearchFocusToken: Int = 0
+    let controlCenterSearchFocusRouter = ControlCenterSearchFocusRouter()
     @Published var isPopoverOverlayVisible: Bool = false
     @Published var suppressWindowBackgroundDragging: Bool = false
     @Published var isSidebarVisible: Bool = true

--- a/apps/macos-ui/Helm/Views/ControlCenterSearchBridge.swift
+++ b/apps/macos-ui/Helm/Views/ControlCenterSearchBridge.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+protocol ControlCenterSearchFocusTarget: AnyObject {
+    func requestSearchFocus(completion: @escaping () -> Void)
+}
+
+final class ControlCenterSearchFocusRouter {
+    private weak var target: ControlCenterSearchFocusTarget?
+    private var nextRequestID = 0
+    private var pendingRequestID: Int?
+
+    func attach(_ target: ControlCenterSearchFocusTarget) {
+        self.target = target
+        deliverPendingRequest()
+    }
+
+    func detach(_ target: ControlCenterSearchFocusTarget) {
+        guard self.target === target else { return }
+        self.target = nil
+    }
+
+    func requestFocus() {
+        nextRequestID += 1
+        pendingRequestID = nextRequestID
+        deliverPendingRequest()
+    }
+
+    private func deliverPendingRequest() {
+        guard let requestID = pendingRequestID, let target else { return }
+        target.requestSearchFocus { [weak self] in
+            guard self?.pendingRequestID == requestID else { return }
+            self?.pendingRequestID = nil
+        }
+    }
+}
+
+final class ControlCenterSearchTextUpdateGate {
+    private(set) var isApplyingModelValue = false
+
+    func applyModelValue(_ update: () -> Void) {
+        isApplyingModelValue = true
+        defer { isApplyingModelValue = false }
+        update()
+    }
+
+    func shouldPublishControlValue(_ controlValue: String, modelValue: String) -> Bool {
+        !isApplyingModelValue && controlValue != modelValue
+    }
+}

--- a/apps/macos-ui/Helm/Views/ControlCenterSearchBridge.swift
+++ b/apps/macos-ui/Helm/Views/ControlCenterSearchBridge.swift
@@ -36,6 +36,8 @@ final class ControlCenterSearchFocusRouter {
 
 final class ControlCenterSearchTextUpdateGate {
     private(set) var isApplyingModelValue = false
+    private(set) var hasScheduledControlPublish = false
+    private var pendingControlValue: String?
 
     func applyModelValue(_ update: () -> Void) {
         isApplyingModelValue = true
@@ -45,5 +47,23 @@ final class ControlCenterSearchTextUpdateGate {
 
     func shouldPublishControlValue(_ controlValue: String, modelValue: String) -> Bool {
         !isApplyingModelValue && controlValue != modelValue
+    }
+
+    func stageControlValue(_ controlValue: String, modelValue: String) -> Bool {
+        guard shouldPublishControlValue(controlValue, modelValue: modelValue) else { return false }
+        pendingControlValue = controlValue
+        guard !hasScheduledControlPublish else { return false }
+        hasScheduledControlPublish = true
+        return true
+    }
+
+    func displayedValue(modelValue: String) -> String {
+        pendingControlValue ?? modelValue
+    }
+
+    func takePendingControlValue() -> String? {
+        hasScheduledControlPublish = false
+        defer { pendingControlValue = nil }
+        return pendingControlValue
     }
 }

--- a/apps/macos-ui/Helm/Views/ControlCenterViews.swift
+++ b/apps/macos-ui/Helm/Views/ControlCenterViews.swift
@@ -102,7 +102,7 @@ struct ControlCenterWindowView: View {
                 ControlCenterToolbarSearchField(
                     text: searchQuery,
                     placeholder: L10n.App.ControlCenter.searchPlaceholder.localized,
-                    focusToken: context.controlCenterSearchFocusToken
+                    focusRouter: context.controlCenterSearchFocusRouter
                 )
                 .frame(width: 260)
             }
@@ -182,11 +182,13 @@ struct ControlCenterWindowView: View {
     }
 }
 
-private final class ControlCenterNativeSearchField: NSSearchField {
+private final class ControlCenterNativeSearchField: NSSearchField, ControlCenterSearchFocusTarget {
     private var focusRequestPending = false
+    private var focusCompletion: (() -> Void)?
 
-    func requestFocus() {
+    func requestSearchFocus(completion: @escaping () -> Void) {
         focusRequestPending = true
+        focusCompletion = completion
         fulfillFocusRequestIfPossible()
     }
 
@@ -200,6 +202,9 @@ private final class ControlCenterNativeSearchField: NSSearchField {
         DispatchQueue.main.async { [weak self] in
             guard let self, self.window?.makeFirstResponder(self) == true else { return }
             self.focusRequestPending = false
+            let completion = self.focusCompletion
+            self.focusCompletion = nil
+            completion?()
         }
     }
 }
@@ -207,10 +212,10 @@ private final class ControlCenterNativeSearchField: NSSearchField {
 private struct ControlCenterToolbarSearchField: NSViewRepresentable {
     @Binding var text: String
     let placeholder: String
-    let focusToken: Int
+    let focusRouter: ControlCenterSearchFocusRouter
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text)
+        Coordinator(text: $text, focusRouter: focusRouter)
     }
 
     func makeNSView(context: Context) -> ControlCenterNativeSearchField {
@@ -218,6 +223,7 @@ private struct ControlCenterToolbarSearchField: NSViewRepresentable {
         searchField.delegate = context.coordinator
         searchField.placeholderString = placeholder
         searchField.setAccessibilityLabel(placeholder)
+        focusRouter.attach(searchField)
         return searchField
     }
 
@@ -227,24 +233,36 @@ private struct ControlCenterToolbarSearchField: NSViewRepresentable {
         searchField.setAccessibilityLabel(placeholder)
 
         if searchField.stringValue != text {
-            searchField.stringValue = text
+            context.coordinator.updateGate.applyModelValue {
+                searchField.stringValue = text
+            }
         }
+    }
 
-        guard context.coordinator.handledFocusToken != focusToken else { return }
-        context.coordinator.handledFocusToken = focusToken
-        searchField.requestFocus()
+    static func dismantleNSView(
+        _ searchField: ControlCenterNativeSearchField,
+        coordinator: Coordinator
+    ) {
+        searchField.delegate = nil
+        coordinator.focusRouter?.detach(searchField)
     }
 
     final class Coordinator: NSObject, NSSearchFieldDelegate {
         var text: Binding<String>
-        var handledFocusToken = 0
+        let updateGate = ControlCenterSearchTextUpdateGate()
+        weak var focusRouter: ControlCenterSearchFocusRouter?
 
-        init(text: Binding<String>) {
+        init(text: Binding<String>, focusRouter: ControlCenterSearchFocusRouter) {
             self.text = text
+            self.focusRouter = focusRouter
         }
 
         func controlTextDidChange(_ notification: Notification) {
             guard let searchField = notification.object as? NSSearchField else { return }
+            guard updateGate.shouldPublishControlValue(
+                searchField.stringValue,
+                modelValue: text.wrappedValue
+            ) else { return }
             text.wrappedValue = searchField.stringValue
         }
     }

--- a/apps/macos-ui/Helm/Views/ControlCenterViews.swift
+++ b/apps/macos-ui/Helm/Views/ControlCenterViews.swift
@@ -37,6 +37,13 @@ struct ControlCenterWindowView: View {
         }
     }
 
+    private func deferInspectorAlignment(for section: ControlCenterSection?) {
+        DispatchQueue.main.async {
+            guard context.selectedSection == section else { return }
+            context.alignInspectorSelection(for: section)
+        }
+    }
+
     var body: some View {
         HStack(spacing: 0) {
             if context.isSidebarVisible {
@@ -96,7 +103,7 @@ struct ControlCenterWindowView: View {
                 )
             }
 
-            ToolbarItem(placement: .automatic) {
+            ToolbarItem(placement: .primaryAction) {
                 ControlCenterToolbarSearchField(
                     text: searchQuery,
                     placeholder: L10n.App.ControlCenter.searchPlaceholder.localized,
@@ -172,10 +179,10 @@ struct ControlCenterWindowView: View {
             navigateToSection(for: step.targetAnchor)
         }
         .onChange(of: context.selectedSection) { newSection in
-            context.alignInspectorSelection(for: newSection)
+            deferInspectorAlignment(for: newSection)
         }
         .onAppear {
-            context.alignInspectorSelection(for: context.selectedSection)
+            deferInspectorAlignment(for: context.selectedSection)
             if core.hasCompletedOnboarding {
                 core.triggerRefresh()
             }

--- a/apps/macos-ui/Helm/Views/ControlCenterViews.swift
+++ b/apps/macos-ui/Helm/Views/ControlCenterViews.swift
@@ -103,7 +103,15 @@ struct ControlCenterWindowView: View {
                 )
             }
 
-            ToolbarItem(placement: .primaryAction) {
+            // Keep a principal item in the native toolbar so AppKit reserves the
+            // center and places the search and actions against the trailing edge.
+            ToolbarItem(placement: .principal) {
+                Color.clear
+                    .frame(width: 1, height: 1)
+                    .accessibilityHidden(true)
+            }
+
+            ToolbarItem(placement: .automatic) {
                 ControlCenterToolbarSearchField(
                     text: searchQuery,
                     placeholder: L10n.App.ControlCenter.searchPlaceholder.localized,
@@ -293,6 +301,18 @@ private struct ControlCenterSidebarView: View {
     @Environment(\.colorScheme) private var colorScheme
     let sidebarWidth: CGFloat
 
+    private var workspaceSelection: Binding<ControlCenterSection?> {
+        Binding(
+            get: { context.selectedSection },
+            set: { newSelection in
+                DispatchQueue.main.async {
+                    guard context.selectedSection != newSelection else { return }
+                    context.selectedSection = newSelection
+                }
+            }
+        )
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 11) {
@@ -324,7 +344,7 @@ private struct ControlCenterSidebarView: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 16)
 
-            List(selection: $context.selectedSection) {
+            List(selection: workspaceSelection) {
                 Section {
                     ForEach(ControlCenterSection.wayfinderWorkspaces) { section in
                         HStack(spacing: 9) {

--- a/apps/macos-ui/Helm/Views/ControlCenterViews.swift
+++ b/apps/macos-ui/Helm/Views/ControlCenterViews.swift
@@ -74,6 +74,9 @@ struct ControlCenterWindowView: View {
                 endPoint: .bottom
             )
         )
+        .background(
+            HelmSettingsOpeningBridge(router: context.settingsOpenRouter)
+        )
         .toolbar {
             ToolbarItem(placement: .navigation) {
                 Button {
@@ -93,18 +96,13 @@ struct ControlCenterWindowView: View {
                 )
             }
 
-            ToolbarItem(placement: .principal) {
-                Text(selectedSection.title)
-                    .font(.headline)
-            }
-
             ToolbarItem(placement: .automatic) {
                 ControlCenterToolbarSearchField(
                     text: searchQuery,
                     placeholder: L10n.App.ControlCenter.searchPlaceholder.localized,
                     focusRouter: context.controlCenterSearchFocusRouter
                 )
-                .frame(width: 260)
+                .frame(width: 320)
             }
 
             ToolbarItemGroup(placement: .primaryAction) {
@@ -134,12 +132,20 @@ struct ControlCenterWindowView: View {
                 .help(L10n.App.Settings.Action.refreshNow.localized)
                 .disabled(core.isRefreshing)
 
-                Button(L10n.App.ControlCenter.upgradeAll.localized) {
-                    context.presentUpgradeSheet(in: .controlCenter)
-                    context.selectedSection = .updates
+                if !core.outdatedPackages.isEmpty {
+                    Button {
+                        context.presentUpgradeSheet(in: .controlCenter)
+                        context.selectedSection = .updates
+                    } label: {
+                        Label(
+                            L10n.App.ControlCenter.upgradeAll.localized,
+                            systemImage: "arrow.up.circle.fill"
+                        )
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.regular)
+                    .fixedSize()
                 }
-                .buttonStyle(.borderedProminent)
-                .disabled(core.outdatedPackages.isEmpty)
             }
         }
         .sheet(
@@ -232,9 +238,10 @@ private struct ControlCenterToolbarSearchField: NSViewRepresentable {
         searchField.placeholderString = placeholder
         searchField.setAccessibilityLabel(placeholder)
 
-        if searchField.stringValue != text {
+        let displayedText = context.coordinator.updateGate.displayedValue(modelValue: text)
+        if searchField.stringValue != displayedText {
             context.coordinator.updateGate.applyModelValue {
-                searchField.stringValue = text
+                searchField.stringValue = displayedText
             }
         }
     }
@@ -259,11 +266,15 @@ private struct ControlCenterToolbarSearchField: NSViewRepresentable {
 
         func controlTextDidChange(_ notification: Notification) {
             guard let searchField = notification.object as? NSSearchField else { return }
-            guard updateGate.shouldPublishControlValue(
+            guard updateGate.stageControlValue(
                 searchField.stringValue,
                 modelValue: text.wrappedValue
             ) else { return }
-            text.wrappedValue = searchField.stringValue
+            DispatchQueue.main.async { [weak self] in
+                guard let self, let value = updateGate.takePendingControlValue() else { return }
+                guard text.wrappedValue != value else { return }
+                text.wrappedValue = value
+            }
         }
     }
 }
@@ -333,7 +344,7 @@ private struct ControlCenterSidebarView: View {
                     isSelected: false,
                     accessibilityLabel: ControlCenterSection.settings.title,
                     action: {
-                        HelmApplicationWindowCommands.openSettings()
+                        context.settingsOpenRouter.requestOpen()
                     }
                 ) {
                     Label(ControlCenterSection.settings.title, systemImage: ControlCenterSection.settings.icon)

--- a/apps/macos-ui/Helm/Views/DashboardView.swift
+++ b/apps/macos-ui/Helm/Views/DashboardView.swift
@@ -129,6 +129,9 @@ struct RedesignPopoverView: View {
                 SpotlightOverlay(manager: walkthrough, anchors: anchors)
             }
         }
+        .background(
+            HelmSettingsOpeningBridge(router: context.settingsOpenRouter)
+        )
     }
 
     private var popoverBaseContent: some View {

--- a/apps/macos-ui/Helm/Views/SettingsOpeningBridge.swift
+++ b/apps/macos-ui/Helm/Views/SettingsOpeningBridge.swift
@@ -1,0 +1,126 @@
+import AppKit
+import SwiftUI
+
+final class HelmSettingsOpenRouter {
+    private struct Registration {
+        let id: UUID
+        let action: () -> Void
+    }
+
+    private var registrations: [Registration] = []
+    private var hasPendingRequest = false
+
+    @discardableResult
+    func register(_ action: @escaping () -> Void) -> UUID {
+        let registration = Registration(id: UUID(), action: action)
+        registrations.append(registration)
+        if hasPendingRequest {
+            hasPendingRequest = false
+            DispatchQueue.main.async(execute: action)
+        }
+        return registration.id
+    }
+
+    func unregister(_ id: UUID) {
+        registrations.removeAll { $0.id == id }
+    }
+
+    func requestOpen() {
+        NSApp.activate(ignoringOtherApps: true)
+        if #available(macOS 14.0, *) {
+            requestRegisteredOpen()
+        } else {
+            openLegacySettings()
+        }
+    }
+
+    func requestRegisteredOpen() {
+        guard let action = registrations.last?.action else {
+            hasPendingRequest = true
+            return
+        }
+        action()
+    }
+
+    private func openLegacySettings() {
+        if !NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil) {
+            NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+        }
+    }
+}
+
+struct HelmSettingsOpeningBridge: View {
+    let router: HelmSettingsOpenRouter
+
+    @ViewBuilder
+    var body: some View {
+        if #available(macOS 14.0, *) {
+            ModernSettingsOpeningBridge(router: router)
+        } else {
+            EmptyView()
+        }
+    }
+}
+
+@available(macOS 14.0, *)
+private struct ModernSettingsOpeningBridge: View {
+    @Environment(\.openSettings) private var openSettings
+    let router: HelmSettingsOpenRouter
+
+    var body: some View {
+        SettingsOpeningRegistrationView(
+            router: router,
+            openAction: { openSettings() }
+        )
+            .frame(width: 0, height: 0)
+            .accessibilityHidden(true)
+    }
+}
+
+@available(macOS 14.0, *)
+private struct SettingsOpeningRegistrationView: NSViewRepresentable {
+    let router: HelmSettingsOpenRouter
+    let openAction: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(router: router, openAction: openAction)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        context.coordinator.registerIfNeeded()
+        return NSView(frame: .zero)
+    }
+
+    func updateNSView(_ view: NSView, context: Context) {
+        context.coordinator.openAction = openAction
+        context.coordinator.registerIfNeeded()
+    }
+
+    static func dismantleNSView(_ view: NSView, coordinator: Coordinator) {
+        coordinator.unregister()
+    }
+
+    final class Coordinator {
+        private let router: HelmSettingsOpenRouter
+        private var registrationID: UUID?
+        var openAction: () -> Void
+
+        init(router: HelmSettingsOpenRouter, openAction: @escaping () -> Void) {
+            self.router = router
+            self.openAction = openAction
+        }
+
+        func registerIfNeeded() {
+            guard registrationID == nil else { return }
+            registrationID = router.register { [weak self] in
+                self?.openAction()
+            }
+        }
+
+        func unregister() {
+            guard let registrationID else { return }
+            router.unregister(registrationID)
+            self.registrationID = nil
+        }
+    }
+}

--- a/apps/macos-ui/HelmTests/ControlCenterSearchBridgeTests.swift
+++ b/apps/macos-ui/HelmTests/ControlCenterSearchBridgeTests.swift
@@ -52,6 +52,17 @@ final class ControlCenterSearchTextUpdateGateTests: XCTestCase {
             gate.shouldPublishControlValue("model value", modelValue: "model value")
         )
     }
+
+    func testControlUpdatesCoalesceWithoutBeingOverwrittenByStaleModel() {
+        let gate = ControlCenterSearchTextUpdateGate()
+
+        XCTAssertTrue(gate.stageControlValue("h", modelValue: ""))
+        XCTAssertFalse(gate.stageControlValue("he", modelValue: ""))
+        XCTAssertEqual(gate.displayedValue(modelValue: ""), "he")
+        XCTAssertEqual(gate.takePendingControlValue(), "he")
+        XCTAssertFalse(gate.hasScheduledControlPublish)
+        XCTAssertEqual(gate.displayedValue(modelValue: "he"), "he")
+    }
 }
 
 private final class SearchFocusTargetSpy: ControlCenterSearchFocusTarget {

--- a/apps/macos-ui/HelmTests/ControlCenterSearchBridgeTests.swift
+++ b/apps/macos-ui/HelmTests/ControlCenterSearchBridgeTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+
+final class ControlCenterSearchFocusRouterTests: XCTestCase {
+    func testRequestBeforeAttachmentIsDeliveredWhenTargetAttaches() {
+        let router = ControlCenterSearchFocusRouter()
+        let target = SearchFocusTargetSpy()
+
+        router.requestFocus()
+        XCTAssertEqual(target.requestCount, 0)
+
+        router.attach(target)
+        XCTAssertEqual(target.requestCount, 1)
+
+        target.completeFocusRequest()
+        router.detach(target)
+        router.attach(target)
+        XCTAssertEqual(target.requestCount, 1)
+    }
+
+    func testUnfulfilledRequestMovesToReplacementTarget() {
+        let router = ControlCenterSearchFocusRouter()
+        let firstTarget = SearchFocusTargetSpy()
+        let replacementTarget = SearchFocusTargetSpy()
+
+        router.attach(firstTarget)
+        router.requestFocus()
+        router.detach(firstTarget)
+        router.attach(replacementTarget)
+
+        XCTAssertEqual(firstTarget.requestCount, 1)
+        XCTAssertEqual(replacementTarget.requestCount, 1)
+    }
+}
+
+final class ControlCenterSearchTextUpdateGateTests: XCTestCase {
+    func testModelUpdateCannotPublishBackThroughControlDelegate() {
+        let gate = ControlCenterSearchTextUpdateGate()
+        var shouldPublishDuringUpdate = true
+
+        gate.applyModelValue {
+            shouldPublishDuringUpdate = gate.shouldPublishControlValue(
+                "model value",
+                modelValue: "old value"
+            )
+        }
+
+        XCTAssertFalse(shouldPublishDuringUpdate)
+        XCTAssertTrue(
+            gate.shouldPublishControlValue("user value", modelValue: "model value")
+        )
+        XCTAssertFalse(
+            gate.shouldPublishControlValue("model value", modelValue: "model value")
+        )
+    }
+}
+
+private final class SearchFocusTargetSpy: ControlCenterSearchFocusTarget {
+    private(set) var requestCount = 0
+    private var completion: (() -> Void)?
+
+    func requestSearchFocus(completion: @escaping () -> Void) {
+        requestCount += 1
+        self.completion = completion
+    }
+
+    func completeFocusRequest() {
+        completion?()
+        completion = nil
+    }
+}

--- a/apps/macos-ui/HelmTests/SettingsOpeningBridgeTests.swift
+++ b/apps/macos-ui/HelmTests/SettingsOpeningBridgeTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+
+final class HelmSettingsOpenRouterTests: XCTestCase {
+    func testRegisteredOpenUsesMostRecentLiveBridge() {
+        let router = HelmSettingsOpenRouter()
+        var firstOpenCount = 0
+        var secondOpenCount = 0
+        let firstID = router.register { firstOpenCount += 1 }
+        let secondID = router.register { secondOpenCount += 1 }
+
+        router.requestRegisteredOpen()
+        XCTAssertEqual(firstOpenCount, 0)
+        XCTAssertEqual(secondOpenCount, 1)
+
+        router.unregister(secondID)
+        router.requestRegisteredOpen()
+        XCTAssertEqual(firstOpenCount, 1)
+        XCTAssertEqual(secondOpenCount, 1)
+        router.unregister(firstID)
+    }
+
+    func testRequestBeforeBridgeAttachmentIsDeliveredOnce() {
+        let router = HelmSettingsOpenRouter()
+        var openCount = 0
+        let openExpectation = expectation(description: "Deferred Settings request opens")
+
+        router.requestRegisteredOpen()
+        let registrationID = router.register {
+            openCount += 1
+            openExpectation.fulfill()
+        }
+        wait(for: [openExpectation], timeout: 1)
+
+        XCTAssertEqual(openCount, 1)
+        router.unregister(registrationID)
+    }
+}


### PR DESCRIPTION
## Summary

- route Dashboard search-focus requests directly to the native toolbar field and retain pending requests until the field is available
- defer and coalesce AppKit-originated search text changes so SwiftUI state is not published during `NSViewRepresentable` updates
- route Settings actions through SwiftUI's native `openSettings` environment action on macOS 14+, while retaining a Ventura-only selector fallback
- simplify the Dashboard toolbar by removing the redundant centered title, widening and trailing-aligning search, and showing a properly sized Upgrade All action only when updates exist
- defer workspace inspector reconciliation until after SwiftUI finishes applying sidebar selection, while avoiding redundant published changes
- add deterministic regression coverage for focus routing, search synchronization, and deferred Settings requests

## Root causes

`Command-F` previously incremented an observable token and depended on a subsequent toolbar view update to deliver focus. That update was not guaranteed at the right point in the native toolbar lifecycle.

The search delegate previously wrote through its SwiftUI binding synchronously during AppKit text-change callbacks. Workspace changes also synchronously cleared multiple published inspector selections from a SwiftUI `onChange` callback. Both paths could publish during an active view update; they now defer their state reconciliation to the next main-loop turn.

Settings buttons used legacy AppKit selectors even when the app's SwiftUI `Settings` scene required the native SwiftUI opening action, producing `Please use SettingsLink for opening the Settings scene.`

## Verification

- `HELM_XCODE_ARCH=arm64 .opencode/skills/run-quality-gate/scripts/run-quality-gate.sh ui` (67 tests, 0 failures)
- full strict SwiftLint (63 files, 0 violations)
- `apps/macos-ui/scripts/check_hardcoded_ui_strings.sh`
- `git diff --check`

## Manual acceptance

- press `Command-F` from the Dashboard and confirm the toolbar search field receives focus and accepts rapid typing
- open Settings using `Command-,`, the Dashboard sidebar, the popover, and the status menu
- switch repeatedly among Dashboard, Plan, Library, Activity, and Environment; confirm the publishing-during-view-update warning does not recur
- confirm Settings and search activity also remain free of the reported Xcode console warnings
- inspect the Dashboard toolbar with no updates and with available updates; confirm search remains aligned right and Upgrade All is absent or cleanly sized as appropriate
