### PR TITLE
Fix Dashboard inspector geometry notices

### DIFF
--- a/apps/macos-ui/Helm.xcodeproj/project.pbxproj
+++ b/apps/macos-ui/Helm.xcodeproj/project.pbxproj
@@ -85,6 +85,9 @@
 		T200000000000000000000001 /* SettingsOpeningBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = T100000000000000000000001 /* SettingsOpeningBridge.swift */; };
 		T200000000000000000000002 /* SettingsOpeningBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = T100000000000000000000001 /* SettingsOpeningBridge.swift */; };
 		T200000000000000000000003 /* SettingsOpeningBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T100000000000000000000002 /* SettingsOpeningBridgeTests.swift */; };
+		C38200000000000000000001 /* ControlCenterSplitViewBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38200000000000000000011 /* ControlCenterSplitViewBridge.swift */; };
+		C38200000000000000000002 /* ControlCenterSplitViewBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38200000000000000000011 /* ControlCenterSplitViewBridge.swift */; };
+		C38200000000000000000003 /* ControlCenterSplitViewBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38200000000000000000012 /* ControlCenterSplitViewBridgeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -189,6 +192,8 @@
 		S100000000000000000000002 /* ControlCenterSearchBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlCenterSearchBridgeTests.swift; sourceTree = "<group>"; };
 		T100000000000000000000001 /* SettingsOpeningBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsOpeningBridge.swift; sourceTree = "<group>"; };
 		T100000000000000000000002 /* SettingsOpeningBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsOpeningBridgeTests.swift; sourceTree = "<group>"; };
+		C38200000000000000000011 /* ControlCenterSplitViewBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlCenterSplitViewBridge.swift; sourceTree = "<group>"; };
+		C38200000000000000000012 /* ControlCenterSplitViewBridgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlCenterSplitViewBridgeTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -288,6 +293,7 @@
 				D10000000000000000000001 /* ControlCenterModels.swift */,
 				S100000000000000000000001 /* ControlCenterSearchBridge.swift */,
 				T100000000000000000000001 /* SettingsOpeningBridge.swift */,
+				C38200000000000000000011 /* ControlCenterSplitViewBridge.swift */,
 				D10000000000000000000003 /* ControlCenterViews.swift */,
 				F10000000000000000000003 /* ControlCenterSectionViews.swift */,
 				R100000000000000000000001 /* WayfinderCourseIndicatorView.swift */,
@@ -432,6 +438,7 @@
 				H100000000000000000000001 /* AppUpdateConfigurationTests.swift */,
 				S100000000000000000000002 /* ControlCenterSearchBridgeTests.swift */,
 				T100000000000000000000002 /* SettingsOpeningBridgeTests.swift */,
+				C38200000000000000000012 /* ControlCenterSplitViewBridgeTests.swift */,
 				N100000000000000000000005 /* HelmCliShimCommandRunnerTests.swift */,
 				C1000000000000000000001A /* LocalizationOverflowValidationTests.swift */,
 				K100000000000000000000002 /* SupportRedactorTests.swift */,
@@ -631,6 +638,7 @@
 				D20000000000000000000001 /* ControlCenterModels.swift in Sources */,
 				S200000000000000000000001 /* ControlCenterSearchBridge.swift in Sources */,
 				T200000000000000000000001 /* SettingsOpeningBridge.swift in Sources */,
+				C38200000000000000000001 /* ControlCenterSplitViewBridge.swift in Sources */,
 				D20000000000000000000002 /* HelmButtonStyles.swift in Sources */,
 				D20000000000000000000003 /* ControlCenterViews.swift in Sources */,
 				D20000000000000000000004 /* HelmCore+Dashboard.swift in Sources */,
@@ -659,6 +667,8 @@
 				S200000000000000000000003 /* ControlCenterSearchBridgeTests.swift in Sources */,
 				T200000000000000000000002 /* SettingsOpeningBridge.swift in Sources */,
 				T200000000000000000000003 /* SettingsOpeningBridgeTests.swift in Sources */,
+				C38200000000000000000002 /* ControlCenterSplitViewBridge.swift in Sources */,
+				C38200000000000000000003 /* ControlCenterSplitViewBridgeTests.swift in Sources */,
 				N100000000000000000000003 /* HelmCliShimCommandRunner.swift in Sources */,
 				N100000000000000000000004 /* HelmCliShimCommandRunnerTests.swift in Sources */,
 				H200000000000000000000001 /* AppUpdateConfigurationTests.swift in Sources */,

