### PR TITLE
fix(first-run): exclude undetected managers from brief mapping

### DIFF
--- a/apps/macos-ui/Helm/Core/EnvironmentBriefProjection.swift
+++ b/apps/macos-ui/Helm/Core/EnvironmentBriefProjection.swift
@@ -180,7 +180,7 @@ enum EnvironmentBriefProjector {
                 managementState: observation.detected ? observation.managementState : .notInstalled,
                 activeInstallationMethod: nonEmpty(observation.activeInstallationMethod),
                 provenance: observation.detected ? (observation.provenance ?? .unknown) : nil,
-                freshness: observation.freshness
+                freshness: observation.detected ? observation.freshness : .unknown
             )
         }
         return byManager.values.sorted { $0.manager < $1.manager }

--- a/apps/macos-ui/Helm/Core/FirstRunPresentationSupport.swift
+++ b/apps/macos-ui/Helm/Core/FirstRunPresentationSupport.swift
@@ -240,7 +240,9 @@ struct EnvironmentBriefPresentationSummary: Equatable {
         let coverage = brief.coverage
         let mappedManagerIDs = Set(
             brief.discoveredManagers.compactMap { observation in
-                observation.freshness == .unknown ? nil : observation.manager
+                observation.detected && observation.freshness != .unknown
+                    ? observation.manager
+                    : nil
             }
         )
         let terminalManagerIDs = mappedManagerIDs
@@ -249,7 +251,9 @@ struct EnvironmentBriefPresentationSummary: Equatable {
             .union(coverage.deferredManagers)
         let attentionManagerIDs = Set(
             brief.discoveredManagers.compactMap { observation in
-                observation.eligibility != .eligible || observation.managementState != .ready
+                observation.detected
+                    && (observation.eligibility != .eligible
+                        || observation.managementState != .ready)
                     ? observation.manager
                     : nil
             }

--- a/apps/macos-ui/HelmTests/EnvironmentBriefProjectionTests.swift
+++ b/apps/macos-ui/HelmTests/EnvironmentBriefProjectionTests.swift
@@ -115,9 +115,11 @@ final class EnvironmentBriefProjectionTests: XCTestCase {
         )
 
         XCTAssertEqual(brief.coverage.intendedManagerCount, 2)
+        XCTAssertEqual(brief.coverage.currentManagerCount, 1)
         XCTAssertEqual(brief.discoveredManagers.map(\.manager), ["mise", "npm"])
         XCTAssertEqual(brief.discoveredManagers[0].provenance, .unknown)
         XCTAssertEqual(brief.discoveredManagers[1].managementState, .notInstalled)
+        XCTAssertEqual(brief.discoveredManagers[1].freshness, .unknown)
         XCTAssertNil(brief.discoveredManagers[1].provenance)
     }
 

--- a/apps/macos-ui/HelmTests/FirstRunPresentationSupportTests.swift
+++ b/apps/macos-ui/HelmTests/FirstRunPresentationSupportTests.swift
@@ -186,6 +186,53 @@ final class FirstRunPresentationSupportTests: XCTestCase {
         XCTAssertEqual(summary.completionFraction, 0.5)
     }
 
+    func testSummaryIgnoresUndetectedManagersWhenComputingMappedProgress() {
+        let brief = EnvironmentBriefProjector.project(
+            EnvironmentBriefProjectionInput(
+                system: EnvironmentBriefSystem(
+                    osVersion: "26.6.0",
+                    architecture: .arm64,
+                    activeShell: "zsh",
+                    distributionChannel: "developer_id",
+                    updateAuthority: "sparkle"
+                ),
+                intendedManagerIDs: ["homebrew_formula", "mise"],
+                observations: [
+                    EnvironmentBriefManagerObservation(
+                        manager: "homebrew_formula",
+                        detected: true,
+                        eligibility: .eligible,
+                        managementState: .ready,
+                        activeInstallationMethod: nil,
+                        provenance: .homebrew,
+                        freshness: .current
+                    ),
+                    EnvironmentBriefManagerObservation(
+                        manager: "mise",
+                        detected: false,
+                        eligibility: .unknown,
+                        managementState: .ready,
+                        activeInstallationMethod: nil,
+                        provenance: .mise,
+                        freshness: .current
+                    ),
+                ],
+                failedManagerIDs: [],
+                cancelledManagerIDs: [],
+                deferredManagerIDs: [],
+                observationClass: .localOnly
+            )
+        )
+
+        let summary = EnvironmentBriefPresentationSummary.make(from: brief)
+
+        XCTAssertEqual(brief.coverage.currentManagerCount, 1)
+        XCTAssertEqual(summary.kind, .mapping)
+        XCTAssertEqual(summary.mappedManagerCount, 1)
+        XCTAssertEqual(summary.attentionCount, 0)
+        XCTAssertEqual(summary.completionFraction, 0.5)
+    }
+
     func testRestorationHonorsLegalGateBeforeAvailableBrief() {
         let brief = EnvironmentBriefFixtureProvider.fixture(named: .current).brief
         let saved = FirstRunPresentationState(


### PR DESCRIPTION
## Summary

- exclude undetected managers from Environment Brief freshness so they no longer count as mapped/current
- tighten first-run summary math so only detected managers contribute mapped and attention counts
- add regression coverage for projector canonicalization and first-run mapped-progress calculations

## Why

PR #392 introduces the Environment Brief first-run surface. During independent review, I found that undetected managers could still retain non-`unknown` freshness and then be counted as already mapped/current in the summary projection. On clean or sparse installs, that could overstate course-indicator progress and incorrectly present the brief as current.

## Validation

- `xcodebuild -project apps/macos-ui/Helm.xcodeproj -scheme Helm -destination 'platform=macOS' test`
