### PR TITLE
docs(release): close out v0.19.0-rc.2 publication

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -8,19 +8,19 @@ It reflects reality, not intention.
 
 ## Version
 
-Current documentation baseline: **0.18.2 remains the latest public stable release on `main`**, and **0.19.0-rc.1 is the published opt-in prerelease**; `v0.18.0` remains withdrawn because of a critical SQLite migration defect. `v0.18.2` is the final v0.18 containment release and includes migration-safety hardening plus the closed Project WOW and Native Mac Experience design-definition artifacts before v0.19 implementation begins.
+Current documentation baseline: **0.18.2 remains the latest public stable release on `main`**, and **0.19.0-rc.2 is the published opt-in prerelease**; `v0.18.0` remains withdrawn because of a critical SQLite migration defect. `v0.18.2` is the final v0.18 containment release and includes migration-safety hardening plus the closed Project WOW and Native Mac Experience design-definition artifacts before v0.19 implementation begins.
 
-Implementation baseline: **prepared `0.19.0-rc.2` source candidate on the published `0.19.0-rc.1` lineage**, combining the Original Wayfinder native Dashboard/window/sidebar/toolbar foundation with dedicated native Settings panes while preserving the manager/updater and migration-safety baseline. The read-only Project WOW Environment Brief runtime projection, deterministic debug fixtures, and resumable presentation state remain development-gated. Issue #388 tracks its unresolved VoiceOver Headings-rotor and bidirectional Full Keyboard Access behavior, so the production first-run route remains on the existing onboarding flow. Operational-card relocation and removal of the legacy in-window Settings compatibility destination are explicitly deferred until after this candidate.
+Implementation baseline: **published `0.19.0-rc.2` opt-in candidate on the `0.19.0-rc.1` lineage**, combining the Original Wayfinder native Dashboard/window/sidebar/toolbar foundation with dedicated native Settings panes while preserving the manager/updater and migration-safety baseline. The read-only Project WOW Environment Brief runtime projection, deterministic debug fixtures, and resumable presentation state remain development-gated. Issue #388 tracks its unresolved VoiceOver Headings-rotor and bidirectional Full Keyboard Access behavior, so the production first-run route remains on the existing onboarding flow. Operational-card relocation and removal of the legacy in-window Settings compatibility destination are explicitly deferred until after this candidate.
 
 See:
 - CHANGELOG.md
 
 Active milestone:
 - latest stable release currently published on `main`: **0.18.2**
-- published opt-in prerelease: **0.19.0-rc.1**, represented by a published GitHub prerelease with signed/notarized GUI artifacts and direct CLI artifacts; GitHub `releases/latest` remains stable-only on `v0.18.2`
-- prepared source candidate: **0.19.0-rc.2**; it is not tagged or published, and public beta/RC metadata remains on `v0.19.0-rc.1` until publication completes
+- published opt-in prerelease: **0.19.0-rc.2**, represented by a published GitHub prerelease with signed/notarized GUI artifacts and direct CLI artifacts; GitHub `releases/latest` remains stable-only on `v0.18.2`
+- `v0.19.0-rc.2` publication completed from final `main` revision `2ef4b692a9850494e8d48e93156838b9831c02a8`; generated CLI and appcast/release-notes PRs `#397` and `#398` are merged, and post-publication release/drift verification is green
 - `v0.18.0` was published on 2026-08-03 and then withdrawn after discovery of a critical SQLite migration defect; its immutable tag is retained for auditability while its release is not publicly distributed.
-- public default-channel GUI appcast and stable CLI metadata remain on signed `v0.18.2` artifacts, while the `beta` appcast item and `latest-rc.json` point to `v0.19.0-rc.1`.
+- public default-channel GUI appcast and stable CLI metadata remain on signed `v0.18.2` artifacts, while the `beta` appcast item and `latest-rc.json` point to `v0.19.0-rc.2`.
 - owner installation validation confirms `/Applications/Helm.app` is the signed Developer ID build for `0.19.0-rc.1` (`CFBundleVersion` `19000601`); this is one successful owner installation, not broad participant validation.
 - delivered in `v0.18.1`: reconciliation of the known development migration `17` collision before released doctor/repair migrations run, plus prevention of historical DDL replay for already-current databases, preserving package identifiers and user data.
 - delivered in `v0.18.2`: immutable migration identities and definition checksums, fail-closed ledger validation, verified bounded pre-migration backups, debug/release database separation, initialization-error propagation, and migration-compatibility CI/release gates.

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -11,18 +11,18 @@ It is intentionally tactical.
 Helm is in:
 
 ```
-v0.19.0-rc.2 source-candidate validation and owner QA
+v0.19.0-rc.2 post-publication validation and v0.19.0 stabilization
 ```
 
 Focus:
-- validate the prepared `v0.19.0-rc.2` source candidate without tagging or publishing until the QA remediations, protected integration, final `main` gates, and explicit release authorization are complete; owner source-build QA is complete, while signed-artifact updater validation remains a post-publication check
-- preserve the published `v0.19.0-rc.1` candidate and stable `v0.18.2` metadata while RC2 remains untagged
+- complete owner validation of the installed `v0.19.0-rc.1` to signed/notarized `v0.19.0-rc.2` Sparkle update path; source, workflow, publication, metadata, and drift gates are complete, but they do not substitute for this distribution-boundary check
+- preserve the published opt-in `v0.19.0-rc.2` candidate alongside stable `v0.18.2`; stable GitHub/latest, appcast, and CLI pointers must remain isolated from the beta/RC channel
 - keep the Environment Brief development-gated in RC2 because Issue #388 remains unresolved, and disclose the limitation without implying that the production first-run route changed
 - continue from the Original Wayfinder foundation checkpoints: shared revisioned Dashboard/popover/status projection, semantic Course Indicator modes, stable destination/deep-link bridge, Dashboard naming, restored/resizable native window hosting, native Dashboard/Plan/Library/Activity sidebar composition, persistent Environment access, rendered Course Indicator, native Dashboard toolbar/app commands, and one shared native Settings scene with General, Updates, Sources, CLI, and Support panes are implemented; operational-card relocation and removal of the legacy in-window Settings compatibility destination are explicitly deferred until after RC2, while destination content migration, contextual inspector behavior, right-click-menu removal, and v0.22 multi-display validation continue
-- maintain release-process hardening guardrails now that `v0.19.0-rc.1` publication and closeout verification are complete
+- maintain release-process hardening guardrails now that `v0.19.0-rc.2` publication and automated closeout verification are complete
 - preserve the released `v0.18.2` migration-safety baseline and `v0.18.1` affected-database recovery coverage
 - preserve manager-specific expected nonzero update-check outcomes as completed refreshes with actionable outdated state, starting with rustup's exit code `100`
-- preserve the published `0.19.0-rc.1` manager/updater baseline: v0.18 migration safety, npm/MAS reliability fixes, full standard-root Sparkle inventory and static-appcast visibility, external-bundle GUI update actions, scheduled direct-channel Helm checks, explicit beta/RC opt-in with stable-channel isolation, dependency modernization, and the macOS 13 Ventura baseline
+- preserve the published `0.19.0-rc.2` manager/updater and native-experience baseline: v0.18 migration safety, npm/MAS reliability fixes, full standard-root Sparkle inventory and static-appcast visibility, external-bundle GUI update actions, scheduled direct-channel Helm checks, explicit beta/RC opt-in with stable-channel isolation, dependency modernization, the macOS 13 Ventura baseline, and the Original Wayfinder Dashboard/Settings foundation
 - preserve the released SQLite doctor/repair lifecycle, bundled knowledge bootstrap, import/export hardening, and repair verification path without widening into online knowledge lookup
 - preserve the compiled typed-action registry as the immutable execution boundary; knowledge remains declarative and cannot carry commands, arguments, scripts, plugins, or arbitrary executable content
 - retain deterministic `v2` finding identity while keeping sensitive local evidence outside shared fingerprint inputs
@@ -402,9 +402,9 @@ Current checkpoint:
     - audit-remediation follow-up delivered: distribution profile contract is now centralized in `docs/contracts/distribution-profiles.json` and consumed by shared build orchestration (`scripts/build.sh`, `scripts/release/build_unsigned_variant.sh`, matrix-based `release-all-variants.yml` auxiliary jobs); Swift update-authority mapping now has one source (`AppUpdateConfiguration`), targeted updater policy tests pass on macOS, and GUI checksum-publication symmetry is explicitly documented as deferred while Sparkle remains canonical GUI integrity authority
     - trust-chain future work is now explicitly tracked: detached signatures + signing-key rotation for CLI update artifacts (`docs/roadmap/CLI_DISTRIBUTION_CI_MILESTONES.md`, milestone M5)
 - latest stable release on `main`: `v0.18.2`
-- latest published prerelease on `main`: `v0.19.0-rc.1`; stable GitHub/latest, appcast, and CLI pointers remain isolated from the opt-in RC channel
+- latest published prerelease on `main`: `v0.19.0-rc.2`; stable GitHub/latest, appcast, and CLI pointers remain isolated from the opt-in RC channel
 - owner installation validation confirms the signed Developer ID app at `0.19.0-rc.1` build `19000601`; broader RC feedback remains pending and should not be inferred from this single installation