--- a/apps/macos-ui/Helm/Views/ControlCenterSplitViewBridge.swift
+++ b/apps/macos-ui/Helm/Views/ControlCenterSplitViewBridge.swift
@@ -1,0 +1,110 @@
+import AppKit
+import SwiftUI
+
+struct ControlCenterSplitViewBridge<Content: View, Inspector: View>: NSViewControllerRepresentable {
+    let isInspectorPresented: Bool
+    let contentMinimumThickness: CGFloat
+    private let content: Content
+    private let inspector: Inspector
+
+    init(
+        isInspectorPresented: Bool,
+        contentMinimumThickness: CGFloat = 400,
+        @ViewBuilder content: () -> Content,
+        @ViewBuilder inspector: () -> Inspector
+    ) {
+        self.isInspectorPresented = isInspectorPresented
+        self.contentMinimumThickness = contentMinimumThickness
+        self.content = content()
+        self.inspector = inspector()
+    }
+
+    func makeNSViewController(context: Context) -> ControlCenterSplitViewController {
+        ControlCenterSplitViewController(
+            content: AnyView(content),
+            contentMinimumThickness: contentMinimumThickness,
+            inspector: { AnyView(inspector) }
+        )
+    }
+
+    func updateNSViewController(
+        _ splitViewController: ControlCenterSplitViewController,
+        context: Context
+    ) {
+        splitViewController.setInspectorPresented(isInspectorPresented)
+    }
+
+    static func dismantleNSViewController(
+        _ splitViewController: ControlCenterSplitViewController,
+        coordinator: Void
+    ) {
+        splitViewController.setInspectorPresented(false)
+    }
+}
+
+final class ControlCenterSplitViewController: NSSplitViewController {
+    private let inspectorProvider: () -> AnyView
+    private let contentHostingController: NSHostingController<AnyView>
+    private let inspectorHostingController: NSHostingController<AnyView>
+    private let contentSplitViewItem: NSSplitViewItem
+    private let inspectorSplitViewItem: NSSplitViewItem
+
+    private(set) var isInspectorContentMounted = false
+
+    var isInspectorCollapsed: Bool {
+        inspectorSplitViewItem.isCollapsed
+    }
+
+    init(
+        content: AnyView,
+        contentMinimumThickness: CGFloat = 400,
+        inspector: @escaping () -> AnyView
+    ) {
+        inspectorProvider = inspector
+        contentHostingController = NSHostingController(rootView: content)
+        inspectorHostingController = NSHostingController(rootView: AnyView(EmptyView()))
+        contentSplitViewItem = NSSplitViewItem(viewController: contentHostingController)
+        inspectorSplitViewItem = NSSplitViewItem(viewController: inspectorHostingController)
+        super.init(nibName: nil, bundle: nil)
+        contentSplitViewItem.minimumThickness = contentMinimumThickness
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        splitView.isVertical = true
+        splitView.dividerStyle = .thin
+
+        inspectorSplitViewItem.minimumThickness = 220
+        inspectorSplitViewItem.maximumThickness = 320
+        inspectorSplitViewItem.preferredThicknessFraction = 0.25
+        inspectorSplitViewItem.canCollapse = true
+
+        addSplitViewItem(contentSplitViewItem)
+        addSplitViewItem(inspectorSplitViewItem)
+        inspectorSplitViewItem.isCollapsed = true
+    }
+
+    func setInspectorPresented(_ isPresented: Bool) {
+        _ = view
+
+        if isPresented {
+            if !isInspectorContentMounted {
+                inspectorHostingController.rootView = inspectorProvider()
+                isInspectorContentMounted = true
+            }
+            inspectorSplitViewItem.isCollapsed = false
+        } else {
+            inspectorSplitViewItem.isCollapsed = true
+            if isInspectorContentMounted {
+                inspectorHostingController.rootView = AnyView(EmptyView())
+                isInspectorContentMounted = false
+            }
+        }
+    }
+}

--- a/apps/macos-ui/Helm/Views/ControlCenterViews.swift
+++ b/apps/macos-ui/Helm/Views/ControlCenterViews.swift
@@ -45,25 +45,20 @@ struct ControlCenterWindowView: View {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
-            if context.isSidebarVisible {
-                ControlCenterSidebarView(sidebarWidth: sidebarWidth)
-                    .spotlightAnchor("ccSidebar")
-                Divider()
-            }
-
-            if !selectedSection.supportsInspector || !context.isInspectorVisible {
-                ControlCenterSectionHostView()
-                    .frame(minWidth: 400, maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                HSplitView {
-                    ControlCenterSectionHostView()
-                        .frame(minWidth: 400, maxWidth: .infinity, maxHeight: .infinity)
-
-                    ControlCenterInspectorView()
-                        .frame(minWidth: 220, idealWidth: 280, maxWidth: 320)
-                }
-            }
+        ControlCenterSplitViewBridge(
+            isInspectorPresented: selectedSection.supportsInspector && context.isInspectorVisible,
+            contentMinimumThickness: sidebarWidth + 400
+        ) {
+            ControlCenterHostedContentView(
+                context: context,
+                walkthrough: walkthrough,
+                sidebarWidth: sidebarWidth
+            )
+        } inspector: {
+            ControlCenterHostedInspectorView(
+                context: context,
+                walkthrough: walkthrough
+            )
         }
         .frame(minWidth: 860, minHeight: 600)
         .background(
@@ -176,11 +171,6 @@ struct ControlCenterWindowView: View {
             RedesignUpgradeSheetView()
                 .environmentObject(context)
         }
-        .overlayPreferenceValue(SpotlightAnchorKey.self) { anchors in
-            if walkthrough.isControlCenterWalkthroughActive {
-                SpotlightOverlay(manager: walkthrough, anchors: anchors)
-            }
-        }
         .onChange(of: walkthrough.currentStepIndex) { _ in
             guard walkthrough.isControlCenterWalkthroughActive,
                   let step = walkthrough.currentStep else { return }
@@ -200,6 +190,53 @@ struct ControlCenterWindowView: View {
                 }
             }
         }
+    }
+}
+
+private struct ControlCenterHostedContentView: View {
+    @ObservedObject var context: ControlCenterContext
+    @ObservedObject var walkthrough: WalkthroughManager
+    let sidebarWidth: CGFloat
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if context.isSidebarVisible {
+                ControlCenterSidebarView(sidebarWidth: sidebarWidth)
+                    .spotlightAnchor("ccSidebar")
+                Divider()
+            }
+
+            ControlCenterSectionHostView()
+                .frame(minWidth: 400, maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .environmentObject(context)
+        .overlayPreferenceValue(SpotlightAnchorKey.self) { anchors in
+            if walkthrough.isControlCenterWalkthroughActive {
+                SpotlightOverlay(manager: walkthrough, anchors: anchors)
+            }
+        }
+    }
+}
+
+private struct ControlCenterHostedInspectorView: View {
+    let context: ControlCenterContext
+    @ObservedObject var walkthrough: WalkthroughManager
+
+    var body: some View {
+        ControlCenterInspectorView()
+            .frame(
+                minWidth: 220,
+                idealWidth: 280,
+                maxWidth: 320,
+                maxHeight: .infinity
+            )
+            .environmentObject(context)
+            .overlay {
+                if walkthrough.isControlCenterWalkthroughActive {
+                    Color.black.opacity(0.5)
+                        .allowsHitTesting(true)
+                }
+            }
     }
 }
 

--- a/apps/macos-ui/HelmTests/ControlCenterSplitViewBridgeTests.swift
+++ b/apps/macos-ui/HelmTests/ControlCenterSplitViewBridgeTests.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import XCTest
+
+final class ControlCenterSplitViewBridgeTests: XCTestCase {
+    func testInspectorContentIsMountedOnlyWhilePresented() {
+        var inspectorCreationCount = 0
+        let controller = ControlCenterSplitViewController(
+            content: AnyView(Text("Content")),
+            inspector: {
+                inspectorCreationCount += 1
+                return AnyView(Text("Inspector"))
+            }
+        )
+
+        _ = controller.view
+        XCTAssertEqual(controller.splitViewItems.count, 2)
+        XCTAssertTrue(controller.isInspectorCollapsed)
+        XCTAssertFalse(controller.isInspectorContentMounted)
+        XCTAssertEqual(inspectorCreationCount, 0)
+
+        controller.setInspectorPresented(true)
+        XCTAssertEqual(controller.splitViewItems.count, 2)
+        XCTAssertFalse(controller.isInspectorCollapsed)
+        XCTAssertTrue(controller.isInspectorContentMounted)
+        XCTAssertEqual(inspectorCreationCount, 1)
+
+        controller.setInspectorPresented(false)
+        XCTAssertTrue(controller.isInspectorCollapsed)
+        XCTAssertFalse(controller.isInspectorContentMounted)
+
+        controller.setInspectorPresented(true)
+        XCTAssertFalse(controller.isInspectorCollapsed)
+        XCTAssertTrue(controller.isInspectorContentMounted)
+        XCTAssertEqual(inspectorCreationCount, 2)
+    }
+
+    func testRepeatedPresentationUpdatesAreIdempotent() {
+        var inspectorCreationCount = 0
+        let controller = ControlCenterSplitViewController(
+            content: AnyView(Text("Content")),
+            inspector: {
+                inspectorCreationCount += 1
+                return AnyView(Text("Inspector"))
+            }
+        )
+
+        controller.setInspectorPresented(true)
+        controller.setInspectorPresented(true)
+        XCTAssertEqual(inspectorCreationCount, 1)
+
+        controller.setInspectorPresented(false)
+        controller.setInspectorPresented(false)
+        XCTAssertEqual(inspectorCreationCount, 1)
+    }
+}


### PR DESCRIPTION
## Summary

- replace the conditionally inserted SwiftUI `HSplitView` with a Ventura-compatible `NSSplitViewController` bridge
- keep split items stable while fully unmounting collapsed inspector SwiftUI content
- preserve Wayfinder walkthrough spotlight anchors and inspector dimming across hosting-controller boundaries
- add regression coverage for inspector mounting, collapse state, and idempotent presentation updates

## Verification

- `HELM_XCODE_ARCH=arm64 .opencode/skills/run-quality-gate/scripts/run-quality-gate.sh ui`
  - 69 tests passed, 0 failures
- live Debug QA with an isolated `HELM_DB_PATH`
  - exercised Dashboard, Plan, Library, Activity, and Environment transitions
  - exercised automatic inspector collapse/reopen and toolbar Hide/Show Details
  - captured no `Invalid view geometry` notices
  - captured no `Publishing changes from within view updates is not allowed` warnings

Closes #382