-- post-publication release verification is green for the GUI beta appcast, RC CLI metadata, GitHub prerelease state, and stable/RC coexistence contract
+- post-publication release verification is green for the `v0.19.0-rc.2` GUI beta appcast, RC CLI metadata, GitHub prerelease state, and stable/RC coexistence contract; installed-candidate Sparkle validation remains open
 - validation gates are green through the stable cut (`cargo test`, macOS `xcodebuild` tests, locale integrity/length audits, release workflow smoke across `v0.17.0-rc.1` through `v0.17.0-rc.5`)
 - `v0.15.0` released on `main` (tag `v0.15.0`)
 - `v0.14.0` released (merged to `main`, tagged, manager rollout + docs/version alignment complete)

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -62,7 +62,7 @@ This checklist is required before creating a release tag on `main`.
   - `CLI Update Metadata Drift Guard`
 - [x] Review `TMP_RELEASE_FRICTION`; promote recurring friction items into durable docs (`docs/DECISIONS.md`, `docs/operations/CLI_RELEASE_AND_CI.md`) and keep temporary notes uncommitted.
 
-## v0.19.0-rc.2 (Native Experience Foundation RC, Source Candidate Prepared)
+## v0.19.0-rc.2 (Native Experience Foundation RC, Published)
 
 ### Candidate Scope
 
@@ -84,10 +84,18 @@ This checklist is required before creating a release tag on `main`.
 
 ### Publication
 
-- [ ] Obtain explicit maintainer approval before creating or pushing `v0.19.0-rc.2` or publishing artifacts.
-- [ ] Publish `v0.19.0-rc.2` as a GitHub prerelease that does not become latest.
-- [ ] Confirm the stable appcast/CLI metadata remains on `v0.18.2` and only beta/RC metadata advances to `v0.19.0-rc.2`.
-- [ ] Complete signed/notarized GUI and direct CLI prerelease publication plus post-publication verification.
+- [x] Obtain explicit maintainer approval before creating or pushing `v0.19.0-rc.2` or publishing artifacts.
+- [x] Publish `v0.19.0-rc.2` as a GitHub prerelease that does not become latest.
+- [x] Confirm the stable appcast/CLI metadata remains on `v0.18.2` and only beta/RC metadata advances to `v0.19.0-rc.2`.
+- [x] Complete signed/notarized GUI and direct CLI prerelease publication plus post-publication verification.
+
+### Closeout Record
+
+- `v0.19.0-rc.2` is a published GitHub prerelease; `v0.18.2` remains the published non-prerelease returned by `releases/latest`.
+- Release canary run `31363833023` and publish-auth write-probe run `31363837968` passed before the tag was created from final `main` revision `2ef4b692a9850494e8d48e93156838b9831c02a8`.
+- Direct CLI run `31364877903` and signed/notarized macOS DMG run `31364877916` completed successfully. Publication PRs `#397` and `#398` merged RC CLI metadata and the beta appcast/release notes into `main`.
+- `Release Publish Verify` run `31366731563`, `CLI Update Metadata Drift Guard` run `31366680922`, the Sparkle/appcast checklist, and `scripts/release/runbook.sh verify --tag v0.19.0-rc.2` pass with no open release-publication PRs.
+- Installed-candidate Sparkle validation remains an explicit owner action and is not implied by successful source, workflow, or metadata verification.
 
 ## v0.19.0-rc.1 (Manager and Updater Modernization RC, Completed)
 


### PR DESCRIPTION
## Summary

- record `v0.19.0-rc.2` as the published opt-in prerelease
- capture canary, publish-auth, artifact workflow, metadata PR, and final verification evidence
- preserve `v0.18.2` as the stable/latest line and leave installed-candidate Sparkle validation open for owner QA

## Release Outcome

- GitHub prerelease: `v0.19.0-rc.2`
- stable GitHub/latest, default appcast, and stable CLI metadata: `v0.18.2`
- RC beta appcast and `latest-rc.json`: `v0.19.0-rc.2`
- publication PRs: `#397` and `#398`

## Validation

- `scripts/release/runbook.sh verify --tag v0.19.0-rc.2`
- `.opencode/skills/sparkle-appcast-checklist/scripts/run-checklist.sh v0.19.0-rc.2`
- `.opencode/skills/docs-sync/scripts/docs-sync-check.sh`
- `.opencode/skills/run-quality-gate/scripts/run-quality-gate.sh release-contracts`
- Release Publish Verify run `31366731563`
- CLI Update Metadata Drift Guard run `31366680922`

## Remaining Owner Check

- Validate the installed `v0.19.0-rc.1` to `v0.19.0-rc.2` Sparkle update path. This PR intentionally does not mark that distribution-boundary check complete.
